### PR TITLE
Update install instructions

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmdstanr
 Title: R Interface to 'CmdStan'
-Version: 0.0.0.9002
+Version: 0.0.0.9003
 Authors@R: 
     c(person(given = "Jonah", family = "Gabry", role = c("aut", "cre"),
            email = "jsg2201@columbia.edu"),
@@ -32,6 +32,8 @@ Suggests:
     rmarkdown,
     rstan,
     testthat (>= 2.1.0)
+Additional_repositories:
+        https://mc-stan.org/r-packages/
 VignetteBuilder: knitr
 Remotes: 
     jgabry/posterior

--- a/README.md
+++ b/README.md
@@ -33,13 +33,16 @@ license required for RStan.
 
 ### Installation
 
-CmdStanR is not released yet, but will eventually be released as the
-**cmdstanr** R package. Currently you can install the development version from
-GitHub, but expect frequent changes until an official release.
+Currently you can install the pre-beta release of the **cmdstanr** R package with 
+
+```r
+install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/"))
+```
+
+or you can install the development version from GitHub:
 
 ```r
 # install.packages("devtools")
-# devtools::install_github("jgabry/posterior")
 devtools::install_github("stan-dev/cmdstanr")
 ```
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

cmdstanr and posterior are now on https://mc-stan.org/r-packages/
This updates the install instructions.

`devtools::install_github("jgabry/posterior")` is also not needed even with install_github due to the 
`Additional_repositories` field.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
