### PR TITLE
use read.csv if vroom fails

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel'}
+          # - {os: macOS-latest,   r: 'devel'}
           - {os: macOS-latest,   r: 'release'}
           - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -35,7 +35,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
 

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -228,7 +228,9 @@ read_cmdstan_csv <- function(files,
     draws <- try(silent = TRUE, expr = {
       suppressWarnings(do.call(vroom::vroom, vroom_args))
     })
-    if (inherits(draws, "try-error")) {
+    if (!inherits(draws, "try-error")) {
+      draws <- draws[!is.na(draws$lp__), ]
+    } else {
       if (vroom_warnings == 0) { # only warn the first time instead of for every csv file
         warning(
           "Fast CSV reading with vroom::vroom() failed. Using utils::read.csv() instead. ",
@@ -241,8 +243,6 @@ read_cmdstan_csv <- function(files,
       draws <- utils::read.csv(output_file, comment.char = "#", skip = metadata$lines_to_skip)
       draws <- draws[, col_select]
     }
-    draws <- draws[!is.na(draws$lp__), ]
-
 
     if (nrow(draws) > 0) {
       if (metadata$method == "sample") {

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -229,7 +229,9 @@ read_cmdstan_csv <- function(files,
       suppressWarnings(do.call(vroom::vroom, vroom_args))
     })
     if (!inherits(draws, "try-error")) {
-      draws <- draws[!is.na(draws$lp__), ]
+      if (metadata$method != "generate_quantities") {
+        draws <- draws[!is.na(draws$lp__), ]
+      }
     } else {
       if (vroom_warnings == 0) { # only warn the first time instead of for every csv file
         warning(


### PR DESCRIPTION
Fixes #249

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Uses `utils::read_csv()` if `vroom::vroom()` errors. Throws a warning asking users to report. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
