### PR TITLE
fix use of posterior::summarise_draws

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -37,18 +37,19 @@ CmdStanFit <- R6::R6Class(
 
     summary = function(...) {
       if (self$runset$method() == "sample") {
-        if (!length(self$output_files())) {
-          stop("No chains finished successfully. Unable to retrieve the fit.",
-              call. = FALSE)
-        }
         summary <- posterior::summarise_draws(self$draws(), ...)
-      } else { # don't include MCMC diagnostics for non MCMC
-        args <- list(...)
-        args$x <- self$draws()
-        if (!"measures" %in% names(args)) {
-          args$measures <- posterior::default_summary_measures()
+      } else {
+        if (!length(list(...))) {
+          # if user didn't supply any args use default summary measures,
+          # which don't include MCMC-specific things
+          summary <- posterior::summarise_draws(
+            self$draws(),
+            posterior::default_summary_measures()
+          )
+        } else {
+          # otherwise use whatever the user specified via ...
+          summary <- posterior::summarise_draws(self$draws(), ...)
         }
-        summary <- do.call(posterior::summarise_draws, args)
       }
       if (self$runset$method() == "optimize") {
         summary <- summary[, c("variable", "mean")]

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -25,6 +25,9 @@ test_that("summary() method works after mcmc", {
   x <- fit_mcmc$summary()
   expect_s3_class(x, "draws_summary")
   expect_equal(x$variable, c("lp__", PARAM_NAMES))
+
+  x <- fit_mcmc$summary(c("rhat", "sd"))
+  expect_equal(colnames(x), c("variable", "rhat", "sd"))
 })
 
 test_that("output() method works after mcmc", {

--- a/tests/testthat/test-fit-mle.R
+++ b/tests/testthat/test-fit-mle.R
@@ -12,11 +12,11 @@ test_that("reading in csv optimization output works", {
   expect_named(fit_mle$lp(), "lp__")
 })
 
-# test_that("summary method doesn't error for optimization", {
-#   skip_on_cran()
-#   # summary method for optimization isn't fully designed yet
-#   x <- fit_mle$summary()
-#   expect_s3_class(x, "draws_summary")
-#   expect_equal(colnames(x), c("variable", "estimate"))
-#   expect_equal(x$variable, PARAM_NAMES)
-# })
+test_that("summary method doesn't error for optimization", {
+  skip_on_cran()
+  # summary method for optimization isn't fully designed yet
+  x <- fit_mle$summary()
+  expect_s3_class(x, "draws_summary")
+  expect_equal(colnames(x), c("variable", "estimate"))
+  expect_equal(x$variable, PARAM_NAMES)
+})

--- a/tests/testthat/test-fit-vb.R
+++ b/tests/testthat/test-fit-vb.R
@@ -6,17 +6,17 @@ if (not_on_cran()) {
   PARAM_NAMES <- c("alpha", "beta[1]", "beta[2]", "beta[3]")
 }
 
-# test_that("summary() method works after vb", {
-#   skip_on_cran()
-#   x <- fit_vb$summary()
-#   expect_s3_class(x, "draws_summary")
-#   expect_equal(x$variable, PARAM_NAMES)
+test_that("summary() method works after vb", {
+  skip_on_cran()
+  x <- fit_vb$summary()
+  expect_s3_class(x, "draws_summary")
+  expect_equal(x$variable, PARAM_NAMES)
 
-#   x <- fit_vb$summary(measures = c("mean", "sd"))
-#   expect_s3_class(x, "draws_summary")
-#   expect_equal(x$variable, PARAM_NAMES)
-#   expect_equal(colnames(x), c("variable", "mean", "sd"))
-# })
+  x <- fit_vb$summary(c("mean", "sd"))
+  expect_s3_class(x, "draws_summary")
+  expect_equal(x$variable, PARAM_NAMES)
+  expect_equal(colnames(x), c("variable", "mean", "sd"))
+})
 
 test_that("draws() method returns posterior sample (reading csv works)", {
   skip_on_cran()


### PR DESCRIPTION
closes #111

Updates use of `posterior::summarise_draws()` to avoid problems for models fit using optimization and vb. The tests that were failing and commented out now pass. 

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Please describe the purpose of the pull request. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
