### PR TITLE
Mention dependency on posterior package which is not on CRAN yet

### DIFF
--- a/README.md
+++ b/README.md
@@ -43,6 +43,7 @@ GitHub, but expect frequent changes until an official release.
 
 ```r
 # install.packages("devtools")
+# devtools::install_github("jgabry/posterior")
 devtools::install_github("stan-dev/cmdstanr")
 ```
 


### PR DESCRIPTION
#### Submission Checklist

- [X] Declare copyright holder and agree to license (see below)

#### Summary

I tried to install following the `README` file but got stuck for the lack of the `posterior` package, and then I had to find again in which repository it was. Let's mention it in the `README` while it's not yet on CRAN.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 

Marco Colombo

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
