### PR TITLE
Add include_paths argument to $compile() method

### DIFF
--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -13,6 +13,7 @@ to the executable can be accesed via the \code{$exe_file()} method.
 \section{Usage}{
 \preformatted{$compile(
   quiet = TRUE,
+  include_paths = NULL,
   threads = FALSE,
   opencl = FALSE,
   opencl_platform_id = 0,
@@ -33,6 +34,8 @@ Stan Math library). See the CmdStan manual for more details.
 compilation be suppressed? The default is \code{TRUE}, but if you encounter an
 error we recommend trying again with \code{quiet=FALSE} to see more of the
 output.
+\item \code{include_paths}: (character vector) Paths to directories where Stan should
+look for files specified in \code{#include} directives in the Stan program.
 \item \code{threads}: (logical) Should the model be compiled with
 \href{https://github.com/stan-dev/math/wiki/Threading-Support}{threading support}?
 If \code{TRUE} then \code{-DSTAN_THREADS} is added to the compiler flags. See

--- a/tests/testthat/resources/stan/bernoulli_include.stan
+++ b/tests/testthat/resources/stan/bernoulli_include.stan
@@ -1,5 +1,5 @@
 functions {
-  #include divide_real_by_two.stan
+#include divide_real_by_two.stan
 }
 data {
   int<lower=0> N;
@@ -9,7 +9,7 @@ parameters {
   real<lower=0,upper=1> theta;
 }
 model {
-  theta ~ beta(divide_real_by_two(2),1);
+  theta ~ beta(divide_real_by_two(2.0),1);
   for (n in 1:N)
     y[n] ~ bernoulli(theta);
 }

--- a/tests/testthat/test-model.R
+++ b/tests/testthat/test-model.R
@@ -93,6 +93,35 @@ test_that("compilation works when stan program not in cmdstan dir", {
   file.remove(paste0(mod_2$exe_file(), c("", ".o",".hpp")))
 })
 
+test_that("compilation works with include_paths", {
+  skip_on_cran()
+
+  stan_program_w_include <- test_path("resources", "stan", "bernoulli_include.stan")
+  expect_error(
+    cmdstan_model(stan_file = stan_program_w_include, include_paths = "NOT_A_DIR",
+                  quiet = TRUE),
+    "Directory 'NOT_A_DIR' does not exist"
+  )
+
+  expect_error(
+    expect_output(
+      cmdstan_model(stan_file = stan_program_w_include, quiet = TRUE),
+      "could not find include file"
+    )
+  )
+
+  expect_message(
+    mod_w_include <- cmdstan_model(stan_file = stan_program_w_include, quiet = TRUE,
+                                   include_paths = test_path("resources", "stan")),
+    "Compiling Stan program"
+  )
+  expect_equal(mod_w_include$exe_file(), strip_ext(absolute_path(stan_program_w_include)))
+
+  # cleanup
+  file.remove(paste0(mod_w_include$exe_file(), c("", ".o",".hpp")))
+})
+
+
 # Sample ------------------------------------------------------------------
 context("CmdStanModel-sample")
 


### PR DESCRIPTION
closes #59

This PR adds an `include_paths` argument to the `$compile()` method and uses it with `make` directly by adding `STANCFLAGS += --include_paths`. It didn’t seem necessary to use `make/local`, but @rok-cesnovar do you see any problems with handling the `include_paths` in this way? Would it be better to do it via `make/local` (or some other way)? 

@bbbales2 feel free to chime in as always, but no obligation! 