### PR TITLE
Switch back to using Rdata temporarily while issue with 0x0s gets resolved for JSON

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,12 +24,12 @@ Imports:
     checkmate,
     posterior (>= 0.0.1),
     processx,
+    rstan,
     R6
 Suggests: 
     jsonlite (>= 1.2.0),
     knitr,
     rmarkdown,
-    rstan,
     testthat (>= 2.1.0)
 VignetteBuilder: knitr
 Remotes:  

--- a/R/model.R
+++ b/R/model.R
@@ -665,7 +665,7 @@ process_data <- function(data) {
     path <- absolute_path(data)
   } else if (is.list(data) && !is.data.frame(data)) {
     path <- tempfile(pattern = "standata-", fileext = ".dat")
-    stan_rdump(names(data), file = path, env = list2env(data))
+    rstan::stan_rdump(names(data), file = path, env = list2env(data))
   } else {
     stop("'data' should be a path or a named list.", call. = FALSE)
   }

--- a/R/model.R
+++ b/R/model.R
@@ -664,8 +664,8 @@ process_data <- function(data) {
   } else if (is.character(data)) {
     path <- absolute_path(data)
   } else if (is.list(data) && !is.data.frame(data)) {
-    path <- tempfile(pattern = "standata-", fileext = ".json")
-    write_stan_json(data = data, file = path)
+    path <- tempfile(pattern = "standata-", fileext = ".dat")
+    stan_rdump(names(data), file = path, env = list2env(data))
   } else {
     stop("'data' should be a path or a named list.", call. = FALSE)
   }

--- a/tests/testthat/test-fit-shared.R
+++ b/tests/testthat/test-fit-shared.R
@@ -96,16 +96,16 @@ test_that("saving data file works", {
   for (method in all_methods) {
     fit <- fits[[method]]
     old_path <- fit$data_file()
-    checkmate::expect_file_exists(old_path, extension = "json")
+    checkmate::expect_file_exists(old_path, extension = "dat")
 
     expect_message(
       path <- fit$save_data_file(tempdir(), basename = NULL,
                                  timestamp = FALSE, random = FALSE),
       "Moved data file and set internal path"
     )
-    checkmate::expect_file_exists(path, extension = "json")
+    checkmate::expect_file_exists(path, extension = "dat")
     expect_true(file.size(path) > 0)
-    expect_equal(basename(path), "logistic.json")
+    expect_equal(basename(path), "logistic.dat")
 
     expect_false(file.exists(old_path))
     expect_equal(fit$data_file(), path)


### PR DESCRIPTION
This swaps stan_rdump in for write_stan_json to handle https://github.com/stan-dev/cmdstanr/issues/96. We expect to go back to write_stan_json once cmdstan can handle multidimensional size zero arguments via json.

#### Submission Checklist

- [] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Columbia University


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
