### PR TITLE
Use the hyphened --include-paths stancflag for 2.24+

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -71,7 +71,7 @@ jobs:
           remotes::install_cran("rcmdcheck")
           install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
           install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
-          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.24.0-rc1/cmdstan-2.24.0-rc1.tar.gz")
+          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.24.0/cmdstan-2.24.0.tar.gz")
         shell: Rscript {0}
 
       - name: Session info

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,14 +19,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel'}
+          # - {os: macOS-latest,   r: 'devel'}
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
           # - {os: windows-latest,   r: 'oldrel'}
           - {os: ubuntu-16.04,   r: 'release'}
           - {os: ubuntu-16.04,   r: 'oldrel'}
-          #- {os: ubuntu-16.04,   r: '3.5'}
+          # - {os: ubuntu-16.04,   r: '3.5'}
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
@@ -71,7 +71,7 @@ jobs:
           remotes::install_cran("rcmdcheck")
           install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
           install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
-          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.23.0/cmdstan-2.23.0.tar.gz")
+          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.24.0-rc1/cmdstan-2.24.0-rc1.tar.gz")
         shell: Rscript {0}
 
       - name: Session info

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages(c("posterior", "cmdstanr", "remotes"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.24.0-rc1/cmdstan-2.24.0-rc1.tar.gz")
+          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.24.0/cmdstan-2.24.0.tar.gz")
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")
         shell: Rscript {0}

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -39,7 +39,7 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages(c("posterior", "cmdstanr", "remotes"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")))
-          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.23.0/cmdstan-2.23.0.tar.gz")
+          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.24.0-rc1/cmdstan-2.24.0-rc1.tar.gz")
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")
         shell: Rscript {0}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cmdstanr
 Title: R Interface to 'CmdStan'
-Version: 0.0.0.9009
-Date: 2020-07-24
+Version: 0.0.0.9010
+Date: 2020-07-28
 Authors@R: 
     c(person(given = "Jonah", family = "Gabry", role = c("aut", "cre"),
            email = "jsg2201@columbia.edu"),

--- a/R/install.R
+++ b/R/install.R
@@ -4,9 +4,9 @@
 #'   install the latest release of
 #'   [CmdStan](https://github.com/stan-dev/cmdstan/releases/latest) or a
 #'   development version from a repository. Currently the necessary C++ tool
-#'   chain is assumed to be available (see Appendix B of the CmdStan
-#'   [guide](https://github.com/stan-dev/cmdstan/releases/latest)), but in the
-#'   future CmdStanR may help install the requirements.
+#'   chain is assumed to be available (see the the CmdStan
+#'   [installation guide](https://mc-stan.org/docs/2_24/cmdstan-guide/cmdstan-installation.html)),
+#'   but in the future CmdStanR may help install the requirements.
 #'
 #'   The `rebuild_cmdstan()` function cleans and rebuilds the cmdstan
 #'   installation. Use this function in case of any issues when compiling

--- a/R/model.R
+++ b/R/model.R
@@ -454,7 +454,9 @@ compile_method <- function(quiet = TRUE,
     }
   }
   stancflags_val <- paste0("STANCFLAGS += ", stancflags_val, paste0(stanc_built_options, collapse = " "))
-  prepare_precompiled(cpp_options, quiet)
+  if (cmdstan_version() < "2.24") {
+    prepare_precompiled(cpp_options, quiet)
+  }
   run_log <- processx::run(
     command = make_cmd(),
     args = c(tmp_exe,

--- a/R/model.R
+++ b/R/model.R
@@ -428,8 +428,14 @@ compile_method <- function(quiet = TRUE,
     checkmate::assert_directory_exists(include_paths, access = "r")
     include_paths <- absolute_path(include_paths)
     include_paths <- paste0(include_paths, collapse = ",")
-    stancflags_val <- paste0(stancflags_val, " --include_paths=", include_paths, " ")
+    if (cmdstan_version() >= "2.24") {
+      include_paths_flag <- " --include-paths="
+    } else {
+      include_paths_flag <- " --include_paths="
+    }
+    stancflags_val <- paste0(stancflags_val, include_paths_flag, include_paths, " ")
   }
+
   if (!is.null(cpp_options$stan_opencl)) {
     stanc_options[["use-opencl"]] <- TRUE
   }

--- a/R/path.R
+++ b/R/path.R
@@ -111,8 +111,6 @@ cmdstan_default_path <- function() {
   installs_path <- file.path(Sys.getenv("HOME"), ".cmdstanr")
   if (dir.exists(installs_path)) {
     cmdstan_installs <- list.dirs(path = installs_path, recursive = FALSE, full.names = FALSE)
-    is_rc <- sapply(cmdstan_installs, is_release_candidate)
-    cmdstan_installs <- cmdstan_installs[!is_rc]
     # if installed in folder cmdstan, with no version
     # move to cmdstan-version folder
     if ("cmdstan" %in% cmdstan_installs) {
@@ -123,7 +121,14 @@ cmdstan_default_path <- function() {
       cmdstan_installs <- list.dirs(path = installs_path, recursive = FALSE, full.names = FALSE)
     }
     if (length(cmdstan_installs) > 0) {
-      return(file.path(installs_path,sort(cmdstan_installs, decreasing = TRUE)[1]))
+      latest_cmdstan <- sort(cmdstan_installs, decreasing = TRUE)[1]
+      if (is_release_candidate(latest_cmdstan)) {
+        non_rc_path <- strsplit(latest_cmdstan, "-rc")[[1]][1]
+        if (dir.exists(file.path(installs_path,latest_cmdstan))) {
+          latest_cmdstan <- non_rc_path
+        }
+      }
+      return(file.path(installs_path,latest_cmdstan))
     }
   }
   return(NULL)

--- a/R/path.R
+++ b/R/path.R
@@ -124,7 +124,7 @@ cmdstan_default_path <- function() {
       latest_cmdstan <- sort(cmdstan_installs, decreasing = TRUE)[1]
       if (is_release_candidate(latest_cmdstan)) {
         non_rc_path <- strsplit(latest_cmdstan, "-rc")[[1]][1]
-        if (dir.exists(file.path(installs_path,latest_cmdstan))) {
+        if (dir.exists(file.path(installs_path,non_rc_path))) {
           latest_cmdstan <- non_rc_path
         }
       }

--- a/tests/testthat/helper-envvars-and-paths.R
+++ b/tests/testthat/helper-envvars-and-paths.R
@@ -15,7 +15,7 @@ not_on_cran <- function() {
 }
 
 test_release_url <- function() {
-  "https://github.com/stan-dev/cmdstan/releases/download/v2.23.0/cmdstan-2.23.0.tar.gz"
+  "https://github.com/stan-dev/cmdstan/releases/download/v2.24.0/cmdstan-2.24.0.tar.gz"
 }
 
 delete_extensions <- function() {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -167,34 +167,6 @@ test_that("switching threads on and off works without rebuild", {
   expect_equal(before_mtime, after_mtime)
 })
 
-test_that("message is shown on building main.o", {
-  skip_on_cran()
-  if (cmdstan_version() > "2.23") {
-    expect_message(
-      mod$compile(force_recompile = TRUE),
-      "Compiling Stan program...",
-      fixed = TRUE
-    )
-    return(invisible(NULL))
-  } else {
-    main_o_files <- c(
-      file.path(cmdstan_path(), "src", "cmdstan", "main.o"),
-      file.path(cmdstan_path(), "src", "cmdstan", "main_noflags.o")
-    )
-    for (f in main_o_files) {
-      if (file.exists(f))
-        file.remove(f)
-    }
-    expect_message(
-      mod$compile(force_recompile = TRUE),
-      "Compiling the main object file and precompiled headers (may take up to a few minutes). ",
-      "This is only necessary for the first compilation after installation or when ",
-      "threading, MPI or OpenCL are used for the first time.",
-      fixed = TRUE
-    )
-  }
-})
-
 test_that("compile errors are shown", {
   skip_on_cran()
   stan_file <- testing_stan_file("fail")

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -141,18 +141,20 @@ test_that("name in STANCFLAGS is set correctly", {
 test_that("switching threads on and off works without rebuild", {
   skip_on_cran()
   main_path_o <- file.path(cmdstan_path(), "src", "cmdstan", "main.o")
+  main_path_threads_o <- file.path(cmdstan_path(), "src", "cmdstan", "main_threads.o")
+  if (file.exists(main_path_threads_o)) {
+    file.remove(main_path_threads_o)
+  }
   mod$compile(force_recompile = TRUE)
 
   before_mtime <- file.mtime(main_path_o)
   mod$compile(force_recompile = TRUE)
   after_mtime <- file.mtime(main_path_o)
   expect_equal(before_mtime, after_mtime)
+  expect_false(file.exists(main_path_threads_o))
 
-  before_mtime <- file.mtime(main_path_o)
   mod$compile(force_recompile = TRUE, cpp_options = list(stan_threads = TRUE))
-  after_mtime <- file.mtime(main_path_o)
-  time_diff <- as.double((after_mtime - before_mtime), units = "secs")
-  expect_gt(time_diff, 0)
+  checkmate::expect_file_exists(main_path_threads_o)
 
   before_mtime <- file.mtime(main_path_o)
   mod$compile(force_recompile = TRUE, cpp_options = list(stan_threads = TRUE))
@@ -162,27 +164,35 @@ test_that("switching threads on and off works without rebuild", {
   before_mtime <- file.mtime(main_path_o)
   mod$compile(force_recompile = TRUE)
   after_mtime <- file.mtime(main_path_o)
-  time_diff <- as.double((after_mtime - before_mtime), units = "secs")
-  expect_gt(time_diff, 0)
+  expect_equal(before_mtime, after_mtime)
 })
 
 test_that("message is shown on building main.o", {
   skip_on_cran()
-  main_o_files <- c(
-    file.path(cmdstan_path(), "src", "cmdstan", "main.o"),
-    file.path(cmdstan_path(), "src", "cmdstan", "main_noflags.o")
-  )
-  for (f in main_o_files) {
-    if (file.exists(f))
-      file.remove(f)
+  if (cmdstan_version() > "2.23") {
+    expect_message(
+      mod$compile(force_recompile = TRUE),
+      "Compiling Stan program...",
+      fixed = TRUE
+    )
+    return(invisible(NULL))
+  } else {
+    main_o_files <- c(
+      file.path(cmdstan_path(), "src", "cmdstan", "main.o"),
+      file.path(cmdstan_path(), "src", "cmdstan", "main_noflags.o")
+    )
+    for (f in main_o_files) {
+      if (file.exists(f))
+        file.remove(f)
+    }
+    expect_message(
+      mod$compile(force_recompile = TRUE),
+      "Compiling the main object file and precompiled headers (may take up to a few minutes). ",
+      "This is only necessary for the first compilation after installation or when ",
+      "threading, MPI or OpenCL are used for the first time.",
+      fixed = TRUE
+    )
   }
-  expect_message(
-    mod$compile(force_recompile = TRUE),
-    "Compiling the main object file and precompiled headers (may take up to a few minutes). ",
-    "This is only necessary for the first compilation after installation or when ",
-    "threading, MPI or OpenCL are used for the first time.",
-    fixed = TRUE
-  )
 })
 
 test_that("compile errors are shown", {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Cmdstan 2.24 deprecated --include_paths in favor of --include-paths. So we should use that. Fixes #245 

The issue also has a request: 
"It would be convenient if include_paths included the directory of the model file"

This PR does not address that. I am not sure what would be best there. I guess there might be situation where users don't want "." in include paths.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Univ. of Ljubljana


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
