### PR TITLE
fix loading if no previous cmdstan installation

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -24,8 +24,10 @@ startup_messages <- function() {
   ))
   if (!skip_version_check) {
     latest_version <- try(suppressWarnings(latest_released_version()), silent = TRUE)
+    current_version <- try(cmdstan_version(), silent = TRUE)
     if (!inherits(latest_version, "try-error")
-        && latest_version > cmdstan_version()) {
+        && !inherits(current_version, "try-error")
+        && latest_version > current_version) {
       packageStartupMessage(
         "\nA newer version of CmdStan is available. See ?install_cmdstan() to install it.",
         "\nTo disable this check set option or environment variable CMDSTANR_NO_VER_CHECK=TRUE."


### PR DESCRIPTION
closes #274

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

I think this fixes #274. We forgot about the case when there is no pre-existing CmdStan installation! 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
