### PR TITLE
link to online cmdstan guide instead of pdf

### DIFF
--- a/man-roxygen/seealso-docs.R
+++ b/man-roxygen/seealso-docs.R
@@ -1,8 +1,9 @@
 #' @seealso
-#' The CmdStanR website ([mc-stan.org/cmdstanr](https://mc-stan.org/cmdstanr/))
-#' for online documentation and tutorials.
+#' The CmdStanR website
+#' ([mc-stan.org/cmdstanr](https://mc-stan.org/cmdstanr/)) for online
+#' documentation and tutorials.
 #'
 #' The Stan and CmdStan documentation:
-#' * Stan doc (html or pdf): [mc-stan.org/users/documentation/](https://mc-stan.org/users/documentation/)
-#' * CmdStan doc (pdf): ([github.com/stan-dev/cmdstan/releases/](https://github.com/stan-dev/cmdstan/releases/latest)).
+#' * Stan documentation: [mc-stan.org/users/documentation](https://mc-stan.org/users/documentation/)
+#' * CmdStan User’s Guide: [mc-stan.org/docs/cmdstan-guide](https://mc-stan.org/docs/cmdstan-guide/)
 #'

--- a/man/CmdStanGQ.Rd
+++ b/man/CmdStanGQ.Rd
@@ -89,13 +89,14 @@ as_draws_df(fit_gq$draws())
 
 }
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 
 Other fitted model objects: 

--- a/man/CmdStanMCMC.Rd
+++ b/man/CmdStanMCMC.Rd
@@ -53,13 +53,14 @@ methods, all of which have their own (linked) documentation pages.
 }
 
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 
 Other fitted model objects: 

--- a/man/CmdStanMLE.Rd
+++ b/man/CmdStanMLE.Rd
@@ -47,13 +47,14 @@ all of which have their own (linked) documentation pages.
 }
 
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 
 Other fitted model objects: 

--- a/man/CmdStanModel.Rd
+++ b/man/CmdStanModel.Rd
@@ -156,12 +156,13 @@ fit_optim_w_init_list$init()
 
 }
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 }

--- a/man/CmdStanVB.Rd
+++ b/man/CmdStanVB.Rd
@@ -50,13 +50,14 @@ all of which have their own (linked) documentation pages.
 }
 
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 
 Other fitted model objects: 

--- a/man/cmdstan_model.Rd
+++ b/man/cmdstan_model.Rd
@@ -140,12 +140,13 @@ fit_optim_w_init_list$init()
 \seealso{
 \code{\link[=install_cmdstan]{install_cmdstan()}}, \code{\link[=cmdstan_path]{cmdstan_path()}}
 
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 }

--- a/man/cmdstanr-package.Rd
+++ b/man/cmdstanr-package.Rd
@@ -168,12 +168,13 @@ fit_optim_w_init_list$init()
 
 }
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 }

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -80,13 +80,14 @@ mod$exe_file()
 
 }
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 
 Other CmdStanModel methods: 

--- a/man/model-method-generate-quantities.Rd
+++ b/man/model-method-generate-quantities.Rd
@@ -84,13 +84,14 @@ as_draws_df(fit_gq$draws())
 
 }
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 
 Other CmdStanModel methods: 

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -230,13 +230,14 @@ fit_optim_w_init_list$init()
 
 }
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 
 Other CmdStanModel methods: 

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -321,13 +321,14 @@ fit_optim_w_init_list$init()
 
 }
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 
 Other CmdStanModel methods: 

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -247,13 +247,14 @@ fit_optim_w_init_list$init()
 
 }
 \seealso{
-The CmdStanR website (\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr})
-for online documentation and tutorials.
+The CmdStanR website
+(\href{https://mc-stan.org/cmdstanr/}{mc-stan.org/cmdstanr}) for online
+documentation and tutorials.
 
 The Stan and CmdStan documentation:
 \itemize{
-\item Stan doc (html or pdf): \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation/}
-\item CmdStan doc (pdf): (\href{https://github.com/stan-dev/cmdstan/releases/latest}{github.com/stan-dev/cmdstan/releases/}).
+\item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
+\item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
 
 Other CmdStanModel methods: 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Closes #244 

Replaces link to PDF guide with https://mc-stan.org/docs/cmdstan-guide/, which links to the latest html version of the CmdStan guide. 

The only change is to `man-roxygen/seealso-docs.R`. All the other files are auto-generated. 


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
