### PR TITLE
Fix Windows run after reboot bug

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -261,10 +261,13 @@ compile_method <- function(quiet = TRUE,
   file.copy(self$stan_file(), temp_stan_file, overwrite = TRUE)
   tmp_exe <- cmdstan_ext(strip_ext(temp_stan_file)) # adds .exe on Windows
 
-  # add path to the build tbb library to the PATH variable to avoid copying the dll file
+  # add path to the TBB library to the PATH variable to avoid copying the dll file
   if (cmdstan_version() >= "2.21" && os_is_windows()) {
     path_to_TBB <- file.path(cmdstan_path(), "stan", "lib", "stan_math", "lib", "tbb")
-    Sys.setenv(PATH = paste0(path_to_TBB, ";", Sys.getenv("PATH")))
+    current_path <- Sys.getenv("PATH")
+    if (regexpr("path_to_TBB", current_path, perl = TRUE) <= 0) {
+      Sys.setenv(PATH = paste0(path_to_TBB, ";", Sys.getenv("PATH")))
+    }    
   }
 
   stancflags_val <- ""

--- a/R/run.R
+++ b/R/run.R
@@ -208,6 +208,15 @@ CmdStanRun <- R6::R6Class(
 .run_sample <- function() {
   procs <- self$procs
   on.exit(procs$cleanup(), add = TRUE)
+  
+  # add path to the TBB library to the PATH variable
+  if (cmdstan_version() >= "2.21" && os_is_windows()) {
+    path_to_TBB <- file.path(cmdstan_path(), "stan", "lib", "stan_math", "lib", "tbb")
+    current_path <- Sys.getenv("PATH")
+    if (regexpr("path_to_TBB", current_path, perl = TRUE) <= 0) {
+      Sys.setenv(PATH = paste0(path_to_TBB, ";", Sys.getenv("PATH")))
+    }    
+  }
 
   cat("Running MCMC with", procs$num_runs(), "chain(s) on", procs$num_cores(),
       "core(s)...\n\n")
@@ -255,6 +264,14 @@ CmdStanRun <- R6::R6Class(
 CmdStanRun$set("private", name = "run_sample_", value = .run_sample)
 
 .run_other <- function() {
+  # add path to the TBB library to the PATH variable
+  if (cmdstan_version() >= "2.21" && os_is_windows()) {
+    path_to_TBB <- file.path(cmdstan_path(), "stan", "lib", "stan_math", "lib", "tbb")
+    current_path <- Sys.getenv("PATH")
+    if (regexpr("path_to_TBB", current_path, perl = TRUE) <= 0) {
+      Sys.setenv(PATH = paste0(path_to_TBB, ";", Sys.getenv("PATH")))
+    }    
+  }
   # FIXME for consistency we should use a CmdStanProcs object
   # for optimize and variational too, but for now this is fine
   run_log <- processx::run(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This was the problem @martinmodrak was experiencing. The problem was that we only set the TBB path in the compiling step and if you did a reboot and used a built model it never got set.

You can check that this is the bug by rebooting, force-compiling some unrelated model, and trying to run the previously failing model.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Univ. of Ljubljana


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
