### PR TITLE
replaces parse_json with read_json and adds retries to download

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -188,25 +188,13 @@ latest_released_version <- function() {
     stop("Please install the jsonlite package.", call. = FALSE)
   }
   dest_file <- tempfile(pattern = "releases-", fileext = ".json")
-  download_url <- "https://api.github.com/repos/stan-dev/cmdstan/releases"
+  download_url <- "https://api.github.com/repos/stan-dev/cmdstan/releases/latest"
   release_list_downloaded <- download_with_retries(download_url, dest_file)
   if (!release_list_downloaded) {
     stop("GitHub download of release list failed.", call. = FALSE)
   }
-  releases <- jsonlite::read_json(dest_file)
-  for(release in releases) {
-    if(!release$prerelease) {
-      version_number <- sub("v", "", release$tag_name)
-      return(version_number)
-    }
-  }
-  # if none of the releases are stable, use the latest
-  if (length(releases) > 0) {
-    version_number <- sub("v", "", releases[[1]]$tag_name)
-    version_number
-  } else {
-    stop("No Cmdstan release available!")
-  }  
+  release <- jsonlite::read_json(dest_file)
+  sub("v", "", release$tag_name)
 }
 
 # download with retries and pauses

--- a/vignettes/cmdstanr.Rmd
+++ b/vignettes/cmdstanr.Rmd
@@ -32,7 +32,7 @@ interface. See the [*Comparison with RStan*](#comparison-with-rstan) section
 later in this vignette for more details on how the two inferfaces differ.
 
 **CmdStanR is unreleased and user facing functions are still subject to change**, 
-but the development version can be installed from GitHub:
+but the development version can be installed from GitHub (requires the `devtools` R package):
 
 ```{r install_github, eval=FALSE}
 devtools::install_github("stan-dev/cmdstanr")


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #145 by:
- replacing `parse_json` with `read_json`. read_json is from jsonlite 1.2.0 which matches our requirement
- adds retries to downloading release files
- move back to using `releases/latest` instead of `releases` as that seems to ignore pre-releases so its fine

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
