### PR TITLE
print() method: only compute stats for rows that will be printed

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -108,6 +108,8 @@ CmdStanFit <- R6::R6Class(
         out[[col]] <- as.integer(out[[col]])
       }
 
+      opts <- options(max.print = prod(dim(out)))
+      on.exit(options(max.print = opts$max.print), add = TRUE)
       print(out, row.names=FALSE)
       if (max_rows < total_rows) {
         cat("\n # showing", max_rows, "of", total_rows,

--- a/R/fit.R
+++ b/R/fit.R
@@ -71,13 +71,37 @@ CmdStanFit <- R6::R6Class(
       summary
     },
 
+    # print summary table without using tibbles
     print = function(variables = NULL, ..., digits = 2, max_rows = 10) {
-      # print summary table without using tibbles
-      out <- self$summary(variables, ...)
+      # FIXME: treat sample and other methods the same once we have
+      # self$metadata() (or equivalent) for all methods
+      if (self$runset$method() == "sample") {
+        all_variables <- self$sampling_info()$model_params
+      } else {
+        all_variables <- posterior::variables(self$draws())
+      }
+
+      # filter variables before passing to summary to avoid computing anything
+      # that won't be printed because of max_rows
+      if (is.null(variables)) {
+        total_rows <- length(all_variables)
+        variables_to_print <- all_variables[seq_len(max_rows)]
+      } else {
+        matches <- matching_variables(variables, all_variables)
+        if (length(matches$not_found) > 0) {
+          stop("Can't find the following variable(s): ",
+               paste(matches$not_found, collapse = ", "))
+        }
+        total_rows <- length(matches$matching)
+        variables_to_print <- matches$matching[seq_len(max_rows)]
+        variables_to_print <- repair_variable_names(variables_to_print)
+      }
+
+      # if max_rows > length(variables_to_print) some will be NA
+      variables_to_print <- variables_to_print[!is.na(variables_to_print)]
+
+      out <- self$summary(variables_to_print, ...)
       out <- as.data.frame(out)
-      rows <- nrow(out)
-      print_rows <- seq_len(min(rows, max_rows))
-      out <- out[print_rows, ]
       out[, 1] <- format(out[, 1], justify = "left")
       out[, -1] <- format(round(out[, -1], digits = digits), nsmall = digits)
       for (col in grep("ess_", colnames(out), value = TRUE)) {
@@ -85,8 +109,9 @@ CmdStanFit <- R6::R6Class(
       }
 
       print(out, row.names=FALSE)
-      if (max_rows < rows) {
-        cat("\n # showing", max_rows, "of", rows, "rows (change via 'max_rows' argument)")
+      if (max_rows < total_rows) {
+        cat("\n # showing", max_rows, "of", total_rows,
+            "rows (change via 'max_rows' argument)")
       }
       invisible(self)
     },

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -101,8 +101,30 @@ test_that("print() method works after mcmc", {
   expect_output(expect_s3_class(fit_mcmc$print(), "CmdStanMCMC"), "variable")
   expect_output(fit_mcmc$print(max_rows = 1), "# showing 1 of 5 rows")
   expect_output(fit_mcmc$print(NULL, c("ess_sd")), "ess_sd")
-})
 
+  # test on model with more parameters
+  fit <- cmdstanr_example("schools_ncp")
+  expect_output(fit$print(), "showing 10 of 19 rows")
+  expect_output(fit$print(max_rows = 2), "showing 2 of 19 rows")
+  expect_output(fit$print(max_rows = 19), "theta[8]", fixed=TRUE) # last parameter
+  expect_output(fit$print("theta", max_rows = 2), "showing 2 of 8 rows")
+
+  out <- capture.output(fit$print("theta"))
+  expect_length(out, 9) # columns names + 8 thetas
+  expect_match(out[1], "variable")
+  expect_match(out[2], "theta[1]", fixed = TRUE)
+  expect_match(out[9], "theta[8]", fixed = TRUE)
+  expect_false(any(grepl("mu|tau|theta_raw", out)))
+
+  # make sure the row order is correct
+  out <- capture.output(fit$print(c("theta[1]", "tau", "mu", "theta_raw[3]")))
+  expect_length(out, 5)
+  expect_match(out[1], " variable", out[1])
+  expect_match(out[2], " theta[1]", fixed = TRUE)
+  expect_match(out[3], " tau")
+  expect_match(out[4], " mu")
+  expect_match(out[5], " theta_raw[3]", fixed = TRUE)
+})
 
 test_that("output() method works after mcmc", {
   skip_on_cran()

--- a/tests/testthat/test-fit-vb.R
+++ b/tests/testthat/test-fit-vb.R
@@ -25,6 +25,22 @@ test_that("print() method works after vb", {
   skip_on_cran()
   expect_output(expect_s3_class(fit_vb$print(), "CmdStanVB"), "variable")
   expect_output(fit_vb$print(max_rows = 1), "# showing 1 of 6 rows")
+
+  # test on model with more parameters
+  fit <- cmdstanr_example("schools_ncp", method = "variational", seed = 123)
+  expect_output(fit$print(), "lp_approx__")
+  expect_output(fit$print(), "showing 10 of 20 rows")
+  expect_output(fit$print(max_rows = 20), "theta[8]", fixed = TRUE) # last parameter
+
+  out <- capture.output(fit$print(c("theta", "tau", "lp__", "lp_approx__")))
+  expect_length(out, 13) # columns names + 8 thetas + tau + lp__ + lp_approx__ + empty + message
+  expect_match(out[1], " variable")
+  expect_match(out[2], " theta[1]", fixed = TRUE)
+  expect_match(out[9], " theta[8]", fixed = TRUE)
+  expect_match(out[10], " tau")
+  expect_match(out[11], " lp__")
+  expect_false(nzchar(out[12])) # empty line
+  expect_match(out[13], "10 of 11 rows")
 })
 
 test_that("draws() method returns posterior sample (reading csv works)", {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #220 

Figures out which rows of the printed data frame will end up being displayed (due to `max_rows` argument) and only computes summary stats for those rows.

#### To verify

Run this same code using the master branch and then using the `only-compute-printed-rows` branch:

```r
tmp_prog <- tempfile(fileext=".stan")
cat("
parameters {
vector[1000] x;
}
model {
x ~ std_normal();
}
", file = tmp_prog)
mod <- cmdstan_model(tmp_prog)
fit <- mod$sample()

# will be very slow on master and fast on PR branch
fit$print()
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
