### PR TITLE
Handle failed chains better

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -68,10 +68,10 @@ CmdStanFit <- R6::R6Class(
       self$runset$run_cmdstan_tool("diagnose", ...)
     },
 
-    output_files = function(include_failed = TRUE) {
+    output_files = function(include_failed = FALSE) {
       self$runset$output_files(include_failed)
     },
-    latent_dynamics_files = function(include_failed = TRUE) {
+    latent_dynamics_files = function(include_failed = FALSE) {
       self$runset$latent_dynamics_files(include_failed)
     },
     data_file = function() {
@@ -80,16 +80,14 @@ CmdStanFit <- R6::R6Class(
     save_output_files = function(dir = ".",
                                  basename = NULL,
                                  timestamp = TRUE,
-                                 random = TRUE,
-                                 include_failed = TRUE) {
-      self$runset$save_output_files(dir, basename, timestamp, random, include_failed)
+                                 random = TRUE) {
+      self$runset$save_output_files(dir, basename, timestamp, random)
     },
     save_latent_dynamics_files = function(dir = ".",
                                      basename = NULL,
                                      timestamp = TRUE,
-                                     random = TRUE,
-                                     include_failed = TRUE) {
-      self$runset$save_latent_dynamics_files(dir, basename, timestamp, random, include_failed)
+                                     random = TRUE) {
+      self$runset$save_latent_dynamics_files(dir, basename, timestamp, random)
     },
     save_data_file = function(dir = ".",
                               basename = NULL,
@@ -247,8 +245,6 @@ NULL
 #' * `timestamp` is of the form `format(Sys.time(), "%Y%m%d%H%M")`;
 #' * `id` is the MCMC chain id (or `1` for non MCMC);
 #' * `random` contains six random alphanumeric characters;
-#' * `include_failed` specifies if files produced by chains that failed to finish
-#'    are included. By default its set to TRUE.
 #'
 #' For `$save_latent_dynamics_files()` everything is the same as for
 #' `$save_output_files()` except `"-diagnostic-"` is included in the new

--- a/R/run.R
+++ b/R/run.R
@@ -33,7 +33,7 @@ CmdStanRun <- R6::R6Class(
     new_latent_dynamics_files = function() {
       self$args$new_files(type = "diagnostic")
     },
-    latent_dynamics_files = function() {
+    latent_dynamics_files = function(include_failed = TRUE) {
       if (!length(private$latent_dynamics_files_)) {
         stop(
           "No latent dynamics files found. ",
@@ -41,20 +41,27 @@ CmdStanRun <- R6::R6Class(
           call. = FALSE
         )
       }
-      private$latent_dynamics_files_
+      if (include_failed) {
+        private$latent_dynamics_files_
+      } else {
+        ok <- self$procs$is_finished() | self$procs$is_queued()
+        private$latent_dynamics_files_[ok]
+      }            
     },
-    output_files = function() {
-      # if we are using background processes only output the file if
-      # the process finished normally
-      ok <- self$procs$is_finished() | self$procs$is_queued()
-      private$output_files_[ok]
+    output_files = function(include_failed = TRUE) {
+      if (include_failed) {
+        private$output_files_
+      } else {
+        ok <- self$procs$is_finished() | self$procs$is_queued()
+        private$output_files_[ok]
+      }      
     },
     save_output_files = function(dir = ".",
                                  basename = NULL,
                                  timestamp = TRUE,
-                                 random = TRUE) {
-      # FIXME use self$output_files(include_failed=TRUE) once #76 is fixed
-      current_files <- private$output_files_
+                                 random = TRUE,
+                                 include_failed = TRUE) {
+      current_files <- self$output_files(include_failed = include_failed)
       new_paths <- copy_temp_files(
         current_paths = current_files,
         new_dir = dir,
@@ -74,10 +81,9 @@ CmdStanRun <- R6::R6Class(
     save_latent_dynamics_files = function(dir = ".",
                                      basename = NULL,
                                      timestamp = TRUE,
-                                     random = TRUE) {
-      # FIXME use self$latent_dynamics_files(include_failed=TRUE) once #76 is fixed
-      current_files <- self$latent_dynamics_files() # used so we get error if 0 files
-      current_files <- private$latent_dynamics_files_ # used so we still save all of them
+                                     random = TRUE,
+                                     include_failed = TRUE) {
+      current_files <- self$latent_dynamics_files(include_failed = include_failed) # used so we get error if 0 files
       new_paths <- copy_temp_files(
         current_paths = current_files,
         new_dir = dir,
@@ -149,7 +155,7 @@ CmdStanRun <- R6::R6Class(
         stop("Not available for optimize method.", call. = FALSE)
       }
       tool <- match.arg(tool)
-      if (!length(self$output_files())) {
+      if (!length(self$output_files(include_failed = FALSE))) {
         stop("No CmdStan runs finished successfully. ",
              "Unable to run bin/", tool, ".", call. = FALSE)
       }
@@ -157,7 +163,7 @@ CmdStanRun <- R6::R6Class(
       check_target_exe(target_exe)
       run_log <- processx::run(
         command = target_exe,
-        args = c(self$output_files(), flags),
+        args = c(self$output_files(include_failed = FALSE), flags),
         wd = cmdstan_path(),
         echo_cmd = TRUE,
         echo = TRUE,
@@ -540,6 +546,9 @@ CmdStanProcs <- R6::R6Class(
               "seconds.\n")
         } else if (num_failed == num_chains) {
           warning("All chains finished unexpectedly!\n", call. = FALSE)
+          warning("Use read_sample_csv() to read the results of the failed chains.",
+                  immediate. = TRUE,
+                  call. = FALSE)
         } else {
           warning(num_failed, " chain(s) finished unexpectedly!",
                   immediate. = TRUE,
@@ -547,6 +556,9 @@ CmdStanProcs <- R6::R6Class(
           cat("The remaining chains had a mean execution time of",
               format(round(mean(self$total_time()), 1), nsmall = 1),
               "seconds.\n")
+          warning("The returned fit object will only read in results of succesful chains. Please use read_sample_csv() to read the results of the failed chains separately.",
+                  immediate. = TRUE,
+                  call. = FALSE)
         }
       }
       invisible(self)

--- a/R/run.R
+++ b/R/run.R
@@ -33,7 +33,7 @@ CmdStanRun <- R6::R6Class(
     new_latent_dynamics_files = function() {
       self$args$new_files(type = "diagnostic")
     },
-    latent_dynamics_files = function(include_failed = TRUE) {
+    latent_dynamics_files = function(include_failed = FALSE) {
       if (!length(private$latent_dynamics_files_)) {
         stop(
           "No latent dynamics files found. ",
@@ -48,7 +48,7 @@ CmdStanRun <- R6::R6Class(
         private$latent_dynamics_files_[ok]
       }            
     },
-    output_files = function(include_failed = TRUE) {
+    output_files = function(include_failed = FALSE) {
       if (include_failed) {
         private$output_files_
       } else {
@@ -59,9 +59,8 @@ CmdStanRun <- R6::R6Class(
     save_output_files = function(dir = ".",
                                  basename = NULL,
                                  timestamp = TRUE,
-                                 random = TRUE,
-                                 include_failed = TRUE) {
-      current_files <- self$output_files(include_failed = include_failed)
+                                 random = TRUE) {
+      current_files <- self$output_files(include_failed = TRUE)
       new_paths <- copy_temp_files(
         current_paths = current_files,
         new_dir = dir,
@@ -81,9 +80,8 @@ CmdStanRun <- R6::R6Class(
     save_latent_dynamics_files = function(dir = ".",
                                      basename = NULL,
                                      timestamp = TRUE,
-                                     random = TRUE,
-                                     include_failed = TRUE) {
-      current_files <- self$latent_dynamics_files(include_failed = include_failed) # used so we get error if 0 files
+                                     random = TRUE) {
+      current_files <- self$latent_dynamics_files(include_failed = TRUE) # used so we get error if 0 files
       new_paths <- copy_temp_files(
         current_paths = current_files,
         new_dir = dir,

--- a/tests/testthat/test-failed-chains.R
+++ b/tests/testthat/test-failed-chains.R
@@ -92,7 +92,6 @@ test_that("$output_files() and latent_dynamic_files() returns path to all files 
 
 test_that("$save_* methods save all files regardless of chain failure", {
   skip_on_cran()
-  fit_all_fail$save_output_files(dir = tempdir())
   expect_message(
     fit_all_fail$save_output_files(dir = tempdir()),
     "Moved 4 files"

--- a/tests/testthat/test-failed-chains.R
+++ b/tests/testthat/test-failed-chains.R
@@ -65,7 +65,7 @@ test_that("correct warnings are thrown when some chains fail", {
 test_that("$output_files() and latent_dynamic_files() returns path to all files regardless of chain failure", {
   skip_on_cran()
   expect_equal(
-    length(fit_all_fail$output_files()),
+    length(fit_all_fail$output_files(include_failed = TRUE)),
     4
   )
   expect_equal(
@@ -73,11 +73,11 @@ test_that("$output_files() and latent_dynamic_files() returns path to all files 
     0
   )
   expect_equal(
-    length(fit_some_fail$output_files()),
+    length(fit_some_fail$output_files(include_failed = TRUE)),
     4
   )
   expect_equal(
-    length(fit_all_fail$latent_dynamics_files()),
+    length(fit_all_fail$latent_dynamics_files(include_failed = TRUE)),
     4
   )
   expect_equal(
@@ -85,8 +85,16 @@ test_that("$output_files() and latent_dynamic_files() returns path to all files 
     0
   )
   expect_equal(
-    length(fit_some_fail$latent_dynamics_files()),
+    length(fit_some_fail$latent_dynamics_files(include_failed = TRUE)),
     4
+  )
+  expect_equal(
+    length(fit_all_fail$output_files()),
+    0
+  )
+  expect_equal(
+    length(fit_all_fail$latent_dynamics_files()),
+    0
   )
 })
 

--- a/tests/testthat/test-failed-chains.R
+++ b/tests/testthat/test-failed-chains.R
@@ -23,7 +23,7 @@ if (not_on_cran()) {
           save_latent_dynamics = TRUE
         )
       )
-      num_files <- length(check_some_fail$output_files())
+      num_files <- length(check_some_fail$output_files(include_failed = FALSE))
     }
     check_some_fail
   }
@@ -52,7 +52,7 @@ test_that("correct warnings are thrown when some chains fail", {
   skip_on_cran()
   expect_warning(
      fit_tmp <- make_some_fail(mod),
-     paste(4 - length(fit_tmp$output_files()), "chain(s) finished unexpectedly"),
+     paste(4 - length(fit_tmp$output_files(include_failed = FALSE)), "chain(s) finished unexpectedly"),
      fixed = TRUE
   )
 
@@ -62,8 +62,37 @@ test_that("correct warnings are thrown when some chains fail", {
   }
 })
 
+test_that("$output_files() and latent_dynamic_files() returns path to all files regardless of chain failure", {
+  skip_on_cran()
+  expect_equal(
+    length(fit_all_fail$output_files()),
+    4
+  )
+  expect_equal(
+    length(fit_all_fail$output_files(include_failed = FALSE)),
+    0
+  )
+  expect_equal(
+    length(fit_some_fail$output_files()),
+    4
+  )
+  expect_equal(
+    length(fit_all_fail$latent_dynamics_files()),
+    4
+  )
+  expect_equal(
+    length(fit_all_fail$latent_dynamics_files(include_failed = FALSE)),
+    0
+  )
+  expect_equal(
+    length(fit_some_fail$latent_dynamics_files()),
+    4
+  )
+})
+
 test_that("$save_* methods save all files regardless of chain failure", {
   skip_on_cran()
+  fit_all_fail$save_output_files(dir = tempdir())
   expect_message(
     fit_all_fail$save_output_files(dir = tempdir()),
     "Moved 4 files"


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #76 

Fit will be returned regardless of the number of chains that finished successfully.

fit$draws(), fit$summary() and all other functions that require results from the CSV files will only read in results from successful chains. Same for cmdstan_summary and cmdstan_diagnose.

fit$latent_dynamics_files(), fit$output_files() , fit$save_latent_dynamics_files() and fit$save_output_files() all have include_failed = TRUE, meaning that the return/save files from failed chains by default. This allows users to read failed chains separately if necessary.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
