### PR TITLE
Message at startup if new CmdStan is available

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -168,9 +168,5 @@ is_release_candidate <- function(path) {
   if (endsWith(path, "/")) {
     path <- substr(path, 1, nchar(path) - 1)
   }
-  if (length(grep(pattern = "-rc[0-9]*$", x = path)) > 0) {
-    TRUE
-  } else{
-    FALSE
-  }
+  grepl(pattern = "-rc[0-9]*$", x = path)
 }

--- a/R/path.R
+++ b/R/path.R
@@ -140,36 +140,6 @@ unset_cmdstan_path <- function() {
   .cmdstanr$VERSION <- NULL
 }
 
-# called in .onLoad() in zzz.R:
-cmdstanr_initialize <- function() {
-  # First check for environment variable CMDSTAN, but if not found
-  # then see if default
-  path <- Sys.getenv("CMDSTAN")
-  if (isTRUE(nzchar(path))) { # CMDSTAN environment variable found
-    if (dir.exists(path)) {
-      path <- absolute_path(path)
-      suppressMessages(set_cmdstan_path(path))
-    } else {
-      warning("Can't find directory specified by environment variable",
-              " 'CMDSTAN'. Path not set.", call. = FALSE)
-      .cmdstanr$PATH <- NULL
-    }
-
-  } else { # environment variable not found
-    path <- cmdstan_default_path()
-    if (!is.null(path)) {
-      suppressMessages(set_cmdstan_path(path))
-    }
-  }
-
-  if (getRversion() < '3.5.0') {
-    .cmdstanr$TEMP_DIR <- tempdir()
-  } else {
-    .cmdstanr$TEMP_DIR <- tempdir(check = TRUE)
-  }
-  invisible(TRUE)
-}
-
 
 #' Find the version of cmdstan from makefile
 #' @noRd

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -16,3 +16,31 @@
 }
 
 
+cmdstanr_initialize <- function() {
+  # First check for environment variable CMDSTAN, but if not found
+  # then see if default
+  path <- Sys.getenv("CMDSTAN")
+  if (isTRUE(nzchar(path))) { # CMDSTAN environment variable found
+    if (dir.exists(path)) {
+      path <- absolute_path(path)
+      suppressMessages(set_cmdstan_path(path))
+    } else {
+      warning("Can't find directory specified by environment variable",
+              " 'CMDSTAN'. Path not set.", call. = FALSE)
+      .cmdstanr$PATH <- NULL
+    }
+
+  } else { # environment variable not found
+    path <- cmdstan_default_path()
+    if (!is.null(path)) {
+      suppressMessages(set_cmdstan_path(path))
+    }
+  }
+
+  if (getRversion() < '3.5.0') {
+    .cmdstanr$TEMP_DIR <- tempdir()
+  } else {
+    .cmdstanr$TEMP_DIR <- tempdir(check = TRUE)
+  }
+  invisible(TRUE)
+}

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,6 +1,14 @@
 .onAttach <- function(...) {
-  ver <- utils::packageVersion("cmdstanr")
-  packageStartupMessage("This is cmdstanr version ", ver)
+  startup_messages()
+}
+
+.onLoad <- function(...) {
+  cmdstanr_initialize()
+}
+
+
+startup_messages <- function() {
+  packageStartupMessage("This is cmdstanr version ", utils::packageVersion("cmdstanr"))
   packageStartupMessage("- Online documentation and vignettes at mc-stan.org/cmdstanr")
   if (is.null(.cmdstanr$PATH)) {
     packageStartupMessage("- Use set_cmdstan_path() to set the path to CmdStan")
@@ -9,10 +17,15 @@
     packageStartupMessage("- CmdStan path set to: ", cmdstan_path(), "")
     packageStartupMessage("- Use set_cmdstan_path() to change the path")
   }
-}
 
-.onLoad <- function(...) {
-  cmdstanr_initialize()
+  latest_version <- try(suppressWarnings(latest_released_version()), silent = TRUE)
+  if (!inherits(latest_version, "try-error")
+      && latest_version > cmdstan_version()) {
+      packageStartupMessage(
+        "\nA newer version of CmdStan is available.",
+        " See ?install_cmdstan() to install it."
+      )
+  }
 }
 
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -18,13 +18,19 @@ startup_messages <- function() {
     packageStartupMessage("- Use set_cmdstan_path() to change the path")
   }
 
-  latest_version <- try(suppressWarnings(latest_released_version()), silent = TRUE)
-  if (!inherits(latest_version, "try-error")
-      && latest_version > cmdstan_version()) {
+  skip_version_check <- getOption(
+    "CMDSTANR_NO_VER_CHECK",
+    default = identical(tolower(Sys.getenv("CMDSTANR_NO_VER_CHECK")), "true")
+  )
+  if (!skip_version_check) {
+    latest_version <- try(suppressWarnings(latest_released_version()), silent = TRUE)
+    if (!inherits(latest_version, "try-error")
+        && latest_version > cmdstan_version()) {
       packageStartupMessage(
-        "\nA newer version of CmdStan is available.",
-        " See ?install_cmdstan() to install it."
+        "\nA newer version of CmdStan is available. See ?install_cmdstan() to install it.",
+        "\nTo disable this check set option or environment variable CMDSTANR_NO_VER_CHECK=TRUE."
       )
+    }
   }
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -18,10 +18,10 @@ startup_messages <- function() {
     packageStartupMessage("- Use set_cmdstan_path() to change the path")
   }
 
-  skip_version_check <- getOption(
+  skip_version_check <- isTRUE(getOption(
     "CMDSTANR_NO_VER_CHECK",
     default = identical(tolower(Sys.getenv("CMDSTANR_NO_VER_CHECK")), "true")
-  )
+  ))
   if (!skip_version_check) {
     latest_version <- try(suppressWarnings(latest_released_version()), silent = TRUE)
     if (!inherits(latest_version, "try-error")


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Closes #265 

When the package is loaded via library it now checks what the latest CmdStan version is to see if it's more recent than the version being used. If it is then there is a message alerting the user (see example below). This slightly but noticeably increase load time because it has to check GitHub. Also, if there is an error checking the version number from GitHub then there is no message.  

#### Example 

```
> library(cmdstanr)

Loading cmdstanr
This is cmdstanr version 0.1.1
- Online documentation and vignettes at mc-stan.org/cmdstanr
- CmdStan path set to: /Users/jgabry/.cmdstanr/cmdstan-2.23.0
- Use set_cmdstan_path() to change the path

A newer version of CmdStan is available. See ?install_cmdstan() to install it.
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
