### PR TITLE
make vroom optional

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cmdstanr
 Title: R Interface to 'CmdStan'
-Version: 0.1.0
-Date: 2020-07-29
+Version: 0.1.1
+Date: 2020-07-31
 Authors@R: 
     c(person(given = "Jonah", family = "Gabry", role = c("aut", "cre"),
            email = "jsg2201@columbia.edu"),
@@ -26,13 +26,13 @@ Imports:
     jsonlite (>= 1.2.0),
     posterior (>= 0.1.0),
     processx,
-    R6 (>= 2.4.0),
-    vroom
+    R6 (>= 2.4.0)
 Suggests: 
     bayesplot,
     knitr,
     rmarkdown,
-    testthat (>= 2.1.0)
+    testthat (>= 2.1.0),
+    vroom
 Additional_repositories:
     https://mc-stan.org/r-packages/
 VignetteBuilder: knitr

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# cmdstanr 0.1.1
+
+* The `vroom` package is now optional. If installed it will be used to speed up csv reading, but it is not required. (#262)
+
 # cmdstanr 0.1.0
 
 * Beta release

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -105,8 +105,8 @@
 #' }
 #'
 read_cmdstan_csv <- function(files,
-                            variables = NULL,
-                            sampler_diagnostics = NULL) {
+                             variables = NULL,
+                             sampler_diagnostics = NULL) {
   checkmate::assert_file_exists(files, access = "r", extension = "csv")
   metadata <- NULL
   warmup_draws <- NULL
@@ -122,6 +122,15 @@ read_cmdstan_csv <- function(files,
   col_select <- NULL
   not_matching <- c()
   vroom_warnings <- 0
+
+  no_vroom <- !requireNamespace("vroom", quietly = TRUE)
+  if (no_vroom && !identical(variables, "")) {
+    warning(
+      "The vroom package is not installed. Using utils::read.csv() instead. ",
+      "\nInstall the vroom package to speed up reading CmdStan output into R.",
+      call. = FALSE
+    )
+  }
 
   for (output_file in files) {
     if (is.null(metadata)) {
@@ -206,44 +215,48 @@ read_cmdstan_csv <- function(files,
       all_draws <- 1
     }
 
-    vroom_args <- list(
-      file = output_file,
-      comment = "#",
-      delim = ",",
-      trim_ws = TRUE,
-      altrep = FALSE,
-      progress = FALSE,
-      skip = metadata$lines_to_skip,
-      col_select = col_select
-    )
-    if (metadata$method == "generate_quantities") {
-      # set the first arg as double to silence the type detection info
-      vroom_args$col_types <- list()
-      vroom_args$col_types[[col_select[1]]] <- "d"
-    } else {
-      vroom_args$col_types <- c("lp__" = "d")
-      vroom_args$n_max <- all_draws * 2
-    }
-
-    draws <- try(silent = TRUE, expr = {
-      suppressWarnings(do.call(vroom::vroom, vroom_args))
-    })
-    if (!inherits(draws, "try-error")) {
-      if (metadata$method != "generate_quantities") {
-        draws <- draws[!is.na(draws$lp__), ]
-      }
-    } else {
-      if (vroom_warnings == 0) { # only warn the first time instead of for every csv file
-        warning(
-          "Fast CSV reading with vroom::vroom() failed. Using utils::read.csv() instead. ",
-          "\nTo help avoid this in the future, please report this issue at github.com/stan-dev/cmdstanr/issues ",
-          "and include the output from sessionInfo(). Thank you!",
-          call. = FALSE
-        )
-      }
-      vroom_warnings <- vroom_warnings + 1
+    if (no_vroom) {
       draws <- utils::read.csv(output_file, comment.char = "#", skip = metadata$lines_to_skip)
-      draws <- draws[, col_select]
+      draws <- draws[, col_select, drop = FALSE]
+    } else {
+      vroom_args <- list(
+        file = output_file,
+        comment = "#",
+        delim = ",",
+        trim_ws = TRUE,
+        altrep = FALSE,
+        progress = FALSE,
+        skip = metadata$lines_to_skip,
+        col_select = col_select
+      )
+      if (metadata$method == "generate_quantities") {
+        # set the first arg as double to silence the type detection info
+        vroom_args$col_types <- list()
+        vroom_args$col_types[[col_select[1]]] <- "d"
+      } else {
+        vroom_args$col_types <- c("lp__" = "d")
+        vroom_args$n_max <- all_draws * 2
+      }
+      draws <- try(silent = TRUE, expr = {
+        suppressWarnings(do.call(vroom::vroom, vroom_args))
+      })
+      if (!inherits(draws, "try-error")) {
+        if (metadata$method != "generate_quantities") {
+          draws <- draws[!is.na(draws$lp__), ]
+        }
+      } else {
+        if (vroom_warnings == 0) { # only warn the first time instead of for every csv file
+          warning(
+            "Fast CSV reading with vroom::vroom() failed. Using utils::read.csv() instead. ",
+            "\nTo help avoid this in the future, please report this issue at github.com/stan-dev/cmdstanr/issues ",
+            "and include the output from sessionInfo(). Thank you!",
+            call. = FALSE
+          )
+        }
+        vroom_warnings <- vroom_warnings + 1
+        draws <- utils::read.csv(output_file, comment.char = "#", skip = metadata$lines_to_skip)
+        draws <- draws[, col_select, drop = FALSE]
+      }
     }
 
     if (nrow(draws) > 0) {


### PR DESCRIPTION
fixes #262

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Moves vroom from Imports to Suggests and adds code to `read_cmdstan_csv()` to handle the case when vroom is not  installed. Also bumps version to 0.1.1. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
