### PR TITLE
Rename flags to cpp_options

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -39,7 +39,7 @@
 #' @param release_url Specifies the URL to a specific Cmdstan release to be
 #'   installed. By default set to `NULL`, which downloads the latest stable
 #'   release from [GitHub](https://github.com/stan-dev/cmdstan/releases).
-#' @param flags A list specifying any makefile flags/variables to be
+#' @param cpp_options A list specifying any makefile flags/variables to be
 #'   written to the `make/local` file. For example, `list("CXX" = "clang++")`
 #'   will force the use of clang for compilation.
 #'
@@ -52,7 +52,7 @@ install_cmdstan <- function(dir = NULL,
                             overwrite = FALSE,
                             timeout = 1200,
                             release_url = NULL,
-                            flags = list()) {
+                            cpp_options = list()) {
   if (is.null(dir)) {
     dir <- cmdstan_default_install_path()
     if (!dir.exists(dir)) {
@@ -107,12 +107,13 @@ install_cmdstan <- function(dir = NULL,
           call. = FALSE)
   }
   file.remove(dest_file)
-  cmdstan_make_local(dir = dir_cmdstan, flags = flags, append = TRUE)
+  cmdstan_make_local(dir = dir_cmdstan, cpp_options = cpp_options, append = TRUE)
+  version <- read_cmdstan_version(dir_cmdstan)
   if (os_is_windows()) {
-    if (cmdstan_ver < "2.24") {
+    if (version < "2.24") {
       cmdstan_make_local(
         dir = dir_cmdstan,
-        flags = list(
+        cpp_options = list(
           "ifeq (gcc,$(CXX_TYPE))",
           "CXXFLAGS_WARNINGS+= -Wno-int-in-bool-context -Wno-attributes",
           "endif"
@@ -120,11 +121,11 @@ install_cmdstan <- function(dir = NULL,
         append = TRUE
       )
     }
-    if (cmdstan_ver > "2.22" && cmdstan_ver < "2.24") {
+    if (version > "2.22" && version < "2.24") {
       windows_stanc <- file.path(dir_cmdstan, "bin", "windows-stanc")
       bin_stanc_exe <- file.path(dir_cmdstan, "bin", "stanc.exe")
       if (file.exists(windows_stanc)) {
-        file.rename(windows_stanc, bin_stanc_exe)
+        file.copy(windows_stanc, bin_stanc_exe)
       }
     }
   }
@@ -161,20 +162,20 @@ rebuild_cmdstan <- function(dir = cmdstan_path(),
 #' @param append For `cmdstan_make_local()`, should the listed makefile flags be
 #'   appended to the end of the existing make/local file? The default is `TRUE`.
 #'   If `FALSE` the file is overwritten.
-#' @return For `cmdstan_make_local()`, if `flags=NULL` then the existing
+#' @return For `cmdstan_make_local()`, if `cpp_options=NULL` then the existing
 #'   contents of `make/local` are returned without writing anything, otherwise
 #'   the updated contents are returned.
 #' @examples
-#' flags <- list(
+#' cpp_options <- list(
 #'   "CXX" = "clang++",
 #'   "CXXFLAGS+= -march-native",
 #'   PRECOMPILED_HEADERS = TRUE
 #' )
-#' # cmdstan_make_local(flags = flags)
+#' # cmdstan_make_local(cpp_options = cpp_options)
 #' # rebuild_cmdstan()
 #'
 cmdstan_make_local <- function(dir = cmdstan_path(),
-                               flags = NULL,
+                               cpp_options = NULL,
                                append = TRUE) {
   make_local_path <- file.path(dir, "make", "local")
   if (!is.null(flags)) {

--- a/R/install.R
+++ b/R/install.R
@@ -178,19 +178,19 @@ cmdstan_make_local <- function(dir = cmdstan_path(),
                                cpp_options = NULL,
                                append = TRUE) {
   make_local_path <- file.path(dir, "make", "local")
-  if (!is.null(flags)) {
+  if (!is.null(cpp_options)) {
     built_flags = c()
-    for (i in seq_len(length(flags))) {
-      option_name <- names(flags)[i]
-      if (isTRUE(as.logical(flags[[i]]))) {
+    for (i in seq_len(length(cpp_options))) {
+      option_name <- names(cpp_options)[i]
+      if (isTRUE(as.logical(cpp_options[[i]]))) {
         built_flags = c(built_flags, paste0(option_name, "=true"))
-      } else if (isFALSE(as.logical(flags[[i]]))) {
+      } else if (isFALSE(as.logical(cpp_options[[i]]))) {
         built_flags = c(built_flags, paste0(option_name, "=false"))
       } else {
         if (is.null(option_name) || !nzchar(option_name)) {
-          built_flags = c(built_flags, paste0(flags[[i]]))
+          built_flags = c(built_flags, paste0(cpp_options[[i]]))
         } else {
-          built_flags = c(built_flags, paste0(option_name, "=", flags[[i]]))
+          built_flags = c(built_flags, paste0(option_name, "=", cpp_options[[i]]))
         }
       }
     }

--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -13,7 +13,7 @@ install_cmdstan(
   overwrite = FALSE,
   timeout = 1200,
   release_url = NULL,
-  flags = list()
+  cpp_options = list()
 )
 
 rebuild_cmdstan(
@@ -23,7 +23,7 @@ rebuild_cmdstan(
   timeout = 600
 )
 
-cmdstan_make_local(dir = cmdstan_path(), flags = NULL, append = TRUE)
+cmdstan_make_local(dir = cmdstan_path(), cpp_options = NULL, append = TRUE)
 }
 \arguments{
 \item{dir}{Path to the directory in which to install CmdStan. The default is
@@ -51,7 +51,7 @@ installation process.}
 installed. By default set to \code{NULL}, which downloads the latest stable
 release from \href{https://github.com/stan-dev/cmdstan/releases}{GitHub}.}
 
-\item{flags}{A list specifying any makefile flags/variables to be
+\item{cpp_options}{A list specifying any makefile flags/variables to be
 written to the \code{make/local} file. For example, \code{list("CXX" = "clang++")}
 will force the use of clang for compilation.}
 
@@ -60,7 +60,7 @@ appended to the end of the existing make/local file? The default is \code{TRUE}.
 If \code{FALSE} the file is overwritten.}
 }
 \value{
-For \code{cmdstan_make_local()}, if \code{flags=NULL} then the existing
+For \code{cmdstan_make_local()}, if \code{cpp_options=NULL} then the existing
 contents of \code{make/local} are returned without writing anything, otherwise
 the updated contents are returned.
 }
@@ -87,12 +87,12 @@ should typically be followed by calling \code{rebuild_cmdstan()}.
 \examples{
 # install_cmdstan(cores = 4)
 
-flags <- list(
+cpp_options <- list(
   "CXX" = "clang++",
   "CXXFLAGS+= -march-native",
   PRECOMPILED_HEADERS = TRUE
 )
-# cmdstan_make_local(flags = flags)
+# cmdstan_make_local(cpp_options = cpp_options)
 # rebuild_cmdstan()
 
 }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -108,7 +108,7 @@ test_that("cmdstan_make_local() works", {
    TEST1 = TRUE,
    "TEST2" = FALSE
   )
-  expect_equal(cmdstan_make_local(cpp_options = flags),
+  expect_equal(cmdstan_make_local(cpp_options = cpp_options),
                c(
                  "CXX=clang++",
                  "CXXFLAGS+= -march-native",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -102,20 +102,20 @@ test_that("cmdstan_make_local() works", {
     file.remove(make_local_path)
   }
   expect_equal(cmdstan_make_local(), NULL)
-  flags = list(
+  cpp_options = list(
    "CXX" = "clang++",
    "CXXFLAGS+= -march-native",
    TEST1 = TRUE,
    "TEST2" = FALSE
   )
-  expect_equal(cmdstan_make_local(flags = flags),
+  expect_equal(cmdstan_make_local(cpp_options = flags),
                c(
                  "CXX=clang++",
                  "CXXFLAGS+= -march-native",
                  "TEST1=true",
                  "TEST2=false"
                  ))
-  expect_equal(cmdstan_make_local(flags = list("TEST3" = TRUE)),
+  expect_equal(cmdstan_make_local(cpp_options = list("TEST3" = TRUE)),
                c(
                  "CXX=clang++",
                  "CXXFLAGS+= -march-native",
@@ -123,8 +123,8 @@ test_that("cmdstan_make_local() works", {
                  "TEST2=false",
                  "TEST3=true"
                ))
-  expect_equal(cmdstan_make_local(flags = list("TEST4" = TRUE), append = FALSE),
+  expect_equal(cmdstan_make_local(cpp_options = list("TEST4" = TRUE), append = FALSE),
                c("TEST4=true"))
-  cmdstan_make_local(flags = as.list(exisiting_make_local), append = FALSE)
+  cmdstan_make_local(cpp_options = as.list(exisiting_make_local), append = FALSE)
 })
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This closes #190. I forgot we have the flags argument in `install_cmdstan` so that was not really an issue. I just renamed it to `cpp_options` as that is the name we use in other places. This also fixes a minor issue I observed on Windows with the flags to silence warnings not being recognized properly.

Will merge when tests pass.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Univ. of Ljubljana


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
