### PR TITLE
Add argument `output_dir`

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -82,7 +82,7 @@ test_script:
   - R.exe CMD check .\\cmdstanr_*.tar.gz %_R_CHECK_FLAGS%
 
 on_success:
-  - Rscript -e "covr::codecov(line_exclusions = list('R/zzz.R'))"
+  - Rscript -e "covr::codecov(quiet=FALSE, line_exclusions = list('R/zzz.R'))"
 
 on_failure:
   - 7z a failure.zip *.Rcheck\*

--- a/R/fit.R
+++ b/R/fit.R
@@ -131,12 +131,12 @@ NULL
 #' @aliases fit-method-save_data_file fit-method-save_diagnostic_files
 #'   fit-method-output_files fit-method-data_file fit-method-diagnostic_files
 #'
-#' @description All fitted model objects have methods for saving (copying to a
-#'   specified location) the temporary files created by CmdStanR for CmdStan
-#'   output csv files and input data files. These methods move the files from
-#'   the CmdStanR temporary directory to a user-specified location. __The paths
-#'   stored in the fitted model object will also be updated to point to the new
-#'   file locations.__
+#' @description All fitted model objects have methods for saving (moving to a
+#'   specified location) the files created by CmdStanR to hold CmdStan output
+#'   csv files and input data files. These methods move the files from their
+#'   current location (possibly the temporary directory) to a user-specified
+#'   location. __The paths stored in the fitted model object will also be
+#'   updated to point to the new file locations.__
 #'
 #'   The versions without the `save_` prefix (e.g., `$output_files()`) return
 #'   the current file paths without moving any files.
@@ -166,7 +166,7 @@ NULL
 #' * `basename` is the user's provided `basename` argument;
 #' * `timestamp` is of the form `format(Sys.time(), "%Y%m%d%H%M")`;
 #' * `id` is the MCMC chain id (or `1` for non MCMC);
-#' * `random` contains five random alphanumeric characters/
+#' * `random` contains six random alphanumeric characters.
 #'
 #' For `$save_diagnostic_files()` everything is the same as for
 #' `$save_output_files()` except `"-diagnostic-"` is included in the new

--- a/R/model.R
+++ b/R/model.R
@@ -278,6 +278,7 @@ CmdStanModel$set("public", name = "compile", value = compile_method)
 #'     refresh = NULL,
 #'     init = NULL,
 #'     save_diagnostics = FALSE,
+#'     output_dir = NULL,
 #'     num_chains = 4,
 #'     num_cores = getOption("mc.cores", 1),
 #'     num_warmup = NULL,
