### PR TITLE
Bugfix/213 session crash with very large number of parameters in the CSV file

### DIFF
--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -155,24 +155,26 @@ read_sample_csv <- function(files,
       col_select <- c(col_select, variables[variables!="lp__"])
       col_select <- c(col_select, sampler_diagnostics)
     }
-    suppressWarnings(
+    num_warmup_draws <- ceiling(sampling_info$iter_warmup/sampling_info$thin)
+    num_post_warmup_draws <- ceiling(sampling_info$iter_sampling/sampling_info$thin)
+    all_draws <- num_warmup_draws + num_post_warmup_draws
+    suppressWarnings(      
       draws <- vroom::vroom(output_file,
-                            comment = "# ",
-                            delim = ',',
-                            trim_ws = TRUE,
-                            col_select = col_select,
-                            col_types = c("lp__" = "d"),
-                            altrep = FALSE,
-                            progress = FALSE)
+                  comment = "#",
+                  delim = ',',
+                  trim_ws = TRUE,
+                  col_select = col_select,
+                  col_types = c("lp__" = "d"),
+                  altrep = FALSE,
+                  progress = FALSE,
+                  skip = sampling_info$lines_to_skip,
+                  n_max = all_draws*2)
     )
     if (ncol(draws) == 0) {
       stop("The supplied csv file does not contain any sampling data!")
     }
     draws <- draws[!is.na(draws$lp__), ]
     if (nrow(draws) > 0) {
-      num_warmup_draws <- ceiling(sampling_info$iter_warmup/sampling_info$thin)
-      num_post_warmup_draws <- ceiling(sampling_info$iter_sampling/sampling_info$thin)
-      all_draws <- num_warmup_draws + num_post_warmup_draws
       if (sampling_info$save_warmup == 1) {
         if (length(variables) > 0) {
           new_warmup_draws <- posterior::as_draws_array(draws[1:num_warmup_draws, variables])
@@ -321,6 +323,7 @@ read_sample_info_csv <- function(csv_file) {
   csv_file_info[["inv_metric"]] <- NULL
   inv_metric_rows <- 0
   parsing_done <- FALSE
+  lines_before_param_names <- 0
   while (length(line <- readLines(con, n = 1, warn = FALSE)) > 0 && !parsing_done) {
     if (!startsWith(line, "#")) {
       if (!param_names_read) {
@@ -343,6 +346,9 @@ read_sample_info_csv <- function(csv_file) {
         }
       }
     } else {
+      if (!param_names_read) {
+        lines_before_param_names <- lines_before_param_names + 1
+      }
       if (!adaptation_terminated) {
         if (regexpr("# Adaptation terminated", line, perl = TRUE) > 0) {
           adaptation_terminated <- TRUE
@@ -431,6 +437,7 @@ read_sample_info_csv <- function(csv_file) {
   csv_file_info$diagnostic_file <- NULL
   csv_file_info$metric_file <- NULL
   csv_file_info$num_threads <- NULL
+  csv_file_info$lines_to_skip <- lines_before_param_names
 
   csv_file_info
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #213 by adding two additional suggestions to the vroom functions: 
- the number of lines to skip from the start of the file. This was the main issue for the bug. Vroom gets confused with multiple comments sections (before param, after warmup, and at the end). As we already read these lines we know the exact number of them so we can just skip them
- the ballpark number of the total lines. This does not have to be exact, just narrowing the options a bit. I put 2x(number of warmup+sampling) and it works fine. There is no speed gain if we narrow it further.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
