### PR TITLE
With Cmdstan 2.22+ use JSON by default

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -24,12 +24,12 @@ Imports:
     checkmate,
     posterior (>= 0.0.1),
     processx,
-    rstan,
     R6
 Suggests: 
     jsonlite (>= 1.2.0),
     knitr,
     rmarkdown,
+    rstan,
     testthat (>= 2.1.0)
 VignetteBuilder: knitr
 Remotes: 

--- a/R/model.R
+++ b/R/model.R
@@ -664,8 +664,8 @@ process_data <- function(data) {
   } else if (is.character(data)) {
     path <- absolute_path(data)
   } else if (is.list(data) && !is.data.frame(data)) {
-    path <- tempfile(pattern = "standata-", fileext = ".dat")
-    rstan::stan_rdump(names(data), file = path, env = list2env(data))
+    path <- tempfile(pattern = "standata-", fileext = ".json")
+    write_stan_json(data = data, file = path)
   } else {
     stop("'data' should be a path or a named list.", call. = FALSE)
   }

--- a/R/model.R
+++ b/R/model.R
@@ -669,6 +669,9 @@ process_data <- function(data) {
       write_stan_json(data = data, file = path)
     } else {
       path <- tempfile(pattern = "standata-", fileext = ".dat")
+      if (!requireNamespace("rstan", quietly = TRUE)) {
+        stop("For CmdStan < 2.22 the rstan package is required for writing data.")
+      }
       rstan::stan_rdump(names(data), file = path, env = list2env(data))
     }
   } else {

--- a/R/model.R
+++ b/R/model.R
@@ -664,8 +664,13 @@ process_data <- function(data) {
   } else if (is.character(data)) {
     path <- absolute_path(data)
   } else if (is.list(data) && !is.data.frame(data)) {
-    path <- tempfile(pattern = "standata-", fileext = ".json")
-    write_stan_json(data = data, file = path)
+    if (cmdstan_version() >= "2.22") {
+      path <- tempfile(pattern = "standata-", fileext = ".json")
+      write_stan_json(data = data, file = path)
+    } else {
+      path <- tempfile(pattern = "standata-", fileext = ".dat")
+      rstan::stan_rdump(names(data), file = path, env = list2env(data))
+    }
   } else {
     stop("'data' should be a path or a named list.", call. = FALSE)
   }

--- a/tests/testthat/test-fit-shared.R
+++ b/tests/testthat/test-fit-shared.R
@@ -96,16 +96,16 @@ test_that("saving data file works", {
   for (method in all_methods) {
     fit <- fits[[method]]
     old_path <- fit$data_file()
-    checkmate::expect_file_exists(old_path, extension = "dat")
+    checkmate::expect_file_exists(old_path, extension = "json")
 
     expect_message(
       path <- fit$save_data_file(tempdir(), basename = NULL,
                                  timestamp = FALSE, random = FALSE),
       "Moved data file and set internal path"
     )
-    checkmate::expect_file_exists(path, extension = "dat")
+    checkmate::expect_file_exists(path, extension = "json")
     expect_true(file.size(path) > 0)
-    expect_equal(basename(path), "logistic.dat")
+    expect_equal(basename(path), "logistic.json")
 
     expect_false(file.exists(old_path))
     expect_equal(fit$data_file(), path)


### PR DESCRIPTION
Reverts stan-dev/cmdstanr#100 since the underlying cmdstan issue will be resolved for 2.22

Closes #109 