@@ -378,6 +379,7 @@ sample_method <- function(data = NULL,
                           refresh = NULL,
                           init = NULL,
                           save_diagnostics = FALSE,
+                          output_dir = NULL,
                           num_chains = 4,
                           num_cores = getOption("mc.cores", 1),
                           num_warmup = NULL,
@@ -422,7 +424,8 @@ sample_method <- function(data = NULL,
     save_diagnostics = save_diagnostics,
     seed = seed,
     init = init,
-    refresh = refresh
+    refresh = refresh,
+    output_dir = output_dir
   )
   cmdstan_procs <- CmdStanProcs$new(num_chains, num_cores)
   runset <- CmdStanRun$new(cmdstan_args, cmdstan_procs)
@@ -457,6 +460,7 @@ CmdStanModel$set("public", name = "sample", value = sample_method)
 #'     refresh = NULL,
 #'     init = NULL,
 #'     save_diagnostics = FALSE,
+#'     output_dir = NULL,
 #'     algorithm = NULL,
 #'     init_alpha = NULL,
 #'     iter = NULL
@@ -488,6 +492,7 @@ optimize_method <- function(data = NULL,
                             refresh = NULL,
                             init = NULL,
                             save_diagnostics = FALSE,
+                            output_dir = NULL,
                             algorithm = NULL,
                             init_alpha = NULL,
                             iter = NULL) {
@@ -505,7 +510,8 @@ optimize_method <- function(data = NULL,
     save_diagnostics = save_diagnostics,
     seed = seed,
     init = init,
-    refresh = refresh
+    refresh = refresh,
+    output_dir = output_dir
   )
 
   cmdstan_procs <- CmdStanProcs$new(num_runs = 1, num_cores = 1)
@@ -546,6 +552,7 @@ CmdStanModel$set("public", name = "optimize", value = optimize_method)
 #'     refresh = NULL,
 #'     init = NULL,
 #'     save_diagnostics = FALSE,
+#'     output_dir = NULL,
 #'     algorithm = NULL,
 #'     iter = NULL,
 #'     grad_samples = NULL,
@@ -595,6 +602,7 @@ variational_method <- function(data = NULL,
                                refresh = NULL,
                                init = NULL,
                                save_diagnostics = FALSE,
+                               output_dir = NULL,
                                algorithm = NULL,
                                iter = NULL,
                                grad_samples = NULL,
@@ -626,7 +634,8 @@ variational_method <- function(data = NULL,
     save_diagnostics = save_diagnostics,
     seed = seed,
     init = init,
-    refresh = refresh
+    refresh = refresh,
+    output_dir = output_dir
   )
 
   cmdstan_procs <- CmdStanProcs$new(num_runs = 1, num_cores = 1)

--- a/R/run.R
+++ b/R/run.R
@@ -27,8 +27,12 @@ CmdStanRun <- R6::R6Class(
     model_name = function() self$args$model_name,
     method = function() self$args$method,
     data_file = function() self$args$data_file,
-    new_output_files = function() self$args$new_output_files(),
-    new_diagnostic_files = function() self$args$new_diagnostic_files(),
+    new_output_files = function() {
+      self$args$new_files(type = "output")
+    },
+    new_diagnostic_files = function() {
+      self$args$new_files(type = "diagnostic")
+    },
     diagnostic_files = function() {
       if (!length(private$diagnostic_files_)) {
         stop(

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -28,3 +28,16 @@
 #'   `save_diagnostics=TRUE` see the
 #'   [`$save_diagnostic_files()`][fit-method-save_diagnostic_files] method.
 #'
+#'   * `output_dir`: (string) A path to a directory where CmdStan should write
+#'   its output CSV files. For interactive use this can typically be left at
+#'   `NULL` (temporary directory) since CmdStanR makes the CmdStan output (e.g.,
+#'   posterior draws and diagnostics) available in \R via methods of the fitted
+#'   model objects. The behavior of `output_dir` is as follows:
+#'     - If `NULL` (the default) then the CSV files are written to a temporary
+#'       directory and only saved permanently if the user calls one of the
+#'       `$save_*` methods of the fitted model object (e.g.,
+#'       [`$save_output_files()`][fit-method-save_output_files]).
+#'     - If a path then the files are created in `output_dir` with names
+#'       corresponding the defaults used by `$save_output_files()` (and similar
+#'       methods like `$save_diagnostic_files()`).
+#'

--- a/man/fit-method-save_output_files.Rd
+++ b/man/fit-method-save_output_files.Rd
@@ -9,12 +9,12 @@
 \alias{fit-method-diagnostic_files}
 \title{Save output and data files}
 \description{
-All fitted model objects have methods for saving (copying to a
-specified location) the temporary files created by CmdStanR for CmdStan
-output csv files and input data files. These methods move the files from
-the CmdStanR temporary directory to a user-specified location. \strong{The paths
-stored in the fitted model object will also be updated to point to the new
-file locations.}
+All fitted model objects have methods for saving (moving to a
+specified location) the files created by CmdStanR to hold CmdStan output
+csv files and input data files. These methods move the files from their
+current location (possibly the temporary directory) to a user-specified
+location. \strong{The paths stored in the fitted model object will also be
+updated to point to the new file locations.}
 
 The versions without the \code{save_} prefix (e.g., \verb{$output_files()}) return
 the current file paths without moving any files.
@@ -50,7 +50,7 @@ the form \code{basename-timestamp-id-random}, where
 \item \code{basename} is the user's provided \code{basename} argument;
 \item \code{timestamp} is of the form \code{format(Sys.time(), "\%Y\%m\%d\%H\%M")};
 \item \code{id} is the MCMC chain id (or \code{1} for non MCMC);
-\item \code{random} contains five random alphanumeric characters/
+\item \code{random} contains six random alphanumeric characters.
 }
 
 For \verb{$save_diagnostic_files()} everything is the same as for

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -24,6 +24,7 @@ variables. Thus modes correspond to modes of the model as written.
   refresh = NULL,
   init = NULL,
   save_diagnostics = FALSE,
+  output_dir = NULL,
   algorithm = NULL,
   init_alpha = NULL,
   iter = NULL
@@ -66,6 +67,20 @@ is \code{save_diagnostics=FALSE}, which is appropriate for almost every use case
 divergences for HMC). To save the temporary files created when
 \code{save_diagnostics=TRUE} see the
 \code{\link[=fit-method-save_diagnostic_files]{$save_diagnostic_files()}} method.
+\item \code{output_dir}: (string) A path to a directory where CmdStan should write
+its output CSV files. For interactive use this can typically be left at
+\code{NULL} (temporary directory) since CmdStanR makes the CmdStan output (e.g.,
+posterior draws and diagnostics) available in \R via methods of the fitted
+model objects. The behavior of \code{output_dir} is as follows:
+\itemize{
+\item If \code{NULL} (the default) then the CSV files are written to a temporary
+directory and only saved permanently if the user calls one of the
+\verb{$save_*} methods of the fitted model object (e.g.,
+\code{\link[=fit-method-save_output_files]{$save_output_files()}}).
+\item If a path then the files are created in \code{output_dir} with names
+corresponding the defaults used by \verb{$save_output_files()} (and similar
+methods like \verb{$save_diagnostic_files()}).
+}
 }
 }
 

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -16,6 +16,7 @@ some data.
   refresh = NULL,
   init = NULL,
   save_diagnostics = FALSE,
+  output_dir = NULL,
   num_chains = 4,
   num_cores = getOption("mc.cores", 1),
   num_warmup = NULL,
@@ -71,6 +72,20 @@ is \code{save_diagnostics=FALSE}, which is appropriate for almost every use case
 divergences for HMC). To save the temporary files created when
 \code{save_diagnostics=TRUE} see the
 \code{\link[=fit-method-save_diagnostic_files]{$save_diagnostic_files()}} method.
+\item \code{output_dir}: (string) A path to a directory where CmdStan should write
+its output CSV files. For interactive use this can typically be left at
+\code{NULL} (temporary directory) since CmdStanR makes the CmdStan output (e.g.,
+posterior draws and diagnostics) available in \R via methods of the fitted
+model objects. The behavior of \code{output_dir} is as follows:
+\itemize{
+\item If \code{NULL} (the default) then the CSV files are written to a temporary
+directory and only saved permanently if the user calls one of the
+\verb{$save_*} methods of the fitted model object (e.g.,
+\code{\link[=fit-method-save_output_files]{$save_output_files()}}).
+\item If a path then the files are created in \code{output_dir} with names
+corresponding the defaults used by \verb{$save_output_files()} (and similar
+methods like \verb{$save_diagnostic_files()}).
+}
 }
 }
 

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -24,6 +24,7 @@ matrix for the approximation.
   refresh = NULL,
   init = NULL,
   save_diagnostics = FALSE,
+  output_dir = NULL,
   algorithm = NULL,
   iter = NULL,
   grad_samples = NULL,
@@ -73,6 +74,20 @@ is \code{save_diagnostics=FALSE}, which is appropriate for almost every use case
 divergences for HMC). To save the temporary files created when
 \code{save_diagnostics=TRUE} see the
 \code{\link[=fit-method-save_diagnostic_files]{$save_diagnostic_files()}} method.
