### PR TITLE
Print method

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmdstanr
 Title: R Interface to 'CmdStan'
-Version: 0.0.0.9005
+Version: 0.0.0.9006
 Authors@R: 
     c(person(given = "Jonah", family = "Gabry", role = c("aut", "cre"),
            email = "jsg2201@columbia.edu"),

--- a/R/fit.R
+++ b/R/fit.R
@@ -40,20 +40,21 @@ CmdStanFit <- R6::R6Class(
       private$sampling_info_
     },
 
-    summary = function(...) {
+    summary = function(variables = NULL, ...) {
+      draws <- self$draws(variables)
       if (self$runset$method() == "sample") {
-        summary <- posterior::summarise_draws(self$draws(), ...)
+        summary <- posterior::summarise_draws(draws, ...)
       } else {
         if (!length(list(...))) {
           # if user didn't supply any args use default summary measures,
           # which don't include MCMC-specific things
           summary <- posterior::summarise_draws(
-            self$draws(),
+            draws,
             posterior::default_summary_measures()
           )
         } else {
           # otherwise use whatever the user specified via ...
-          summary <- posterior::summarise_draws(self$draws(), ...)
+          summary <- posterior::summarise_draws(draws, ...)
         }
       }
       if (self$runset$method() == "optimize") {

--- a/R/fit.R
+++ b/R/fit.R
@@ -281,18 +281,18 @@ NULL
 #' Compute a summary table of MCMC estimates and diagnostics
 #'
 #' @name fit-method-summary
-#' @aliases summary
-#' @description Run [`summarise_draws()`][posterior::draws_summary]
-#'   from the \pkg{posterior} package. For MCMC only post-warmup draws are
-#'   included in the summary.
+#' @aliases summary print.CmdStanMCMC print.CmdStanMLE print.CmdStanVB
+#' @description The `$summary()` method runs
+#'   [`summarise_draws()`][posterior::draws_summary] from the \pkg{posterior}
+#'   package. For MCMC only post-warmup draws are included in the summary.
 #'
-#'   The `$print()` method is a wrapper around the `$summary()` method that
-#'   removes the extra formatting used for printing tibbles.
+#'   The `$print()` method prints the same summary but removes the extra
+#'   formatting used for printing tibbles.
 #'
 #' @section Usage:
 #'   ```
 #'   $summary(variables = NULL, ...)
-#'   $print(variables = NULL, ..., digits = 2)
+#'   $print(variables = NULL, ..., digits = 2, max_rows = 10)
 #'   ```
 #' @section Arguments:
 #' * `variables`: (character vector) The variables to include.
@@ -300,9 +300,14 @@ NULL
 #' [`posterior::summarise_draws()`][posterior::draws_summary].
 #' * `digits`: (integer) For `print` only, the number of digits to use for
 #' rounding.
+#' * `max_rows`: (integer) For `print` only, the maximum number of rows to print.
 #'
 #' @section Value:
-#' See [`posterior::summarise_draws()`][posterior::draws_summary].
+#' The `$summary()` method returns the tibble created by
+#' [`posterior::summarise_draws()`][posterior::draws_summary].
+#'
+#' The `$print()` method returns the fitted model object itself (invisibly),
+#' which is the standard behavior for print methods in \R.
 #'
 #' @seealso [`CmdStanMCMC`], [`CmdStanMLE`], [`CmdStanVB`]
 #'
@@ -311,6 +316,7 @@ NULL
 #' fit <- cmdstanr_example("logistic")
 #' fit$summary()
 #' fit$print()
+#' fit$print(max_rows = 2) # same as print(fit, max_rows = 2)
 #'
 #' # include only certain variables
 #' fit$summary("beta")

--- a/R/fit.R
+++ b/R/fit.R
@@ -68,13 +68,11 @@ CmdStanFit <- R6::R6Class(
       # print summary table without using tibbles
       out <- self$summary(variables, ...)
       out <- as.data.frame(out)
-      rownames(out) <- out$variable
-      out$variable <- NULL
-      out <- format(round(out, digits = digits), nsmall = digits)
+      out[, -1] <- format(round(out[, -1], digits = digits), nsmall = digits)
       for (col in c("rhat", "ess_bulk", "ess_tail")) {
         if (col %in% colnames(out)) out[[col]] <- as.integer(out[[col]])
       }
-      print(out)
+      print(out, row.names=FALSE)
     },
 
     cmdstan_summary = function(...) {

--- a/R/fit.R
+++ b/R/fit.R
@@ -64,15 +64,24 @@ CmdStanFit <- R6::R6Class(
       summary
     },
 
-    print = function(variables = NULL, ..., digits = 2) {
+    print = function(variables = NULL, ..., digits = 2, max_rows = 10) {
       # print summary table without using tibbles
       out <- self$summary(variables, ...)
       out <- as.data.frame(out)
+      rows <- nrow(out)
+      print_rows <- seq_len(min(rows, max_rows))
+      out <- out[print_rows, ]
+      out[, 1] <- format(out[, 1], justify = "left")
       out[, -1] <- format(round(out[, -1], digits = digits), nsmall = digits)
-      for (col in c("rhat", "ess_bulk", "ess_tail")) {
-        if (col %in% colnames(out)) out[[col]] <- as.integer(out[[col]])
+      for (col in grep("ess_", colnames(out), value = TRUE)) {
+        out[[col]] <- as.integer(out[[col]])
       }
+
       print(out, row.names=FALSE)
+      if (max_rows < rows) {
+        cat("\n # showing", max_rows, "of", rows, "rows (change via 'max_rows' argument)")
+      }
+      invisible(self)
     },
 
     cmdstan_summary = function(...) {

--- a/R/fit.R
+++ b/R/fit.R
@@ -63,6 +63,20 @@ CmdStanFit <- R6::R6Class(
       }
       summary
     },
+
+    print = function(variables = NULL, ..., digits = 2) {
+      # print summary table without using tibbles
+      out <- self$summary(variables, ...)
+      out <- as.data.frame(out)
+      rownames(out) <- out$variable
+      out$variable <- NULL
+      out <- format(round(out, digits = digits), nsmall = digits)
+      for (col in c("rhat", "ess_bulk", "ess_tail")) {
+        if (col %in% colnames(out)) out[[col]] <- as.integer(out[[col]])
+      }
+      print(out)
+    },
+
     cmdstan_summary = function(...) {
       self$runset$run_cmdstan_tool("stansummary", ...)
     },
@@ -265,13 +279,20 @@ NULL
 #'   from the \pkg{posterior} package. For MCMC only post-warmup draws are
 #'   included in the summary.
 #'
+#'   The `$print()` method is a wrapper around the `$summary()` method that
+#'   removes the extra formatting used for printing tibbles.
+#'
 #' @section Usage:
 #'   ```
-#'   $summary(...)
+#'   $summary(variables = NULL, ...)
+#'   $print(variables = NULL, ..., digits = 2)
 #'   ```
 #' @section Arguments:
+#' * `variables`: (character vector) The variables to include.
 #' * `...`: Optional arguments to pass to
 #' [`posterior::summarise_draws()`][posterior::draws_summary].
+#' * `digits`: (integer) For `print` only, the number of digits to use for
+#' rounding.
 #'
 #' @section Value:
 #' See [`posterior::summarise_draws()`][posterior::draws_summary].
@@ -282,7 +303,14 @@ NULL
 #' \dontrun{
 #' fit <- cmdstanr_example("logistic")
 #' fit$summary()
-#' fit$summary(c("mean", "sd"))
+#' fit$print()
+#'
+#' # include only certain variables
+#' fit$summary("beta")
+#' fit$print(c("alpha", "beta[2]"))
+#'
+#' # include all variables but only certain summaries
+#' fit$summary(NULL, c("mean", "sd"))
 #' }
 #'
 NULL

--- a/docs/reference/fit-method-summary.html
+++ b/docs/reference/fit-method-summary.html
@@ -47,9 +47,11 @@
 
 
 <meta property="og:title" content="Compute a summary table of MCMC estimates and diagnostics — fit-method-summary" />
-<meta property="og:description" content="Run summarise_draws()
-from the posterior package. For MCMC only post-warmup draws are
-included in the summary." />
+<meta property="og:description" content="The $summary() method runs
+summarise_draws() from the posterior
+package. For MCMC only post-warmup draws are included in the summary.
+The $print() method prints the same summary but removes the extra
+formatting used for printing tibbles." />
 <meta property="og:image" content="https://mc-stan.org/cmdstanr/logo.png" />
 
 
@@ -82,7 +84,7 @@ included in the summary." />
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">cmdstanr</a>
-        <span class="version label label-danger" data-toggle="tooltip" data-placement="bottom" title="Unreleased version">0.0.0.9005</span>
+        <span class="version label label-danger" data-toggle="tooltip" data-placement="bottom" title="Unreleased version">0.0.0.9006</span>
       </span>
     </div>
 
@@ -175,9 +177,11 @@ included in the summary." />
     </div>
 
     <div class="ref-description">
-    <p>Run <code><a href='https://mc-stan.org/posterior/reference/draws_summary.html'>summarise_draws()</a></code>
-from the <span class="pkg">posterior</span> package. For MCMC only post-warmup draws are
-included in the summary.</p>
+    <p>The <code>$summary()</code> method runs
+<code><a href='https://mc-stan.org/posterior/reference/draws_summary.html'>summarise_draws()</a></code> from the <span class="pkg">posterior</span>
+package. For MCMC only post-warmup draws are included in the summary.</p>
+<p>The <code>$print()</code> method prints the same summary but removes the extra
+formatting used for printing tibbles.</p>
     </div>
 
 
@@ -185,7 +189,8 @@ included in the summary.</p>
     <h2 class="hasAnchor" id="usage"><a class="anchor" href="#usage"></a>Usage</h2>
 
     
-<pre>$summary(...)
+<pre>$summary(variables = NULL, ...)
+$print(variables = NULL, ..., digits = 2, max_rows = 10)
 </pre>
 
     <h2 class="hasAnchor" id="arguments"><a class="anchor" href="#arguments"></a>Arguments</h2>
@@ -193,15 +198,22 @@ included in the summary.</p>
     
 
 <ul>
+<li><p><code>variables</code>: (character vector) The variables to include.</p></li>
 <li><p><code>...</code>: Optional arguments to pass to
 <code><a href='https://mc-stan.org/posterior/reference/draws_summary.html'>posterior::summarise_draws()</a></code>.</p></li>
+<li><p><code>digits</code>: (integer) For <code>print</code> only, the number of digits to use for
+rounding.</p></li>
+<li><p><code>max_rows</code>: (integer) For <code>print</code> only, the maximum number of rows to print.</p></li>
 </ul>
 
     <h2 class="hasAnchor" id="value"><a class="anchor" href="#value"></a>Value</h2>
 
     
 
-<p>See <code><a href='https://mc-stan.org/posterior/reference/draws_summary.html'>posterior::summarise_draws()</a></code>.</p>
+<p>The <code>$summary()</code> method returns the tibble created by
+<code><a href='https://mc-stan.org/posterior/reference/draws_summary.html'>posterior::summarise_draws()</a></code>.</p>
+<p>The <code>$print()</code> method returns the fitted model object itself (invisibly),
+which is the standard behavior for print methods in <span style="R">R</span>.</p>
     <h2 class="hasAnchor" id="see-also"><a class="anchor" href="#see-also"></a>See also</h2>
 
     <div class='dont-index'><p><code><a href='CmdStanMCMC.html'>CmdStanMCMC</a></code>, <code><a href='CmdStanMLE.html'>CmdStanMLE</a></code>, <code><a href='CmdStanVB.html'>CmdStanVB</a></code></p></div>
@@ -211,18 +223,38 @@ included in the summary.</p>
 <span class='no'>fit</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='cmdstanr_example.html'>cmdstanr_example</a></span>(<span class='st'>"logistic"</span>)</div><div class='output co'>#&gt; <span class='message'>Model executable is up to date!</span></div><div class='input'><span class='no'>fit</span>$<span class='fu'>summary</span>()</div><div class='output co'>#&gt; <span style='color: #949494;'># A tibble: 5 x 10</span><span>
 #&gt;   variable    mean  median    sd   mad       q5      q95  rhat ess_bulk ess_tail
 #&gt;   </span><span style='color: #949494;font-style: italic;'>&lt;chr&gt;</span><span>      </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>   </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>    </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>    </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>    </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>    </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>
-#&gt; </span><span style='color: #BCBCBC;'>1</span><span> lp__     -</span><span style='color: #BB0000;'>65.9</span><span>   -</span><span style='color: #BB0000;'>65.6</span><span>   1.41  1.23  -</span><span style='color: #BB0000;'>68.7</span><span>    -</span><span style='color: #BB0000;'>64.3</span><span>     1.00    </span><span style='text-decoration: underline;'>2</span><span>201.    </span><span style='text-decoration: underline;'>2</span><span>896.
-#&gt; </span><span style='color: #BCBCBC;'>2</span><span> alpha      0.378   0.377 0.215 0.212   0.025</span><span style='text-decoration: underline;'>7</span><span>   0.738   1.00    </span><span style='text-decoration: underline;'>4</span><span>068.    </span><span style='text-decoration: underline;'>2</span><span>995.
-#&gt; </span><span style='color: #BCBCBC;'>3</span><span> beta[1]   -</span><span style='color: #BB0000;'>0.664</span><span>  -</span><span style='color: #BB0000;'>0.662</span><span> 0.250 0.244  -</span><span style='color: #BB0000;'>1.09</span><span>    -</span><span style='color: #BB0000;'>0.265</span><span>   1.00    </span><span style='text-decoration: underline;'>4</span><span>421.    </span><span style='text-decoration: underline;'>3</span><span>013.
-#&gt; </span><span style='color: #BCBCBC;'>4</span><span> beta[2]   -</span><span style='color: #BB0000;'>0.276</span><span>  -</span><span style='color: #BB0000;'>0.274</span><span> 0.226 0.232  -</span><span style='color: #BB0000;'>0.653</span><span>    0.088</span><span style='text-decoration: underline;'>3</span><span>  1.00    </span><span style='text-decoration: underline;'>4</span><span>042.    </span><span style='text-decoration: underline;'>3</span><span>181.
-#&gt; </span><span style='color: #BCBCBC;'>5</span><span> beta[3]    0.688   0.681 0.266 0.263   0.253    1.14    1.00    </span><span style='text-decoration: underline;'>4</span><span>212.    </span><span style='text-decoration: underline;'>3</span><span>444.</div><div class='input'><span class='no'>fit</span>$<span class='fu'>summary</span>(<span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"mean"</span>, <span class='st'>"sd"</span>))</div><div class='output co'>#&gt; </span><span style='color: #949494;'># A tibble: 5 x 3</span><span>
+#&gt; </span><span style='color: #BCBCBC;'>1</span><span> lp__     -</span><span style='color: #BB0000;'>66.0</span><span>   -</span><span style='color: #BB0000;'>65.7</span><span>   1.43  1.28  -</span><span style='color: #BB0000;'>68.8</span><span>    -</span><span style='color: #BB0000;'>64.3</span><span>     1.00    </span><span style='text-decoration: underline;'>2</span><span>053.    </span><span style='text-decoration: underline;'>2</span><span>672.
+#&gt; </span><span style='color: #BCBCBC;'>2</span><span> alpha      0.380   0.373 0.222 0.220   0.018</span><span style='text-decoration: underline;'>4</span><span>   0.753   1.00    </span><span style='text-decoration: underline;'>4</span><span>413.    </span><span style='text-decoration: underline;'>3</span><span>074.
+#&gt; </span><span style='color: #BCBCBC;'>3</span><span> beta[1]   -</span><span style='color: #BB0000;'>0.674</span><span>  -</span><span style='color: #BB0000;'>0.666</span><span> 0.252 0.247  -</span><span style='color: #BB0000;'>1.10</span><span>    -</span><span style='color: #BB0000;'>0.274</span><span>   1.00    </span><span style='text-decoration: underline;'>3</span><span>950.    </span><span style='text-decoration: underline;'>2</span><span>963.
+#&gt; </span><span style='color: #BCBCBC;'>4</span><span> beta[2]   -</span><span style='color: #BB0000;'>0.272</span><span>  -</span><span style='color: #BB0000;'>0.273</span><span> 0.222 0.219  -</span><span style='color: #BB0000;'>0.637</span><span>    0.096</span><span style='text-decoration: underline;'>5</span><span>  1.00    </span><span style='text-decoration: underline;'>4</span><span>540.    </span><span style='text-decoration: underline;'>3</span><span>173.
+#&gt; </span><span style='color: #BCBCBC;'>5</span><span> beta[3]    0.685   0.680 0.267 0.259   0.256    1.14    1.00    </span><span style='text-decoration: underline;'>4</span><span>481.    </span><span style='text-decoration: underline;'>3</span><span>085.</div><div class='input'><span class='no'>fit</span>$<span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>()</div><div class='output co'>#&gt;  variable   mean median   sd  mad     q5    q95 rhat ess_bulk ess_tail
+#&gt;   lp__    -65.97 -65.67 1.43 1.28 -68.80 -64.28 1.00     2052     2671
+#&gt;   alpha     0.38   0.37 0.22 0.22   0.02   0.75 1.00     4412     3074
+#&gt;   beta[1]  -0.67  -0.67 0.25 0.25  -1.10  -0.27 1.00     3949     2963
+#&gt;   beta[2]  -0.27  -0.27 0.22 0.22  -0.64   0.10 1.00     4539     3173
+#&gt;   beta[3]   0.68   0.68 0.27 0.26   0.26   1.14 1.00     4481     3084</div><div class='input'><span class='no'>fit</span>$<span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>(<span class='kw'>max_rows</span> <span class='kw'>=</span> <span class='fl'>2</span>) <span class='co'># same as print(fit, max_rows = 2)</span></div><div class='output co'>#&gt;  variable   mean median   sd  mad     q5    q95 rhat ess_bulk ess_tail
+#&gt;     lp__  -65.97 -65.67 1.43 1.28 -68.80 -64.28 1.00     2052     2671
+#&gt;     alpha   0.38   0.37 0.22 0.22   0.02   0.75 1.00     4412     3074
+#&gt; 
+#&gt;  # showing 2 of 5 rows (change via 'max_rows' argument)</div><div class='input'>
+<span class='co'># include only certain variables</span>
+<span class='no'>fit</span>$<span class='fu'>summary</span>(<span class='st'>"beta"</span>)</div><div class='output co'>#&gt; </span><span style='color: #949494;'># A tibble: 3 x 10</span><span>
+#&gt;   variable   mean median    sd   mad     q5     q95  rhat ess_bulk ess_tail
+#&gt;   </span><span style='color: #949494;font-style: italic;'>&lt;chr&gt;</span><span>     </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>  </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>  </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>   </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>    </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>    </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>
+#&gt; </span><span style='color: #BCBCBC;'>1</span><span> beta[1]  -</span><span style='color: #BB0000;'>0.674</span><span> -</span><span style='color: #BB0000;'>0.666</span><span> 0.252 0.247 -</span><span style='color: #BB0000;'>1.10</span><span>  -</span><span style='color: #BB0000;'>0.274</span><span>   1.00    </span><span style='text-decoration: underline;'>3</span><span>950.    </span><span style='text-decoration: underline;'>2</span><span>963.
+#&gt; </span><span style='color: #BCBCBC;'>2</span><span> beta[2]  -</span><span style='color: #BB0000;'>0.272</span><span> -</span><span style='color: #BB0000;'>0.273</span><span> 0.222 0.219 -</span><span style='color: #BB0000;'>0.637</span><span>  0.096</span><span style='text-decoration: underline;'>5</span><span>  1.00    </span><span style='text-decoration: underline;'>4</span><span>540.    </span><span style='text-decoration: underline;'>3</span><span>173.
+#&gt; </span><span style='color: #BCBCBC;'>3</span><span> beta[3]   0.685  0.680 0.267 0.259  0.256  1.14    1.00    </span><span style='text-decoration: underline;'>4</span><span>481.    </span><span style='text-decoration: underline;'>3</span><span>085.</div><div class='input'><span class='no'>fit</span>$<span class='fu'><a href='https://rdrr.io/r/base/print.html'>print</a></span>(<span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"alpha"</span>, <span class='st'>"beta[2]"</span>))</div><div class='output co'>#&gt;  variable  mean median   sd  mad    q5  q95 rhat ess_bulk ess_tail
+#&gt;   alpha    0.38   0.37 0.22 0.22  0.02 0.75 1.00     4412     3074
+#&gt;   beta[2] -0.27  -0.27 0.22 0.22 -0.64 0.10 1.00     4539     3173</div><div class='input'>
+<span class='co'># include all variables but only certain summaries</span>
+<span class='no'>fit</span>$<span class='fu'>summary</span>(<span class='kw'>NULL</span>, <span class='fu'><a href='https://rdrr.io/r/base/c.html'>c</a></span>(<span class='st'>"mean"</span>, <span class='st'>"sd"</span>))</div><div class='output co'>#&gt; </span><span style='color: #949494;'># A tibble: 5 x 3</span><span>
 #&gt;   variable    mean    sd
 #&gt;   </span><span style='color: #949494;font-style: italic;'>&lt;chr&gt;</span><span>      </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span> </span><span style='color: #949494;font-style: italic;'>&lt;dbl&gt;</span><span>
-#&gt; </span><span style='color: #BCBCBC;'>1</span><span> lp__     -</span><span style='color: #BB0000;'>65.9</span><span>   1.41 
-#&gt; </span><span style='color: #BCBCBC;'>2</span><span> alpha      0.378 0.215
-#&gt; </span><span style='color: #BCBCBC;'>3</span><span> beta[1]   -</span><span style='color: #BB0000;'>0.664</span><span> 0.250
-#&gt; </span><span style='color: #BCBCBC;'>4</span><span> beta[2]   -</span><span style='color: #BB0000;'>0.276</span><span> 0.226
-#&gt; </span><span style='color: #BCBCBC;'>5</span><span> beta[3]    0.688 0.266</div><div class='input'># }
+#&gt; </span><span style='color: #BCBCBC;'>1</span><span> lp__     -</span><span style='color: #BB0000;'>66.0</span><span>   1.43 
+#&gt; </span><span style='color: #BCBCBC;'>2</span><span> alpha      0.380 0.222
+#&gt; </span><span style='color: #BCBCBC;'>3</span><span> beta[1]   -</span><span style='color: #BB0000;'>0.674</span><span> 0.252
+#&gt; </span><span style='color: #BCBCBC;'>4</span><span> beta[2]   -</span><span style='color: #BB0000;'>0.272</span><span> 0.222
+#&gt; </span><span style='color: #BCBCBC;'>5</span><span> beta[3]    0.685 0.267</div><div class='input'># }
 
 </div></span></pre>
   </div>

--- a/docs/reference/index.html
+++ b/docs/reference/index.html
@@ -79,7 +79,7 @@
       </button>
       <span class="navbar-brand">
         <a class="navbar-link" href="../index.html">cmdstanr</a>
-        <span class="version label label-danger" data-toggle="tooltip" data-placement="bottom" title="Unreleased version">0.0.0.9005</span>
+        <span class="version label label-danger" data-toggle="tooltip" data-placement="bottom" title="Unreleased version">0.0.0.9006</span>
       </span>
     </div>
 

--- a/man/fit-method-summary.Rd
+++ b/man/fit-method-summary.Rd
@@ -8,17 +8,24 @@
 Run \code{\link[posterior:draws_summary]{summarise_draws()}}
 from the \pkg{posterior} package. For MCMC only post-warmup draws are
 included in the summary.
+
+The \verb{$print()} method is a wrapper around the \verb{$summary()} method that
+removes the extra formatting used for printing tibbles.
 }
 \section{Usage}{
-\preformatted{$summary(...)
+\preformatted{$summary(variables = NULL, ...)
+$print(variables = NULL, ..., digits = 2)
 }
 }
 
 \section{Arguments}{
 
 \itemize{
+\item \code{variables}: (character vector) The variables to include.
 \item \code{...}: Optional arguments to pass to
 \code{\link[posterior:draws_summary]{posterior::summarise_draws()}}.
+\item \code{digits}: (integer) For \code{print} only, the number of digits to use for
+rounding.
 }
 }
 
@@ -31,7 +38,14 @@ See \code{\link[posterior:draws_summary]{posterior::summarise_draws()}}.
 \dontrun{
 fit <- cmdstanr_example("logistic")
 fit$summary()
-fit$summary(c("mean", "sd"))
+fit$print()
+
+# include only certain variables
+fit$summary("beta")
+fit$print(c("alpha", "beta[2]"))
+
+# include all variables but only certain summaries
+fit$summary(NULL, c("mean", "sd"))
 }
 
 }

--- a/man/fit-method-summary.Rd
+++ b/man/fit-method-summary.Rd
@@ -3,18 +3,21 @@
 \name{fit-method-summary}
 \alias{fit-method-summary}
 \alias{summary}
+\alias{print.CmdStanMCMC}
+\alias{print.CmdStanMLE}
+\alias{print.CmdStanVB}
 \title{Compute a summary table of MCMC estimates and diagnostics}
 \description{
-Run \code{\link[posterior:draws_summary]{summarise_draws()}}
-from the \pkg{posterior} package. For MCMC only post-warmup draws are
-included in the summary.
+The \verb{$summary()} method runs
+\code{\link[posterior:draws_summary]{summarise_draws()}} from the \pkg{posterior}
+package. For MCMC only post-warmup draws are included in the summary.
 
-The \verb{$print()} method is a wrapper around the \verb{$summary()} method that
-removes the extra formatting used for printing tibbles.
+The \verb{$print()} method prints the same summary but removes the extra
+formatting used for printing tibbles.
 }
 \section{Usage}{
 \preformatted{$summary(variables = NULL, ...)
-$print(variables = NULL, ..., digits = 2)
+$print(variables = NULL, ..., digits = 2, max_rows = 10)
 }
 }
 
@@ -26,12 +29,17 @@ $print(variables = NULL, ..., digits = 2)
 \code{\link[posterior:draws_summary]{posterior::summarise_draws()}}.
 \item \code{digits}: (integer) For \code{print} only, the number of digits to use for
 rounding.
+\item \code{max_rows}: (integer) For \code{print} only, the maximum number of rows to print.
 }
 }
 
 \section{Value}{
 
-See \code{\link[posterior:draws_summary]{posterior::summarise_draws()}}.
+The \verb{$summary()} method returns the tibble created by
+\code{\link[posterior:draws_summary]{posterior::summarise_draws()}}.
+
+The \verb{$print()} method returns the fitted model object itself (invisibly),
+which is the standard behavior for print methods in \R.
 }
 
 \examples{
@@ -39,6 +47,7 @@ See \code{\link[posterior:draws_summary]{posterior::summarise_draws()}}.
 fit <- cmdstanr_example("logistic")
 fit$summary()
 fit$print()
+fit$print(max_rows = 2) # same as print(fit, max_rows = 2)
 
 # include only certain variables
 fit$summary("beta")

--- a/tests/testthat/test-failed-chains.R
+++ b/tests/testthat/test-failed-chains.R
@@ -140,7 +140,7 @@ test_that("init warnings are shown", {
   suppressWarnings(
     expect_message(
       utils::capture.output(
-        mod_init_warnings$sample(chains = 1)
+        fit <- mod_init_warnings$sample(chains = 1)
       ),
       "Rejecting initial value"
     )

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -74,17 +74,9 @@ test_that("summary() method works after mcmc", {
 
 test_that("print() method works after mcmc", {
   skip_on_cran()
-  x <- fit_mcmc$print()
-  expect_s3_class(x, "data.frame")
-  expect_equal(rownames(x), c("lp__", PARAM_NAMES))
-
-  x <- fit_mcmc$print(NULL, c("rhat", "sd"))
-  expect_equal(rownames(x), c("lp__", PARAM_NAMES))
-  expect_equal(colnames(x), c("rhat", "sd"))
-
-  x <- fit_mcmc$print("lp__", c("median", "mad"))
-  expect_equal(rownames(x), "lp__")
-  expect_equal(colnames(x), c("median", "mad"))
+  expect_output(expect_s3_class(fit_mcmc$print(), "CmdStanMCMC"), "variable")
+  expect_output(fit_mcmc$print(max_rows = 1), "# showing 1 of 5 rows")
+  expect_output(fit_mcmc$print(NULL, c("ess_sd")), "ess_sd")
 })
 
 

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -64,9 +64,29 @@ test_that("summary() method works after mcmc", {
   expect_s3_class(x, "draws_summary")
   expect_equal(x$variable, c("lp__", PARAM_NAMES))
 
-  x <- fit_mcmc$summary(c("rhat", "sd"))
+  x <- fit_mcmc$summary(NULL, c("rhat", "sd"))
   expect_equal(colnames(x), c("variable", "rhat", "sd"))
+
+  x <- fit_mcmc$summary("lp__", c("median", "mad"))
+  expect_equal(x$variable, "lp__")
+  expect_equal(colnames(x), c("variable", "median", "mad"))
 })
+
+test_that("print() method works after mcmc", {
+  skip_on_cran()
+  x <- fit_mcmc$print()
+  expect_s3_class(x, "data.frame")
+  expect_equal(rownames(x), c("lp__", PARAM_NAMES))
+
+  x <- fit_mcmc$print(NULL, c("rhat", "sd"))
+  expect_equal(rownames(x), c("lp__", PARAM_NAMES))
+  expect_equal(colnames(x), c("rhat", "sd"))
+
+  x <- fit_mcmc$print("lp__", c("median", "mad"))
+  expect_equal(rownames(x), "lp__")
+  expect_equal(colnames(x), c("median", "mad"))
+})
+
 
 test_that("output() method works after mcmc", {
   skip_on_cran()

--- a/tests/testthat/test-fit-mle.R
+++ b/tests/testthat/test-fit-mle.R
@@ -14,9 +14,24 @@ test_that("mle and lp methods work after optimization", {
 
 test_that("summary method doesn't error for optimization", {
   skip_on_cran()
-  # summary method for optimization isn't fully designed yet
   x <- fit_mle$summary()
   expect_s3_class(x, "draws_summary")
   expect_equal(colnames(x), c("variable", "estimate"))
   expect_equal(x$variable, c("lp__", PARAM_NAMES))
+
+  x <- fit_mle$summary("lp__")
+  expect_equal(colnames(x), c("variable", "estimate"))
+  expect_equal(x$variable, "lp__")
+})
+
+test_that("print method works error for optimization", {
+  skip_on_cran()
+  x <- fit_mle$print()
+  expect_s3_class(x, "data.frame")
+  expect_equal(colnames(x), "estimate")
+  expect_equal(rownames(x), c("lp__", PARAM_NAMES))
+
+  x <- fit_mle$print("lp__")
+  expect_equal(colnames(x), c("estimate"))
+  expect_equal(rownames(x), "lp__")
 })

--- a/tests/testthat/test-fit-mle.R
+++ b/tests/testthat/test-fit-mle.R
@@ -12,7 +12,7 @@ test_that("mle and lp methods work after optimization", {
   checkmate::expect_numeric(fit_mle$lp(), len = 1)
 })
 
-test_that("summary method doesn't error for optimization", {
+test_that("summary method works after optimization", {
   skip_on_cran()
   x <- fit_mle$summary()
   expect_s3_class(x, "draws_summary")
@@ -24,14 +24,8 @@ test_that("summary method doesn't error for optimization", {
   expect_equal(x$variable, "lp__")
 })
 
-test_that("print method works error for optimization", {
+test_that("print() method works after optimization", {
   skip_on_cran()
-  x <- fit_mle$print()
-  expect_s3_class(x, "data.frame")
-  expect_equal(colnames(x), "estimate")
-  expect_equal(rownames(x), c("lp__", PARAM_NAMES))
-
-  x <- fit_mle$print("lp__")
-  expect_equal(colnames(x), c("estimate"))
-  expect_equal(rownames(x), "lp__")
+  expect_output(expect_s3_class(fit_mle$print(), "CmdStanMLE"), "estimate")
+  expect_output(fit_mle$print(max_rows = 1), "# showing 1 of 5 rows")
 })

--- a/tests/testthat/test-fit-vb.R
+++ b/tests/testthat/test-fit-vb.R
@@ -13,10 +13,21 @@ test_that("summary() method works after vb", {
   expect_s3_class(x, "draws_summary")
   expect_equal(x$variable, c("lp__", "lp_approx__", PARAM_NAMES))
 
-  x <- fit_vb$summary(c("mean", "sd"))
+  x <- fit_vb$summary(variables = NULL, c("mean", "sd"))
   expect_s3_class(x, "draws_summary")
   expect_equal(x$variable, c("lp__", "lp_approx__", PARAM_NAMES))
   expect_equal(colnames(x), c("variable", "mean", "sd"))
+})
+
+test_that("print() method works after vb", {
+  skip_on_cran()
+  x <- fit_vb$print()
+  expect_s3_class(x, "data.frame")
+  expect_equal(rownames(x), c("lp__", "lp_approx__", PARAM_NAMES))
+
+  x <- fit_vb$print(c("lp__", "lp_approx__"), c("mean", "sd"))
+  expect_equal(rownames(x), c("lp__", "lp_approx__"))
+  expect_equal(colnames(x), c("mean", "sd"))
 })
 
 test_that("draws() method returns posterior sample (reading csv works)", {
@@ -43,7 +54,7 @@ test_that("vb works with scientific notation args", {
   expect_s3_class(x, "draws_summary")
   expect_equal(x$variable, c("lp__", "lp_approx__", PARAM_NAMES))
 
-  x <- fit_vb_sci_not$summary(c("mean", "sd"))
+  x <- fit_vb_sci_not$summary(variables = NULL, c("mean", "sd"))
   expect_s3_class(x, "draws_summary")
   expect_equal(x$variable, c("lp__", "lp_approx__", PARAM_NAMES))
   expect_equal(colnames(x), c("variable", "mean", "sd"))

--- a/tests/testthat/test-fit-vb.R
+++ b/tests/testthat/test-fit-vb.R
@@ -21,13 +21,8 @@ test_that("summary() method works after vb", {
 
 test_that("print() method works after vb", {
   skip_on_cran()
-  x <- fit_vb$print()
-  expect_s3_class(x, "data.frame")
-  expect_equal(rownames(x), c("lp__", "lp_approx__", PARAM_NAMES))
-
-  x <- fit_vb$print(c("lp__", "lp_approx__"), c("mean", "sd"))
-  expect_equal(rownames(x), c("lp__", "lp_approx__"))
-  expect_equal(colnames(x), c("mean", "sd"))
+  expect_output(expect_s3_class(fit_vb$print(), "CmdStanVB"), "variable")
+  expect_output(fit_vb$print(max_rows = 1), "# showing 1 of 6 rows")
 })
 
 test_that("draws() method returns posterior sample (reading csv works)", {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Closes #27 

* Implements a `$print()` method for fitted model objects. Based on a suggestion from Andrew (who doesn't like the way tibbles are printed), the print method is the same as `$summary()` but drops all the weird tibble formatting.

* In the process I also added a `variables` argument to `$summary()` 

To see the difference between print and summary do: 

```r
fit <- cmdstanr_example("logistic")
fit$summary(variables = "beta") # prints with tibble formatting
fit$print(variables = "beta") # prints with regular formatting
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
