### PR TITLE
Update divergences warning

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -281,11 +281,16 @@ check_divergences <- function(data_csv) {
     num_of_divergences <- sum(divergences)
     if (num_of_divergences > 0) {
       percentage_divergences <- (num_of_divergences)/num_of_draws*100
-      message(num_of_divergences, " of ", num_of_draws, " (", (format(round(percentage_divergences, 0), nsmall = 1)), "%)",
-              " transitions ended with a divergence.\n",
-              "These divergent transitions indicate that HMC is not fully able to explore the posterior distribution.\n",
-              "Try increasing adapt delta closer to 1.\n",
-              "If this doesn't remove all divergences, try to reparameterize the model.\n")
+      message(
+        "\nWarning: ", num_of_divergences, " of ", num_of_draws,
+        " (", (format(round(percentage_divergences, 0), nsmall = 1)), "%)",
+        " transitions ended with a divergence.\n",
+        "This may indicate insufficient exploration of the posterior distribution.\n",
+        "Possible remedies include: \n",
+        "  * Increasing adapt_delta closer to 1 (default is 0.8) \n",
+        "  * Reparameterizing the model (e.g. using a non-centered parameterization)\n",
+        "  * Using informative or weakly informative prior distributions \n"
+      )
     }
   }
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Updates the warning about divergences with a bit more information. Once we have something like the interface-agnostic page described at https://discourse.mc-stan.org/t/text-for-warning-message/16928/37?u=jonah then we can simplify this message and just point there. 

To see what the new message looks like run the schools example, which has divergences: 

```
fit <- cmdstanr_example("schools") 
```

```
Warning: 226 of 4000 (6.0%) transitions ended with a divergence.
This may indicate insufficient exploration of the posterior distribution.
Possible remedies include: 
  * Increasing adapt_delta closer to 1 (default is 0.8) 
  * Reparameterizing the model (e.g. using a non-centered parameterization)
  * Using informative or weakly informative prior distributions 
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
