### PR TITLE
Dont overwrite users make local flags

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -195,7 +195,7 @@ compile_method <- function(threads = FALSE,
   # add path to the build tbb library to the PATH variable to avoid copying the dll file
   if ((.cmdstanr$VERSION >= "2.21") && os_is_windows()) {
     path_to_TBB <- file.path(cmdstan_path(), "stan", "lib", "stan_math", "lib", "tbb")
-    Sys.setenv(PATH = paste0(path_to_TBB, ";", Sys.getenv("PATH"),sep=""))
+    Sys.setenv(PATH = paste0(path_to_TBB, ";", Sys.getenv("PATH")))
   }
   exe <- cmdstan_ext(exe) # adds .exe on Windows
   run_log <- processx::run(

--- a/R/model.R
+++ b/R/model.R
@@ -188,7 +188,7 @@ compile_method <- function(threads = FALSE,
                                        compiler_flags)
   # rebuild main.o and the model if there was a change in make/local
   if(make_local_changed) {
-    print("A change in the compile flags was found. Recompiling the model...\n")
+    print("A change in the compile flags was found. Forcing re-compile of the model...\n")
     build_cleanup(exe,
                   remove_main = TRUE)
   }

--- a/R/model.R
+++ b/R/model.R
@@ -193,7 +193,7 @@ compile_method <- function(threads = FALSE,
                   remove_main = TRUE)
   }
   # add path to the build tbb library to the PATH variable to avoid copying the dll file
-  if ((.cmdstanr$VERSION >= "2.21") && os_is_windows()) {
+  if (cmdstan_version() >= "2.21" && os_is_windows()) {
     path_to_TBB <- file.path(cmdstan_path(), "stan", "lib", "stan_math", "lib", "tbb")
     Sys.setenv(PATH = paste0(path_to_TBB, ";", Sys.getenv("PATH")))
   }

--- a/R/model.R
+++ b/R/model.R
@@ -187,10 +187,9 @@ compile_method <- function(threads = FALSE,
                                        opencl_device_id,
                                        compiler_flags)
   # rebuild main.o and the model if there was a change in make/local
-  if(make_local_changed) {
-    print("A change in the compile flags was found. Forcing re-compile of the model...\n")
-    build_cleanup(exe,
-                  remove_main = TRUE)
+  if (make_local_changed) {
+    message("A change in the compiler flags was found. Forcing recompilation.\n")
+    build_cleanup(exe, remove_main = TRUE)
   }
   # add path to the build tbb library to the PATH variable to avoid copying the dll file
   if (cmdstan_version() >= "2.21" && os_is_windows()) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -302,12 +302,27 @@ set_make_local <- function(threads = FALSE,
                            opencl_platform_id = 0,
                            opencl_device_id = 0,
                            compiler_flags = NULL) {
+  cmdstanr_generated_flags_comment <- "# cmdstanr generated make/local flags"
   make_local_path <- file.path(cmdstan_path(), "make", "local")
-  old_make_local_content <- ""
-  if(file.exists(make_local_path)) {
-    # read the contents of make/local to compare with the new contents
-    old_make_local_content <- paste(readLines(make_local_path), collapse = "\n")
+  user_flags <- c()
+  if (file.exists(make_local_path)) {
+    old_make_local_all <- readLines(make_local_path)
+    old_make_local_cmdstanr <- c()
+    is_user_flag <- TRUE
+    for (x in old_make_local_all) {
+      if (startsWith(x, cmdstanr_generated_flags_comment)) {
+        is_user_flag <- FALSE
+      }
+      if(!is_user_flag) {
+        old_make_local_cmdstanr <- c(old_make_local_cmdstanr, x)
+      } else {
+        user_flags <- c(user_flags, x)
+      }
+    }
+  } else {
+    old_make_local_cmdstanr <- c()
   }
+  old_make_local_cmdstanr <- paste(old_make_local_cmdstanr, collapse = "\n")
   if(opencl) {
     stan_opencl <- "STAN_OPENCL = true"
     platform_id <- paste("OPENCL_PLATFORM_ID", opencl_platform_id, sep = " = ")
@@ -318,10 +333,12 @@ set_make_local <- function(threads = FALSE,
     stan_threads <- "CXXFLAGS += -DSTAN_THREADS"
     compiler_flags <- c(compiler_flags, stan_threads)
   }
-  new_make_local_content <- paste(compiler_flags, collapse = "\n")
+  compiler_flags <- c(cmdstanr_generated_flags_comment, compiler_flags)
+  new_make_local_cmdstanr <- paste(compiler_flags, collapse = "\n")
   # dont rewrite make/local if there are no changes
-  if(new_make_local_content != old_make_local_content) {
-    write(new_make_local_content, file = make_local_path, append = FALSE)
+  if (new_make_local_cmdstanr != old_make_local_cmdstanr) {
+    make_local_content <- c(user_flags, new_make_local_cmdstanr)
+    write(make_local_content, file = make_local_path, append = FALSE)
     return(TRUE)
   }
   return(FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -302,7 +302,7 @@ set_make_local <- function(threads = FALSE,
                            opencl_platform_id = 0,
                            opencl_device_id = 0,
                            compiler_flags = NULL) {
-  cmdstanr_generated_flags_comment <- "# cmdstanr generated make/local flags"
+  cmdstanr_generated_flags_comment <- "# cmdstanr generated make/local flags (add user flags above this line)"
   make_local_path <- file.path(cmdstan_path(), "make", "local")
   user_flags <- c()
   if (file.exists(make_local_path)) {
@@ -333,7 +333,9 @@ set_make_local <- function(threads = FALSE,
     stan_threads <- "CXXFLAGS += -DSTAN_THREADS"
     compiler_flags <- c(compiler_flags, stan_threads)
   }
-  compiler_flags <- c(cmdstanr_generated_flags_comment, compiler_flags)
+  if (length(compiler_flags) > 0) {
+    compiler_flags <- c(cmdstanr_generated_flags_comment, compiler_flags)
+  }
   new_make_local_cmdstanr <- paste(compiler_flags, collapse = "\n")
   # dont rewrite make/local if there are no changes
   if (new_make_local_cmdstanr != old_make_local_cmdstanr) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -305,31 +305,29 @@ set_make_local <- function(threads = FALSE,
   cmdstanr_generated_flags_comment <- "# cmdstanr generated make/local flags (add user flags above this line)"
   make_local_path <- file.path(cmdstan_path(), "make", "local")
   user_flags <- c()
+  old_make_local_cmdstanr <- c()
   if (file.exists(make_local_path)) {
     old_make_local_all <- readLines(make_local_path)
-    old_make_local_cmdstanr <- c()
     is_user_flag <- TRUE
     for (x in old_make_local_all) {
       if (startsWith(x, cmdstanr_generated_flags_comment)) {
         is_user_flag <- FALSE
       }
-      if(!is_user_flag) {
+      if (!is_user_flag) {
         old_make_local_cmdstanr <- c(old_make_local_cmdstanr, x)
       } else {
         user_flags <- c(user_flags, x)
       }
     }
-  } else {
-    old_make_local_cmdstanr <- c()
   }
   old_make_local_cmdstanr <- paste(old_make_local_cmdstanr, collapse = "\n")
-  if(opencl) {
+  if (opencl) {
     stan_opencl <- "STAN_OPENCL = true"
-    platform_id <- paste("OPENCL_PLATFORM_ID", opencl_platform_id, sep = " = ")
-    device_id <- paste("OPENCL_DEVICE_ID", opencl_device_id, sep = " = ")
+    platform_id <- paste("OPENCL_PLATFORM_ID =", opencl_platform_id)
+    device_id <- paste("OPENCL_DEVICE_ID =", opencl_device_id)
     compiler_flags <- c(compiler_flags, stan_opencl, platform_id, device_id)
   }
-  if(threads) {
+  if (threads) {
     stan_threads <- "CXXFLAGS += -DSTAN_THREADS"
     compiler_flags <- c(compiler_flags, stan_threads)
   }
@@ -337,10 +335,10 @@ set_make_local <- function(threads = FALSE,
     compiler_flags <- c(cmdstanr_generated_flags_comment, compiler_flags)
   }
   new_make_local_cmdstanr <- paste(compiler_flags, collapse = "\n")
-  # dont rewrite make/local if there are no changes
   if (new_make_local_cmdstanr != old_make_local_cmdstanr) {
+    # only rewrite make/local if there are changes
     make_local_content <- c(user_flags, new_make_local_cmdstanr)
-    write(make_local_content, file = make_local_path, append = FALSE)
+    writeLines(make_local_content, make_local_path)
     return(TRUE)
   }
   return(FALSE)


### PR DESCRIPTION
Fixes #47 
This issue was raised by @bbbales2, thank you for that. Sorry for any inconvenience.

The way I envisioned things before was that the users would set all of their compile time flags through cmdstanr which now that I think of it was probably not the brightest idea. It would cause problems for users coming from cmdstan because it would demand they copy their flags to R.

With this PR users can still handle all their compile time flags directly in make/local. cmdstanr will append any additional flags after the directly set flags. The convenience cmdstanr features (force recompiling of model.o and main.o on changes to the flags) will only be available for flags set through cmdstanr.