+\item \code{output_dir}: (string) A path to a directory where CmdStan should write
+its output CSV files. For interactive use this can typically be left at
+\code{NULL} (temporary directory) since CmdStanR makes the CmdStan output (e.g.,
+posterior draws and diagnostics) available in \R via methods of the fitted
+model objects. The behavior of \code{output_dir} is as follows:
+\itemize{
+\item If \code{NULL} (the default) then the CSV files are written to a temporary
+directory and only saved permanently if the user calls one of the
+\verb{$save_*} methods of the fitted model object (e.g.,
+\code{\link[=fit-method-save_output_files]{$save_output_files()}}).
+\item If a path then the files are created in \code{output_dir} with names
+corresponding the defaults used by \verb{$save_output_files()} (and similar
+methods like \verb{$save_diagnostic_files()}).
+}
 }
 }
 

--- a/tests/testthat/answers/sandbox/README
+++ b/tests/testthat/answers/sandbox/README
@@ -1,4 +1,0 @@
-A directory we can play around with during testing, e.g. for reading and writing files (test-method-output_dir.R for example).
-
-Everything in this directory (except this file) gets removed during
-teardown after tests are run.

--- a/tests/testthat/answers/sandbox/README
+++ b/tests/testthat/answers/sandbox/README
@@ -1,0 +1,4 @@
+A directory we can play around with during testing, e.g. for reading and writing files (test-method-output_dir.R for example).
+
+Everything in this directory (except this file) gets removed during
+teardown after tests are run.

