### PR TITLE
Fix csv match check

### DIFF
--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -14,10 +14,12 @@ check_sampling_csv_info_matches <- function(a, b) {
     return(list(error = "Supplied CSV files have samples for different parameters!"))
   }
   if(a$num_samples != b$num_samples ||
+    a$thin != b$thin ||
+    a$save_warmup != b$save_warmup ||
     (a$save_warmup == 1 && a$num_warmup != b$num_warmup)) {
       return(list(error = "Supplied CSV files dont match in the number of stored samples!"))
   }
-  dont_match_list <- c("id", "inverse_metric", "step_size", "seed", "init", "file_name")
+  dont_match_list <- c("id", "inverse_metric", "step_size", "seed", "init")
   not_matching <- c()
   for (name in names(a)) {
     if (!(name %in% dont_match_list) && (is.null(b[[name]]) ||  all(a[[name]] != b[[name]]))) {
@@ -126,7 +128,6 @@ read_sample_info_csv <- function(csv_file) {
     cols <- length(csv_file_info$inverse_metric)/inverse_metric_rows
     dim(csv_file_info$inverse_metric) <- c(rows,cols)
   }
-  csv_file_info$file_name <- csv_file
   csv_file_info$model_name <- csv_file_info$model
   csv_file_info$model <- NULL
   csv_file_info$adapt_engaged <- csv_file_info$engaged
@@ -254,7 +255,7 @@ read_sample_csv <- function(output_files) {
   }
   if(length(not_matching) > 0) {
     not_matching_list <- paste(unique(not_matching), collapse = ", ")
-    warning("The supplied csv files do not match in the following arguments: ", not_matching_list)
+    warning("The supplied csv files do not match in the following arguments: ", not_matching_list, "!")
   }
   sampling_info$model_params <- repair_variable_names(sampling_info$model_params)
   sampling_info$inverse_metric <- NULL

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -8,18 +8,23 @@
 #'
 check_sampling_csv_info_matches <- function(a, b) {
   if (a$model_name != b$model_name) {
-    return("Supplied CSV files were not generated wtih the same model!")
+    return(list(error = "Supplied CSV files were not generated wtih the same model!"))
   }
   if ((length(a$model_params)!= length(b$model_params)) || !(all(a$model_params == b$model_params) && all(a$sampler_diagnostics == b$sampler_diagnostics))) {
-    return("Supplied CSV files have samples for different parameters!")
+    return(list(error = "Supplied CSV files have samples for different parameters!"))
   }
-  dont_match_list <- c("id", "inverse_metric", "step_size", "seed")
+  if(a$num_samples != b$num_samples ||
+    (a$save_warmup == 1 && a$num_warmup != b$num_warmup)) {
+      return(list(error = "Supplied CSV files dont match in the number of stored samples!"))
+  }
+  dont_match_list <- c("id", "inverse_metric", "step_size", "seed", "init", "file_name")
+  not_matching <- c()
   for (name in names(a)) {
     if (!(name %in% dont_match_list) && (is.null(b[[name]]) ||  all(a[[name]] != b[[name]]))) {
-      return("Supplied CSV files do not match in all sampling settings!")
+      not_matching <- c(not_matching, name)
     }
   }
-  NULL
+  list(not_matching = not_matching)
 }
 
 #' Reads the sampling arguments and the diagonal of the
@@ -39,7 +44,7 @@ read_sample_info_csv <- function(csv_file) {
   csv_file_info = list()
   con  <- file(csv_file, open = "r")
   csv_file_info[["inverse_metric"]] <- NULL
-  csv_file_info$inverse_metric_rows <- 0
+  inverse_metric_rows <- 0
   parsing_done <- FALSE
   while (length(line <- readLines(con, n = 1, warn = FALSE)) > 0 && !parsing_done) {
     if (!startsWith(line, "#")) {
@@ -100,12 +105,12 @@ read_sample_info_csv <- function(csv_file) {
             parsing_done <- TRUE
             break;
           }
-          if (csv_file_info$inverse_metric_rows == 0) {
+          if (inverse_metric_rows == 0) {
             csv_file_info$inverse_metric <- rapply(inv_metric_split, as.numeric)
           } else {
             csv_file_info$inverse_metric <- c(csv_file_info$inverse_metric, rapply(inv_metric_split, as.numeric))
           }
-          csv_file_info$inverse_metric_rows <- csv_file_info$inverse_metric_rows + 1
+          inverse_metric_rows <- inverse_metric_rows + 1
         }
       }
     }
@@ -116,11 +121,12 @@ read_sample_info_csv <- function(csv_file) {
   } else if (csv_file_info$method != "sample") {
     stop("Supplied CSV file was not generated with sampling. Consider using read_optim_csv or read_vb_csv!")
   }
-  if (csv_file_info$inverse_metric_rows > 0) {
-    rows <- csv_file_info$inverse_metric_rows
-    cols <- length(csv_file_info$inverse_metric)/csv_file_info$inverse_metric_rows
+  if (inverse_metric_rows > 0) {
+    rows <- inverse_metric_rows
+    cols <- length(csv_file_info$inverse_metric)/inverse_metric_rows
     dim(csv_file_info$inverse_metric) <- c(rows,cols)
   }
+  csv_file_info$file_name <- csv_file
   csv_file_info$model_name <- csv_file_info$model
   csv_file_info$model <- NULL
   csv_file_info$adapt_engaged <- csv_file_info$engaged
@@ -155,6 +161,7 @@ read_sample_csv <- function(output_files) {
   post_warmup_sampler_diagnostics_draws <- NULL
   inverse_metric = list()
   step_size = list()
+  not_matching = c()
   for(output_file in output_files) {
     checkmate::assert_file_exists(output_file, access = "r", extension = "csv")
     # read meta data
@@ -166,11 +173,12 @@ read_sample_csv <- function(output_files) {
     } else {
       csv_file_info <- read_sample_info_csv(output_file)
       # check if sampling info matches
-      error <- check_sampling_csv_info_matches(sampling_info,
+      check <- check_sampling_csv_info_matches(sampling_info,
                                   csv_file_info)
-      if (!is.null(error)) {
-        stop(error)
+      if (!is.null(check$error)) {
+        stop(check$error)
       }
+      not_matching <- c(not_matching, check$not_matching)
       sampling_info$id <- c(sampling_info$id,
                             csv_file_info$id)
       inverse_metric[[csv_file_info$id]] <- csv_file_info$inverse_metric
@@ -243,6 +251,10 @@ read_sample_csv <- function(output_files) {
   }
   if (!is.null(post_warmup_draws)){
     dimnames(post_warmup_draws)$variable <- repair_variable_names(sampling_info$model_params)
+  }
+  if(length(not_matching) > 0) {
+    not_matching_list <- paste(unique(not_matching), collapse = ", ")
+    warning("The supplied csv files do not match in the following arguments: ", not_matching_list)
   }
   sampling_info$model_params <- repair_variable_names(sampling_info$model_params)
   sampling_info$inverse_metric <- NULL

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -19,10 +19,12 @@ check_sampling_csv_info_matches <- function(a, b) {
     (a$save_warmup == 1 && a$num_warmup != b$num_warmup)) {
       return(list(error = "Supplied CSV files dont match in the number of stored samples!"))
   }
-  dont_match_list <- c("id", "inverse_metric", "step_size", "seed", "init")
+  match_list <- c("stan_version_major", "stan_version_minor", "stan_version_patch", "gamma", "kappa",
+                  "t0", "init_buffer", "term_buffer", "window", "algorithm", "engine", "max_depth",
+                  "metric", "stepsize", "stepsize_jitter", "adapt_engaged", "adapt_delta", "num_warmup")
   not_matching <- c()
   for (name in names(a)) {
-    if (!(name %in% dont_match_list) && (is.null(b[[name]]) ||  all(a[[name]] != b[[name]]))) {
+    if ((name %in% match_list) && (is.null(b[[name]]) ||  all(a[[name]] != b[[name]]))) {
       not_matching <- c(not_matching, name)
     }
   }

--- a/tests/testthat/test-csv.R
+++ b/tests/testthat/test-csv.R
@@ -11,6 +11,10 @@ if (not_on_cran()) {
                           seed = 123, num_chains = 2, num_samples = 1000, num_warmup = 1000, thin = 1)
   fit_logistic_thin_1 <- testing_fit("logistic", method = "sample",
                           seed = 123, num_chains = 2, num_samples = 1000, num_warmup = 1000, thin = 1)
+  fit_logistic_thin_1a <- testing_fit("logistic", method = "sample",
+                                     seed = 123, num_chains = 2, num_samples = 500, num_warmup = 1000, thin = 1)
+  fit_logistic_thin_1b <- testing_fit("logistic", method = "sample",
+                                      seed = 123, num_chains = 2, num_samples = 1000, num_warmup = 500, thin = 1)
   fit_logistic_thin_1_with_warmup <- testing_fit("logistic", method = "sample",
                           seed = 123, num_chains = 2, num_samples = 1000, num_warmup = 1000, thin = 1, save_warmup = 1)
   fit_logistic_thin_3 <- testing_fit("logistic", method = "sample",
@@ -31,12 +35,24 @@ test_that("read_sample_csv() fails for different model names", {
                "Supplied CSV files were not generated wtih the same model!")
 })
 
-test_that("read_sample_csv() fails for different sampling settings", {
+test_that("read_sample_csv() fails for different number of samples in csv", {
   skip_on_cran()
   csv_files <- c(fit_logistic_thin_1$output_files(),
                  fit_logistic_thin_10$output_files())
   expect_error(read_sample_csv(csv_files),
-               "Supplied CSV files do not match in all sampling settings!")
+               "Supplied CSV files dont match in the number of stored samples!")
+  csv_files <- c(fit_logistic_thin_1$output_files(),
+                 fit_logistic_thin_1a$output_files())
+  expect_error(read_sample_csv(csv_files),
+               "Supplied CSV files dont match in the number of stored samples!")
+  csv_files <- c(fit_logistic_thin_1$output_files(),
+                 fit_logistic_thin_1b$output_files())
+  expect_warning(read_sample_csv(csv_files),
+               "The supplied csv files do not match in the following arguments: num_warmup!")
+  csv_files <- c(fit_logistic_thin_1$output_files(),
+                 fit_logistic_thin_1_with_warmup$output_files())
+  expect_error(read_sample_csv(csv_files),
+                 "Supplied CSV files dont match in the number of stored samples!")
 })
 
 test_that("read_sample_csv() fails for different parameters", {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #131 

`read_sample_csv` will now stop only if the following args in csv files dont match: 
- num_samples
- num_warmup if save_warmup = 1
- thin
- save_warmup (one csv contains warmup samples, the other doesnt)

This are the args that will cause chains of different length and we cant merge them. If other args dont match it will just give out a warning.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
