### PR TITLE
Bugfix/recompiled header

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmdstanr
 Title: R Interface to 'CmdStan'
-Version: 0.0.0.9000
+Version: 0.0.0.9001
 Authors@R: 
     c(person(given = "Jonah", family = "Gabry", role = c("aut", "cre"),
            email = "jsg2201@columbia.edu"),

--- a/R/install.R
+++ b/R/install.R
@@ -286,6 +286,37 @@ build_cmdstan <- function(dir,
   )
 }
 
+# Removes files that are used to simplify switching to using threading,
+# opencl or mpi.
+clean_compile_helper_files <- function() {
+  # remove main_.*.o files and model_header_.*.hpp.gch files
+  files_to_remove <- c(
+    list.files(
+      path = file.path(cmdstan_path(), "src", "cmdstan"),
+      pattern = "main.*\\.o$",
+      full.names = TRUE
+    ),
+    list.files(
+      path = file.path(cmdstan_path(), "src", "cmdstan"),
+      pattern = "main.*\\.d$",
+      full.names = TRUE
+    ),
+    list.files(
+      path = file.path(cmdstan_path(), "stan", "src", "stan", "model"),
+      pattern = "model_header.*\\.hpp.gch$",
+      full.names = TRUE
+    ),
+    list.files(
+      path = file.path(cmdstan_path(), "stan", "src", "stan", "model"),
+      pattern = "model_header.*\\.d$",
+      full.names = TRUE
+    )
+  )
+  if (!is.null(files_to_remove)) {
+    file.remove(files_to_remove)
+  }
+}
+
 clean_cmdstan <- function(dir = cmdstan_path(),
                           cores = getOption("mc.cores", 2),
                           quiet = FALSE) {
@@ -299,20 +330,7 @@ clean_cmdstan <- function(dir = cmdstan_path(),
     error_on_status = FALSE,
     stderr_line_callback = function(x,p) { if(quiet) message(x) }
   )
-  # remove main_.*.o files and model_header_.*.hpp.gch files
-  files_to_remove <- c(
-    list.files(
-      path = file.path(cmdstan_path(), "src", "cmdstan"),
-      pattern = "main_.*\\.o$",
-      full.names = TRUE
-    ),
-    list.files(
-      path = file.path(cmdstan_path(), "stan", "src", "stan", "model"),
-      pattern = "model_header_.*\\.hpp.gch$",
-      full.names = TRUE
-    )
-  )
-  file.remove(files_to_remove)
+  clean_compile_helper_files()
 }
 
 build_example <- function(dir, cores, quiet, timeout) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -285,27 +285,15 @@ prepare_precompiled <- function(cpp_options = list(), quiet = FALSE) {
   }
   main_path_w_flags <- file.path(cmdstan_path(), "src", "cmdstan", paste0("main_", flags, ".o"))
   main_path_o <- file.path(cmdstan_path(), "src", "cmdstan", "main.o")
-  main_path_d <- file.path(cmdstan_path(), "src", "cmdstan", "main.d")
   model_header_path_w_flags <- file.path(cmdstan_path(), "stan", "src", "stan", "model", paste0("model_header_", flags, ".hpp.gch"))
   model_header_path_gch <- file.path(cmdstan_path(), "stan", "src", "stan", "model", "model_header.hpp.gch")
-  model_header_path_d <- file.path(cmdstan_path(), "stan", "src", "stan", "model", "model_header.d")
-  model_header_path_hpp <- file.path(cmdstan_path(), "stan", "src", "stan", "model", "model_header.d")
   if (file.exists(model_header_path_gch)) {
     model_header_gch_used <- TRUE
   } else {
     model_header_gch_used <- FALSE
   }
   if (!file.exists(main_path_w_flags)) {
-
-    files_to_remove <- c(
-      main_path_o,
-      main_path_d,
-      model_header_path_gch,
-      model_header_path_d
-    )
-    for (file in files_to_remove) if (file.exists(file)) {
-      file.remove(file)
-    }
+    clean_compile_helper_files()
     run_log <- processx::run(
       command = make_cmd(),
       args = c(cpp_options_to_compile_flags(cpp_options),
@@ -330,14 +318,7 @@ prepare_precompiled <- function(cpp_options = list(), quiet = FALSE) {
         stderr_line_callback = function(x,p) { if (!quiet) message(x) },
         error_on_status = TRUE
       )
-      if (file.exists(model_header_path_gch)) {
-        file.copy(model_header_path_gch, model_header_path_w_flags)
-      }
-    }
-  } else {
-    file.copy(main_path_w_flags, main_path_o, overwrite=TRUE)
-    if (model_header_gch_used && file.exists(model_header_path_w_flags)) {
-      file.copy(model_header_path_w_flags, model_header_path_gch, overwrite=TRUE)
+      file.copy(model_header_path_gch, model_header_path_w_flags)
     }
   }
 }

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -74,35 +74,5 @@ test_that("install_cmdstan() errors if it times out", {
   )
 })
 
