### PR TITLE
Respect variables order

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -578,6 +578,11 @@ CmdStanMCMC <- R6::R6Class(
       if (!length(self$output_files(include_failed = FALSE))) {
         stop("No chains finished successfully. Unable to retrieve the draws.")
       }
+      if (inc_warmup && !private$sampling_info_$save_warmup) {
+        stop("Warmup draws were requested from a fit object without them! ",
+             "Please rerun the model with save_warmup = TRUE.", call. = FALSE)
+      }
+
       to_read <- remaining_columns_to_read(
         requested = variables,
         currently_read = dimnames(private$draws_)$variable,
@@ -597,10 +602,6 @@ CmdStanMCMC <- R6::R6Class(
       }
       variables <- repair_variable_names(matching_res$matching)
       if (inc_warmup) {
-        if (!private$sampling_info_$save_warmup) {
-          stop("Warmup draws were requested from a fit object without them! ",
-               "Please rerun the model with save_warmup = TRUE.")
-        }
         posterior::bind_draws(private$warmup_draws_, private$draws_, along="iteration")[,,variables]
       } else {
         private$draws_[,,variables]

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -504,8 +504,12 @@ remaining_columns_to_read <- function(requested, currently_read, all) {
     all_remaining <- all[!(all %in% currently_read)]
     unread <- c()
     for (p in requested) {
-      if (any(all_remaining == p) || any(startsWith(all_remaining, paste0(p,".")))) {
+      if (any(all_remaining == p)) {
         unread <- c(unread, p)
+      }
+      is_unread_element <- startsWith(all_remaining, paste0(p,"["))
+      if (any(is_unread_element)) {
+        unread <- c(unread, all_remaining[is_unread_element])
       }
     }
   }

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -514,7 +514,7 @@ remaining_columns_to_read <- function(requested, currently_read, all) {
     }
   }
   if (length(unread)) {
-    unread
+    unique(unread)
   } else {
     ""
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -383,16 +383,17 @@ matching_variables <- function(variable_filters, variables) {
   not_found <- NULL
   variable_filters <- unrepair_variable_names(variable_filters)
   variables <- unrepair_variable_names(variables)
-  selected <- rep(FALSE, length(variables))
+  selected <- c()
   for (p in variable_filters) {
-      matches <- variables == p | startsWith(variables, paste0(p, "."))
-      if (!any(matches)) {
-        not_found <- c(not_found, p)
-      }
-      selected <- selected | matches
+    matches <- which(variables == p | startsWith(variables, paste0(p, ".")))
+    if (length(matches)) {
+      selected <- c(selected, matches)
+    } else {
+      not_found <- c(not_found, p)
+    }
   }
   list(
-    matching = variables[selected],
+    matching = variables[unique(selected)],
     not_found = not_found
   )
 }

--- a/tests/testthat/test-csv.R
+++ b/tests/testthat/test-csv.R
@@ -309,6 +309,13 @@ test_that("read_sample_csv() works with filtered variables", {
                fixed = TRUE)
 })
 
+test_that("read_sample_csv returned filtered variables in correct order", {
+  csv_output_1 <- read_sample_csv(fit_logistic_thin_1$output_files(), variables = c("lp__", "beta[1]"), sampler_diagnostics = "")
+  expect_equal(posterior::variables(csv_output_1$post_warmup_draws), c("lp__", "beta[1]"))
+  csv_output_2 <- read_sample_csv(fit_logistic_thin_1$output_files(), variables = c("beta[1]", "lp__"), sampler_diagnostics = "")
+  expect_equal(posterior::variables(csv_output_2$post_warmup_draws), c("beta[1]", "lp__"))
+})
+
 test_that("read_sample_csv() works with no samples", {
   skip_on_cran()
 
@@ -340,6 +347,19 @@ test_that("remaining_columns_to_read() works", {
   expect_equal(remaining_columns_to_read(NULL, NULL, c("a", "b", "c")), c("a", "b", "c"))
   expect_equal(remaining_columns_to_read(c("a", "b", "c"), c("a", "b", "c"), NULL), "")
   expect_equal(remaining_columns_to_read(c("a", "b", "c"), NULL, c("a", "b", "c")), c("a", "b", "c"))
+
+  # with vector and matrix variables
+  b_vec <- paste0("b[", 1:4, "]")
+  c_mat <- paste0("c[", c(1,2,1,2), ",", c(1,1,2,2), "]")
+  all_vars <- c("a", b_vec, c_mat)
+  expect_equal(
+    remaining_columns_to_read(c("a", "b[2]"), c("a", c_mat), all_vars),
+    "b[2]"
+  )
+  expect_equal(
+    remaining_columns_to_read(c("a", "b", "c"), c(paste0("b[", c(1,4), "]"), "c[1,2]"), all_vars),
+    c("a", "b[2]", "b[3]", "c[1,1]", "c[2,1]", "c[2,2]")
+  )
 })
 
 test_that("read_sample_csv() reads adaptation step size correctly", {

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -38,6 +38,7 @@ test_that("draws() method returns draws_array (reading csv works)", {
   draws_betas <- fit_mcmc$draws(variables = "beta")
   draws_beta <- fit_mcmc$draws(variables = "beta[1]")
   draws_alpha_beta <- fit_mcmc$draws(variables = c("alpha", "beta"))
+  draws_beta_alpha <- fit_mcmc$draws(variables = c("beta", "alpha"))
   draws_all_after <- fit_mcmc$draws()
   expect_type(draws, "double")
   expect_s3_class(draws, "draws_array")
@@ -55,6 +56,10 @@ test_that("draws() method returns draws_array (reading csv works)", {
   expect_s3_class(draws_all_after, "draws_array")
   expect_equal(posterior::nvariables(draws_all_after), 5)
   expect_equal(posterior::nchains(draws_all_after), fit_mcmc$num_chains())
+
+  # check the order of the draws
+  expect_equal(posterior::variables(draws_alpha_beta), c("alpha", "beta[1]", "beta[2]", "beta[3]"))
+  expect_equal(posterior::variables(draws_beta_alpha), c("beta[1]", "beta[2]", "beta[3]", "alpha"))
 })
 
 test_that("inv_metric method works after mcmc", {

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -11,7 +11,7 @@ if (not_on_cran()) {
                             seed = 123, chains = 2,
                             refresh = 0, save_warmup = TRUE)
   fit_mcmc_2 <- testing_fit("logistic", method = "sample",
-                            seed = 123, chains = 1,
+                            seed = 1234, chains = 1,
                             iter_sampling = 100000,
                             refresh = 0, metric = "dense_e")
   PARAM_NAMES <- c("alpha", "beta[1]", "beta[2]", "beta[3]")


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

fixes #211 

Fixes `matching_variables` and `remaining_columns_to_read` so that variables are returned in the correct order. @rok-cesnovar I made some comments below to explain why I made the changes I did. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
