### PR TITLE
Add deprecation warning for threads = TRUE

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -242,7 +242,7 @@ compile_method <- function(quiet = TRUE,
   # temporary deprecation warnings
   if (isTRUE(threads)) {
     warning("'threads' is deprecated. Please use 'cpp_options = list(stan_threads = TRUE)' instead.")
-    stanc_options[["stan_threads"]] <- TRUE
+    cpp_options[["stan_threads"]] <- TRUE
   }
   if (!force_recompile) {
     message("Model executable is up to date!")

--- a/R/model.R
+++ b/R/model.R
@@ -217,7 +217,9 @@ compile_method <- function(quiet = TRUE,
                            include_paths = NULL,
                            cpp_options = list(),
                            stanc_options = list(),
-                           force_recompile = FALSE) {
+                           force_recompile = FALSE,
+                           #deprecated
+                           threads = FALSE) {
   if (all(nzchar(self$exe_file()))) {
     exe <- cmdstan_ext(strip_ext(self$stan_file()))
   } else {
@@ -236,6 +238,11 @@ compile_method <- function(quiet = TRUE,
   } else if (file.exists(self$stan_file())
              && file.mtime(exe) < file.mtime(self$stan_file())) {
     force_recompile <- TRUE
+  }
+  # temporary deprecation warnings
+  if (isTRUE(threads)) {
+    warning("'threads' is deprecated. Please use 'cpp_options = list(stan_threads = TRUE)' instead.")
+    stanc_options[["stan_threads"]] <- TRUE
   }
   if (!force_recompile) {
     message("Model executable is up to date!")


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Using threads = TRUE warns the user and not stops.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
