### PR TITLE
Better handling of compile errors

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -48,7 +48,8 @@ CmdStanMCMC <- R6::R6Class(
         args = self$output_files(),
         wd = cmdstan_path(),
         echo_cmd = TRUE,
-        echo = TRUE
+        echo = TRUE,
+        error_on_status = TRUE
       )
     },
     diagnose = function() {
@@ -60,7 +61,8 @@ CmdStanMCMC <- R6::R6Class(
         args = self$output_files(),
         wd = cmdstan_path(),
         echo_cmd = TRUE,
-        echo = TRUE
+        echo = TRUE,
+        error_on_status = TRUE
       )
     },
     draws = function() {
@@ -211,7 +213,8 @@ CmdStanVB <- R6::R6Class(
         args = self$output_files(),
         wd = cmdstan_path(),
         echo_cmd = TRUE,
-        echo = TRUE
+        echo = TRUE,
+        error_on_status = TRUE
       )
     },
     draws = function() {

--- a/R/install.R
+++ b/R/install.R
@@ -67,7 +67,8 @@ install_cmdstan <- function(dir = NULL,
     echo_cmd = FALSE,
     echo = !quiet,
     spinner = quiet,
-    error_on_status = FALSE
+    error_on_status = FALSE,
+    stderr_line_callback = function(x,p) { if(quiet) message(x) }
   )
 
   if (is.na(install_log$status) || install_log$status != 0) {
@@ -121,7 +122,9 @@ cmdstan_git_checkout_branch <- function(repo_branch,
     args = make_cmdstan,
     echo = !quiet,
     echo_cmd = !quiet,
-    spinner = quiet
+    spinner = quiet,
+    stderr_line_callback = function(x,p) { if(quiet) message(x) },
+    error_on_status = TRUE
   )
   invisible(install_log)
 }

--- a/R/model.R
+++ b/R/model.R
@@ -242,7 +242,7 @@ compile_method <- function(quiet = TRUE,
     echo_cmd = !quiet,
     echo = !quiet,
     spinner = quiet,
-    stderr_line_callback = function(x,p) { if(quiet) parse_compile_error(x, p) },
+    stderr_line_callback = function(x,p) { if(quiet) message(x) },
     error_on_status = TRUE
   )
 

--- a/R/model.R
+++ b/R/model.R
@@ -242,7 +242,8 @@ compile_method <- function(quiet = TRUE,
     echo_cmd = !quiet,
     echo = !quiet,
     spinner = quiet,
-    stderr_line_callback = parse_compile_error
+    stderr_line_callback = function(x,p) { if(quiet) parse_compile_error(x, p) },
+    error_on_status = TRUE
   )
 
   private$exe_file_ <- exe

--- a/R/model.R
+++ b/R/model.R
@@ -241,7 +241,8 @@ compile_method <- function(quiet = TRUE,
     wd = cmdstan_path(),
     echo_cmd = !quiet,
     echo = !quiet,
-    spinner = quiet
+    spinner = quiet,
+    stderr_line_callback = parse_compile_error
   )
 
   private$exe_file_ <- exe

--- a/R/model.R
+++ b/R/model.R
@@ -518,7 +518,8 @@ optimize_method <- function(data = NULL,
     args = runset$command_args()[[1]],
     wd = dirname(self$exe_file()),
     echo_cmd = FALSE,
-    echo = TRUE
+    echo = TRUE,
+    error_on_status = TRUE
   )
   CmdStanMLE$new(runset)
 }
@@ -646,7 +647,8 @@ variational_method <- function(data = NULL,
     args = runset$command_args()[[1]],
     wd = dirname(self$exe_file()),
     echo_cmd = FALSE,
-    echo = TRUE
+    echo = TRUE,
+    error_on_status = TRUE
   )
   CmdStanVB$new(runset)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -35,7 +35,8 @@ check_target_exe <- function(exe) {
       args = exe,
       wd = cmdstan_path(),
       echo_cmd = TRUE,
-      echo = TRUE
+      echo = TRUE,
+      error_on_status = TRUE
     )
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -378,5 +378,5 @@ set_num_threads <- function(num_threads) {
 }
 
 parse_compile_error = function(line, proc) {
-  warning(line, immediate. = TRUE, call. = FALSE)
+  message(line)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -376,3 +376,7 @@ set_num_threads <- function(num_threads) {
          call. = FALSE)
   }
 }
+
+parse_compile_error = function(line, proc) {
+  warning(line, immediate. = TRUE, call. = FALSE)
+}

--- a/R/utils.R
+++ b/R/utils.R
@@ -376,7 +376,3 @@ set_num_threads <- function(num_threads) {
          call. = FALSE)
   }
 }
-
-parse_compile_error = function(line, proc) {
-  message(line)
-}


### PR DESCRIPTION
Fixes #60

Adds the following: 
- R scripts will stop on compile error, which I think is expected behavior. Now scripts continue sampling with previously compiled models.
- will also stop on error in optimize, VI, diagnose and summary
- will always print stderr (warnings and errors) regardless if quiet is set or not

