### PR TITLE
install_cmdstan windows fixes & cleanup, set TBB path

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -28,6 +28,7 @@ install_cmdstan <- function(dir = NULL, cores = 2, quiet = FALSE) {
   if (os_is_windows()) {
     make_cmdstan <- c(make_cmdstan, "-w")
   }
+
   install_log <- processx::run(
     command = "bash",
     args = make_cmdstan,

--- a/R/install.R
+++ b/R/install.R
@@ -25,6 +25,9 @@ install_cmdstan <- function(dir = NULL, cores = 2, quiet = FALSE) {
     make_cmdstan <- c(make_cmdstan, paste0("-d ", dir))
   }
   make_cmdstan <- c(make_cmdstan, paste0("-j", cores))
+  if (os_is_windows()) {
+    make_cmdstan <- c(make_cmdstan, "-w")
+  }
   install_log <- processx::run(
     command = "bash",
     args = make_cmdstan,

--- a/R/install.R
+++ b/R/install.R
@@ -25,7 +25,7 @@ install_cmdstan <- function(dir = NULL, cores = 2, quiet = FALSE) {
     make_cmdstan <- c(make_cmdstan, paste0("-d ", dir))
   }
   make_cmdstan <- c(make_cmdstan, paste0("-j", cores))
-  if ((.cmdstanr$VERSION >= "2.21") && os_is_windows()) {
+  if (os_is_windows()) {
     make_cmdstan <- c(make_cmdstan, "-w")
   }
   install_log <- processx::run(

--- a/R/install.R
+++ b/R/install.R
@@ -25,7 +25,7 @@ install_cmdstan <- function(dir = NULL, cores = 2, quiet = FALSE) {
     make_cmdstan <- c(make_cmdstan, paste0("-d ", dir))
   }
   make_cmdstan <- c(make_cmdstan, paste0("-j", cores))
-  if (os_is_windows()) {
+  if ((.cmdstanr$VERSION >= "2.21") && os_is_windows()) {
     make_cmdstan <- c(make_cmdstan, "-w")
   }
   install_log <- processx::run(

--- a/R/model.R
+++ b/R/model.R
@@ -193,7 +193,7 @@ compile_method <- function(threads = FALSE,
                   remove_main = TRUE)
   }
   # add path to the build tbb library to the PATH variable to avoid copying the dll file
-  if (os_is_windows()) {
+  if ((.cmdstanr$VERSION >= "2.21") && os_is_windows()) {
     path_to_TBB <- file.path(cmdstan_path(), "stan", "lib", "stan_math", "lib", "tbb")
     Sys.setenv(PATH = paste0(path_to_TBB, ";", Sys.getenv("PATH"),sep=""))
   }

--- a/R/model.R
+++ b/R/model.R
@@ -192,6 +192,11 @@ compile_method <- function(threads = FALSE,
     build_cleanup(exe,
                   remove_main = TRUE)
   }
+  # add path to the build tbb library to the PATH variable to avoid copying the dll file
+  if (os_is_windows()) {
+    path_to_TBB <- file.path(cmdstan_path(), "stan", "lib", "stan_math", "lib", "tbb")
+    Sys.setenv(PATH = paste0(path_to_TBB, ";", Sys.getenv("PATH"),sep=""))
+  }
   exe <- cmdstan_ext(exe) # adds .exe on Windows
   run_log <- processx::run(
     command = "make",

--- a/inst/make_cmdstan.sh
+++ b/inst/make_cmdstan.sh
@@ -4,13 +4,16 @@
 #  - build binaries, compile example model to build model header
 #  - symlink downloaded version as "cmdstan"
 
-while getopts ":d:v:j:" opt; do
+WIN=0
+while getopts ":d:v:j:w" opt; do
   case $opt in
     d) RELDIR="$OPTARG"
     ;;
     v) VER="$OPTARG"
     ;;
     j) JOBS="$OPTARG"
+    ;;
+    w) WIN=1
     ;;
     \?) echo "Invalid option -$OPTARG" >&2
     ;;
@@ -76,8 +79,11 @@ fi
 ln -s ${CS} cmdstan
 pushd cmdstan > /dev/null
 echo "building cmdstan binaries"
-make -j${JOBS} build examples/bernoulli/bernoulli
-# make build -j${JOBS}
+if [[ ${WIN} -ne 0 ]]; then
+  mingw32-make -j${JOBS} build examples/bernoulli/bernoulli.exe
+else
+  make -j${JOBS} build examples/bernoulli/bernoulli
+fi
 echo "installed ${CS}; symlink: `ls -l ${RELDIR}/cmdstan`"
 
 # cleanup

--- a/inst/make_cmdstan.sh
+++ b/inst/make_cmdstan.sh
@@ -66,17 +66,19 @@ fi
 echo "download complete"
 
 echo "unpacking archive"
-tar xzf ${CS}.tar.gz
+if [[ -e cmdstan ]]; then
+    rm -rf cmdstan
+fi
+
+mkdir cmdstan
+tar xzf ${CS}.tar.gz -C cmdstan/ --strip-components 1
 TAR_RC=$?
 if [[ ${TAR_RC} -ne 0 ]]; then
     echo "corrupt download file ${CS}.tar.gz, tar exited with: ${TAR_RC}"
     exit ${TAR_RC}
 fi
+rm ${CS}.tar.gz
 
-if [[ -h cmdstan ]]; then
-    unlink cmdstan
-fi
-ln -s ${CS} cmdstan
 pushd cmdstan > /dev/null
 echo "building cmdstan binaries"
 if [[ ${WIN} -ne 0 ]]; then
@@ -84,11 +86,10 @@ if [[ ${WIN} -ne 0 ]]; then
 else
   make -j${JOBS} build examples/bernoulli/bernoulli
 fi
-echo "installed ${CS}; symlink: `ls -l ${RELDIR}/cmdstan`"
+echo "installed ${CS} to ${RELDIR}/cmdstan"
 
 # cleanup
 pushd -0 > /dev/null
 dirs -c > /dev/null
 echo ""
-echo "CmdStan installation location: `ls -Fd ${RELDIR}/${CS}`"
-echo "Can use symlink: ${RELDIR}/cmdstan"
+echo "CmdStan installation location: `ls -Fd ${RELDIR}/cmdstan`"


### PR DESCRIPTION
Fixes #37 and #42 

This PR does the following: 
- on windows calls make_cmdstan.sh with `-w` so we can handle window specific stuff
- uses mingw32-make on Windows to build (mandatory in 2.21 due to TBB, its also fine for all previous versions, comes with RTools just like make)
- removes the need for smylinking of cmdstan on install; just extracts to cmdstan/ (was there a reason this wasnt done this way? I might be missing something);
- adds removal of the tar.gz file to make_cmdstan.sh
- on Windows with 2.21+ adds path to TBB lib to the environment variable PATH so we dont need to copy tbb.dll every time in the model exe folders