--- a/tests/testthat/teardown-remove-files.R
+++ b/tests/testthat/teardown-remove-files.R
@@ -1,6 +1,17 @@
 # remove any files that aren't .stan files from resources/stan,
 # e.g. files created by $compile()
+all_files_in_stan <-
+  list.files(test_path("resources", "stan"),
+             full.names = TRUE,
+             recursive = TRUE)
+not_stan_programs <- !grepl(".stan$", all_files_in_stan)
+file.remove(all_files_in_stan[not_stan_programs])
 
-all_files <- list.files(test_path("resources", "stan"), full.names = TRUE)
-not_stan_programs <- !grepl(".stan$", all_files)
-file.remove(all_files[not_stan_programs])
+# remove all files from answers/sandbox except readme
+all_files_in_sandbox <-
+  list.files(test_path("answers", "sandbox"),
+             full.names = TRUE,
+             include.dirs = TRUE,
+             recursive = TRUE)
+not_readme <- !grepl("README$", all_files_in_sandbox)
+file.remove(all_files_in_sandbox[not_readme])

--- a/tests/testthat/teardown-remove-files.R
+++ b/tests/testthat/teardown-remove-files.R
@@ -6,13 +6,3 @@ all_files_in_stan <-
              recursive = TRUE)
 not_stan_programs <- !grepl(".stan$", all_files_in_stan)
 file.remove(all_files_in_stan[not_stan_programs])
-
-# remove all files from answers/sandbox except README
-all_files_in_sandbox <-
-  list.files(test_path("answers", "sandbox"),
-             full.names = TRUE,
-             include.dirs = FALSE,
-             recursive = TRUE)
-not_readme <- !grepl("README$", all_files_in_sandbox)
-file.remove(all_files_in_sandbox[not_readme])
-file.remove(list.dirs(test_path("answers", "sandbox"), recursive = FALSE))

--- a/tests/testthat/teardown-remove-files.R
+++ b/tests/testthat/teardown-remove-files.R
@@ -7,11 +7,12 @@ all_files_in_stan <-
 not_stan_programs <- !grepl(".stan$", all_files_in_stan)
 file.remove(all_files_in_stan[not_stan_programs])
 
-# remove all files from answers/sandbox except readme
+# remove all files from answers/sandbox except README
 all_files_in_sandbox <-
   list.files(test_path("answers", "sandbox"),
              full.names = TRUE,
-             include.dirs = TRUE,
+             include.dirs = FALSE,
              recursive = TRUE)
 not_readme <- !grepl("README$", all_files_in_sandbox)
 file.remove(all_files_in_sandbox[not_readme])
+file.remove(list.dirs(test_path("answers", "sandbox"), recursive = FALSE))

