### PR TITLE
Suppress CmdStan compilation output by default

### DIFF
--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -12,6 +12,7 @@ to the executable can be accesed via the \code{$exe_file()} method.
 }
 \section{Usage}{
 \preformatted{$compile(
+  quiet = TRUE,
   threads = FALSE,
   opencl = FALSE,
   opencl_platform_id = 0,
@@ -28,6 +29,10 @@ Leaving all arguments at their defaults should be fine for most users, but
 optional arguments are provided to enable new features in CmdStan (and the
 Stan Math library). See the CmdStan manual for more details.
 \itemize{
+\item \code{quiet}: (logical) Should the verbose output from CmdStan during
+compilation be suppressed? The default is \code{TRUE}, but if you encounter an
+error we recommend trying again with \code{quiet=FALSE} to see more of the
+output.
 \item \code{threads}: (logical) Should the model be compiled with
 \href{https://github.com/stan-dev/math/wiki/Threading-Support}{threading support}?
 If \code{TRUE} then \code{-DSTAN_THREADS} is added to the compiler flags. See

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -71,7 +71,7 @@ test_that("compile() method works", {
   skip_on_cran()
   expected <- if (!file.exists(strip_ext(mod$stan_file())))
     "Translating Stan model" else "is up to date"
-  out <- utils::capture.output(mod$compile())
+  out <- utils::capture.output(mod$compile(quiet = FALSE))
   expect_output(print(out), expected)
   expect_equal(mod$exe_file(), strip_ext(stan_program))
 })
@@ -80,11 +80,16 @@ test_that("compilation works when stan program not in cmdstan dir", {
   skip_on_cran()
 
   stan_program_2 <- test_path("resources", "stan", "bernoulli.stan")
-  out <- utils::capture.output(
-    mod_2 <- cmdstan_model(stan_file = stan_program_2)
+  expect_message(
+    mod_2 <- cmdstan_model(stan_file = stan_program_2, quiet = TRUE),
+    "Compiling Stan program..."
   )
-  expect_output(print(out), "Translating Stan model")
   expect_equal(mod_2$exe_file(), strip_ext(absolute_path(stan_program_2)))
+
+  out <- utils::capture.output(
+    mod_2 <- suppressMessages(cmdstan_model(stan_file = stan_program_2, quiet = FALSE))
+  )
+  expect_output(print(out), "is up to date")
 
   # cleanup
   file.remove(paste0(mod_2$exe_file(), c("", ".o",".hpp")))


### PR DESCRIPTION
Closes #50

This PR adds an argument `quiet` (defaulting to `TRUE`) to the `$compile()` method. This means that the standard output and error from CmdStan is suppressed during compilation. The downside to this is that any errors are just generic errors (instead of the content of stderr), so I put in the doc a suggestion to set `quiet=FALSE` if the user encounters an error during compilation and wants to see more of the output. Another option I guess would be to store the stderr output in case there's an error and then return that to the user if necessary? 