### PR TITLE
avoid duplicating code in $initialize() and private$read_csv_()

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -302,7 +302,11 @@ CmdStanMCMC <- R6::R6Class(
   public = list(
     initialize = function(runset) {
       super$initialize(runset)
-      private$read_csv_(diagnostic_warnings = TRUE)
+      if (!length(self$output_files())) {
+        warning("No chains finished successfully. Unable to retrieve the fit.")
+      } else {
+        private$read_csv_(diagnostic_warnings = TRUE)
+      }
     },
     num_chains = function() {
       super$num_runs()

--- a/R/fit.R
+++ b/R/fit.R
@@ -302,21 +302,7 @@ CmdStanMCMC <- R6::R6Class(
   public = list(
     initialize = function(runset) {
       super$initialize(runset)
-      if (!length(self$output_files())) {
-        warning("No chains finished successfully. Unable to retrieve the fit.")
-      } else {
-        data_csv <- read_sample_csv(self$output_files())
-        check_divergences(data_csv)
-        check_sampler_transitions_treedepth(data_csv)
-        private$draws_ <- data_csv$post_warmup_draws
-        private$sampler_diagnostics_ <- data_csv$post_warmup_sampler_diagnostics
-        private$sampling_info_ <- data_csv$sampling_info
-        if (!is.null(data_csv$sampling_info$save_warmup)
-            && data_csv$sampling_info$save_warmup) {
-          private$warmup_draws_ <- data_csv$warmup_draws
-          private$warmup_sampler_diagnostics_ <- data_csv$warmup_sampler_diagnostics
-        }
-      }
+      private$read_csv_(diagnostic_warnings = TRUE)
     },
     num_chains = function() {
       super$num_runs()
@@ -362,12 +348,16 @@ CmdStanMCMC <- R6::R6Class(
     warmup_sampler_diagnostics_ = NULL,
     warmup_draws_ = NULL,
     draws_ = NULL,
-    read_csv_ = function() {
+    read_csv_ = function(diagnostic_warnings = FALSE) {
       if (!length(self$output_files())) {
         stop("No chains finished successfully. Unable to retrieve the fit.",
              call. = FALSE)
       }
       data_csv <- read_sample_csv(self$output_files())
+      if (diagnostic_warnings) {
+        check_divergences(data_csv)
+        check_sampler_transitions_treedepth(data_csv)
+      }
       private$draws_ <- data_csv$post_warmup_draws
       private$sampler_diagnostics_ <- data_csv$post_warmup_sampler_diagnostics
       private$sampling_info_ <- data_csv$sampling_info


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Avoids code duplication in CmdStanMCMC by calling `private$read_csv_(diagnostic_warnings=TRUE)` in `$initialize()`. I added an argument `diagnostic_warnings` to `private$read_csv_` (defaulting to FALSE) so that it can be turned on during initialize but is otherwise off. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