--- a/tests/testthat/test-model-output_dir.R
+++ b/tests/testthat/test-model-output_dir.R
@@ -2,12 +2,16 @@ context("model-output_dir")
 
 if (not_on_cran()) {
   set_cmdstan_path()
+  sandbox <- file.path(tempdir(check = TRUE), "sandbox")
+  if (!dir.exists(sandbox)) {
+    dir.create(sandbox)
+  }
 }
 
 test_that("all fitting methods work with output_dir", {
   skip_on_cran()
   for (method in c("sample", "optimize", "variational")) {
-    method_dir <- test_path("answers", "sandbox", method)
+    method_dir <- file.path(sandbox, method)
     if (!dir.exists(method_dir)) {
       dir.create(method_dir)
     }
@@ -25,10 +29,10 @@ test_that("all fitting methods work with output_dir", {
 
   # specifying output_dir and save_diagnostics
   fit <- testing_fit("bernoulli", method = "sample", seed = 123,
-                     output_dir = test_path("answers", "sandbox", "sample"),
+                     output_dir = file.path(sandbox, "sample"),
                      save_diagnostics = TRUE)
 
-  files <- list.files(test_path("answers", "sandbox", "sample"))
+  files <- list.files(file.path(sandbox, "sample"))
   expect_equal(
     sum(grepl("diagnostic", files)),
     fit$num_runs()
@@ -48,7 +52,7 @@ test_that("error if output_dir is invalid", {
     "No directory provided"
   )
 
-  not_readable <- test_path("answers", "sandbox", "locked")
+  not_readable <- file.path(sandbox, "locked")
   dir.create(not_readable, mode = 0)
   expect_error(
     testing_fit("bernoulli", output_dir = not_readable),

--- a/tests/testthat/test-model-output_dir.R
+++ b/tests/testthat/test-model-output_dir.R
@@ -29,19 +29,19 @@ test_that("error if output_dir is invalid", {
   skip_on_cran()
 
   expect_error(
-    mod$sample(output_dir = "NOT_A_DIR"),
+    testing_fit("bernoulli", output_dir = "NOT_A_DIR"),
     "Directory 'NOT_A_DIR' does not exist",
     fixed = TRUE
   )
   expect_error(
-    mod$sample(output_dir = list()),
+    testing_fit("bernoulli", output_dir = TRUE),
     "No directory provided"
   )
 
   not_readable <- test_path("answers", "sandbox", "locked")
   dir.create(not_readable, mode = 0)
   expect_error(
-    mod$sample(output_dir = not_readable),
+    testing_fit("bernoulli", output_dir = not_readable),
     "not readable"
   )
 })

--- a/tests/testthat/test-model-output_dir.R
+++ b/tests/testthat/test-model-output_dir.R
@@ -51,13 +51,16 @@ test_that("error if output_dir is invalid", {
     testing_fit("bernoulli", output_dir = TRUE),
     "No directory provided"
   )
-
-  not_readable <- file.path(sandbox, "locked")
-  dir.create(not_readable, mode = "220")
-  expect_error(
-    testing_fit("bernoulli", output_dir = not_readable),
-    "not readable"
-  )
+  
+  if (!os_is_windows()) {
+    # FIXME: how do I create an unreadable file on windows?
+    not_readable <- file.path(sandbox, "locked")
+    dir.create(not_readable, mode = "220")
+    expect_error(
+      testing_fit("bernoulli", output_dir = not_readable),
+      "not readable"
+    )
+  }
   file.remove(list.files(sandbox, full.names = TRUE, recursive = TRUE))
 })
 

--- a/tests/testthat/test-model-output_dir.R
+++ b/tests/testthat/test-model-output_dir.R
@@ -53,11 +53,12 @@ test_that("error if output_dir is invalid", {
   )
 
   not_readable <- file.path(sandbox, "locked")
-  dir.create(not_readable, mode = 0)
+  dir.create(not_readable, mode = "220")
   expect_error(
     testing_fit("bernoulli", output_dir = not_readable),
     "not readable"
   )
+  file.remove(list.files(sandbox, full.names = TRUE, recursive = TRUE))
 })
 
 

--- a/tests/testthat/test-model-output_dir.R
+++ b/tests/testthat/test-model-output_dir.R
@@ -4,7 +4,6 @@ if (not_on_cran()) {
   set_cmdstan_path()
 }
 
-
 test_that("all fitting methods work with output_dir", {
   skip_on_cran()
   for (method in c("sample", "optimize", "variational")) {
@@ -13,16 +12,27 @@ test_that("all fitting methods work with output_dir", {
       dir.create(method_dir)
     }
 
-    # no output_dir should equate to tempdir
+    # no output_dir means should use tempdir
     fit <- testing_fit("bernoulli", method = method, seed = 123)
     expect_equal(fit$runset$args$output_dir, absolute_path(tempdir()))
 
-    # specify output_dir
+    # specifying output_dir
     fit <- testing_fit("bernoulli", method = method, seed = 123,
                         output_dir = method_dir)
     expect_equal(fit$runset$args$output_dir, absolute_path(method_dir))
     expect_equal(length(list.files(method_dir)), fit$num_runs())
   }
+
+  # specifying output_dir and save_diagnostics
+  fit <- testing_fit("bernoulli", method = "sample", seed = 123,
+                     output_dir = test_path("answers", "sandbox", "sample"),
+                     save_diagnostics = TRUE)
+
+  files <- list.files(test_path("answers", "sandbox", "sample"))
+  expect_equal(
+    sum(grepl("diagnostic", files)),
+    fit$num_runs()
+  )
 })
 
 test_that("error if output_dir is invalid", {

--- a/tests/testthat/test-model-output_dir.R
+++ b/tests/testthat/test-model-output_dir.R
@@ -1,0 +1,49 @@
+context("model-output_dir")
+
+if (not_on_cran()) {
+  set_cmdstan_path()
+}
+
+
+test_that("all fitting methods work with output_dir", {
+  skip_on_cran()
+  for (method in c("sample", "optimize", "variational")) {
+    method_dir <- test_path("answers", "sandbox", method)
+    if (!dir.exists(method_dir)) {
+      dir.create(method_dir)
+    }
+
+    # no output_dir should equate to tempdir
+    fit <- testing_fit("bernoulli", method = method, seed = 123)
+    expect_equal(fit$runset$args$output_dir, absolute_path(tempdir()))
+
+    # specify output_dir
+    fit <- testing_fit("bernoulli", method = method, seed = 123,
+                        output_dir = method_dir)
+    expect_equal(fit$runset$args$output_dir, absolute_path(method_dir))
+    expect_equal(length(list.files(method_dir)), fit$num_runs())
+  }
+})
+
+test_that("error if output_dir is invalid", {
+  skip_on_cran()
+
+  expect_error(
+    mod$sample(output_dir = "NOT_A_DIR"),
+    "Directory 'NOT_A_DIR' does not exist",
+    fixed = TRUE
+  )
+  expect_error(
+    mod$sample(output_dir = list()),
+    "No directory provided"
+  )
+
+  not_readable <- test_path("answers", "sandbox", "locked")
+  dir.create(not_readable, mode = 0)
+  expect_error(
+    mod$sample(output_dir = not_readable),
+    "not readable"
+  )
+})
+
+

--- a/tests/testthat/test-model-sample.R
+++ b/tests/testthat/test-model-sample.R
@@ -13,6 +13,7 @@ if (not_on_cran()) {
   # these are all valid for sample()
   ok_arg_values <- list(
     data = data_list,
+    output_dir = tempdir(),
     num_chains = 2,
     num_cores = 1,
     num_warmup = 50,
@@ -36,6 +37,7 @@ if (not_on_cran()) {
   # using any one of these should cause sample() to error
   bad_arg_values <- list(
     data = "NOT_A_FILE",
+    output_dir = "NOT_A_DIRECTORY",
     num_chains = -1,
     num_cores = -1,
     num_warmup = -1,
@@ -58,6 +60,7 @@ if (not_on_cran()) {
 
   bad_arg_values_2 <- list(
     data = matrix(1:10),
+    output_dir = 1,
     num_chains = "NOT_A_NUMBER",
     num_cores = "NOT_A_NUMBER",
     init = "NOT_A_FILE",


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Closes #89

* Builds off of the branch for PR #84 so should be reviewed after #84 is merged (the diff for this PR currently looks bigger than it really is since this branch includes all the changes from that one) 

* Adds argument `output_dir` to `$sample()`, `$optimize()`, and `$variational()` methods to control where output and diagnostic csv files are written:
   - e.g., `mod$sample(data = stan_data, output_dir = PATH_TO_DIRECTORY)`
   - internally `output_dir` is handled by `CmdStanArgs`
   - defaults to temporary directory (so default behavior stays the same)
* Added new test file `tests/testthat/test-model-output_dir.R`
* Refactored `copy_temp_files` to separate out generating file names into a different function that can also be called by `$new_files()` method of `CmdStanArgs` object.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