-test_that("prepare_precompiled() works", {
-  main_noflags_o <- file.path(cmdstan_path(), "src", "cmdstan", paste0("main_noflags.o"))
-  main_threads_o <- file.path(cmdstan_path(), "src", "cmdstan", paste0("main_threads.o"))
-  if (file.exists(main_noflags_o)) {
-    file.remove(main_noflags_o)
-  }
-  if (file.exists(main_threads_o)) {
-    file.remove(main_threads_o)
-  }
-  prepare_precompiled(cpp_options = list(), quiet = TRUE)
-  expect_true(file.exists(main_noflags_o))
-  expect_false(file.exists(main_threads_o))
-  no_flags_time = file.mtime(main_noflags_o)
-  prepare_precompiled(cpp_options = list(stan_threads = TRUE), quiet = TRUE)
-  expect_true(file.exists(main_noflags_o))
-  expect_true(file.exists(main_threads_o))
-  threads_time = file.mtime(main_threads_o)
-  prepare_precompiled(cpp_options = list(), quiet = TRUE)
-  expect_true(file.exists(main_noflags_o))
-  expect_true(file.exists(main_threads_o))
-  expect_equal(file.mtime(main_noflags_o), no_flags_time)
-  expect_equal(file.mtime(main_threads_o), threads_time)
-  prepare_precompiled(cpp_options = list(stan_threads = TRUE), quiet = TRUE)
-  expect_true(file.exists(main_noflags_o))
-  expect_true(file.exists(main_threads_o))
-  expect_equal(file.mtime(main_noflags_o), no_flags_time)
-  expect_equal(file.mtime(main_threads_o), threads_time)
 
-  file.remove(main_noflags_o)
-  file.remove(main_threads_o)
-})
 

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -132,3 +132,30 @@ test_that("name in STANCFLAGS is set correctly", {
   out <- utils::capture.output(mod$compile(quiet = FALSE, force_recompile = TRUE, stanc_options = list(name = "bernoulli2_model")))
   expect_output(print(out), out_name)
 })
+
+
+test_that("switching threads on and off works without rebuild", {
+  skip_on_cran()
+  main_path_o <- file.path(cmdstan_path(), "src", "cmdstan", "main.o")
+  mod$compile(force_recompile = TRUE)
+
+  before_mtime <- file.mtime(main_path_o)
+  mod$compile(force_recompile = TRUE)
+  after_mtime <- file.mtime(main_path_o)
+  expect_equal(before_mtime, after_mtime)
+
+  before_mtime <- file.mtime(main_path_o)
+  mod$compile(force_recompile = TRUE, cpp_options = list(stan_threads = TRUE))
+  after_mtime <- file.mtime(main_path_o)
+  expect_gt(after_mtime, before_mtime)
+
+  before_mtime <- file.mtime(main_path_o)
+  mod$compile(force_recompile = TRUE, cpp_options = list(stan_threads = TRUE))
+  after_mtime <- file.mtime(main_path_o)
+  expect_equal(before_mtime, after_mtime)
+
+  before_mtime <- file.mtime(main_path_o)
+  mod$compile(force_recompile = TRUE)
+  after_mtime <- file.mtime(main_path_o)
+  expect_gt(after_mtime, before_mtime)
+})


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This PR fixes the bug that caused issues for @andrewgelman and everyone where the compiler version changed (even the patch number).

I was trying to be too clever in PR #172 and did not account for precompiled headers.
This eliminates some of that "cleverness" and fixes the bug.

Behavior now:
```R
mod <- cmdstan_model(file, force_recompile = TRUE) # 1 - slow - first compile ever - must build main.o and precompiled header for no stan flags
mod <- cmdstan_model(file, force_recompile = TRUE) # 2 - fast - main.o and precompiled header built

mod <- cmdstan_model(file, force_recompile = TRUE, cpp_options = list(stan_threads=TRUE)) # 3 - slow - must build main.o and precompiled header for stan_threads
mod <- cmdstan_model(file, force_recompile = TRUE, cpp_options = list(stan_threads=TRUE)) # 4 - fast - main.o and precompiled header built

mod <- cmdstan_model(file, force_recompile = TRUE) # 5 - slow - must build main.o and precompiled header for no flags again
mod <- cmdstan_model(file, force_recompile = TRUE) # 6 - fast - main.o and precompiled header built
```

We will hopefully also add some of this to cmdstan makefiles for the next version which will eliminate the need for cmdstanr doing any of this.
And also make case 5 faster which was the intent of PR #172 which caused this bug.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, University of Ljubljana

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
