### PR TITLE
Fix error with off by one indexing

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,11 @@
+# Items for next tagged release
+
+* Fix potential indexing error if using `read_cmdstan_csv()` with CSV files
+created by CmdStan without CmdStanR. (#291, #292, @johnlees)
+
 # cmdstanr 0.1.3
 
-* New `$check_syntax()` method for CmdStanModel objects (#276, #277)
+* New `$check_syntax()` method for CmdStanModel objects. (#276, #277)
 
 # cmdstanr 0.1.2
 

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -126,13 +126,18 @@ read_cmdstan_csv <- function(files,
   for (output_file in files) {
     if (is.null(metadata)) {
       metadata <- read_csv_metadata(output_file)
+      if (metadata$id == 0) {
+          id <- "0"
+      } else {
+          id <- metadata$id
+      }
+
       if (!is.null(metadata$inv_metric)) {
-        inv_metric[[as.character(metadata$id)]] <- metadata$inv_metric
+        inv_metric[[id]] <- metadata$inv_metric
       }
       if (!is.null(metadata$step_size_adaptation)) {
-        step_size[[as.character(metadata$id)]] <- metadata$step_size_adaptation
+        step_size[[id]] <- metadata$step_size_adaptation
       }
-      id <- metadata$id
     } else {
       csv_file_info <- read_csv_metadata(output_file)
       check <- check_csv_metadata_matches(metadata, csv_file_info)

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -148,10 +148,10 @@ read_cmdstan_csv <- function(files,
       metadata$fitted_params <- c(metadata$fitted_params, csv_file_info$fitted_params)
 
       if (!is.null(csv_file_info$inv_metric)) {
-        inv_metric[[csv_file_info$id]] <- csv_file_info$inv_metric
+        inv_metric[[as.character(csv_file_info$id)]] <- csv_file_info$inv_metric
       }
       if (!is.null(csv_file_info$step_size_adaptation)) {
-        step_size[[csv_file_info$id]] <- csv_file_info$step_size_adaptation
+        step_size[[as.character(csv_file_info$id)]] <- csv_file_info$step_size_adaptation
       }
       id <- csv_file_info$id
     }

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -126,18 +126,13 @@ read_cmdstan_csv <- function(files,
   for (output_file in files) {
     if (is.null(metadata)) {
       metadata <- read_csv_metadata(output_file)
-      if (metadata$id == 0) {
-          id <- "0"
-      } else {
-          id <- metadata$id
-      }
-
       if (!is.null(metadata$inv_metric)) {
-        inv_metric[[id]] <- metadata$inv_metric
+        inv_metric[[as.character(metadata$id)]] <- metadata$inv_metric
       }
       if (!is.null(metadata$step_size_adaptation)) {
-        step_size[[id]] <- metadata$step_size_adaptation
+        step_size[[as.character(metadata$id)]] <- metadata$step_size_adaptation
       }
+      id <- metadata$id
     } else {
       csv_file_info <- read_csv_metadata(output_file)
       check <- check_csv_metadata_matches(metadata, csv_file_info)

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -127,10 +127,10 @@ read_cmdstan_csv <- function(files,
     if (is.null(metadata)) {
       metadata <- read_csv_metadata(output_file)
       if (!is.null(metadata$inv_metric)) {
-        inv_metric[[metadata$id]] <- metadata$inv_metric
+        inv_metric[[as.character(metadata$id)]] <- metadata$inv_metric
       }
       if (!is.null(metadata$step_size_adaptation)) {
-        step_size[[metadata$id]] <- metadata$step_size_adaptation
+        step_size[[as.character(metadata$id)]] <- metadata$step_size_adaptation
       }
       id <- metadata$id
     } else {
@@ -148,10 +148,10 @@ read_cmdstan_csv <- function(files,
       metadata$fitted_params <- c(metadata$fitted_params, csv_file_info$fitted_params)
 
       if (!is.null(csv_file_info$inv_metric)) {
-        inv_metric[[csv_file_info$id]] <- csv_file_info$inv_metric
+        inv_metric[[as.character(csv_file_info$id)]] <- csv_file_info$inv_metric
       }
       if (!is.null(csv_file_info$step_size_adaptation)) {
-        step_size[[csv_file_info$id]] <- csv_file_info$step_size_adaptation
+        step_size[[as.character(csv_file_info$id)]] <- csv_file_info$step_size_adaptation
       }
       id <- csv_file_info$id
     }

--- a/R/read_csv.R
+++ b/R/read_csv.R
@@ -148,10 +148,10 @@ read_cmdstan_csv <- function(files,
       metadata$fitted_params <- c(metadata$fitted_params, csv_file_info$fitted_params)
 
       if (!is.null(csv_file_info$inv_metric)) {
-        inv_metric[[as.character(csv_file_info$id)]] <- csv_file_info$inv_metric
+        inv_metric[[csv_file_info$id]] <- csv_file_info$inv_metric
       }
       if (!is.null(csv_file_info$step_size_adaptation)) {
-        step_size[[as.character(csv_file_info$id)]] <- csv_file_info$step_size_adaptation
+        step_size[[csv_file_info$id]] <- csv_file_info$step_size_adaptation
       }
       id <- csv_file_info$id
     }

--- a/tests/testthat/test-csv.R
+++ b/tests/testthat/test-csv.R
@@ -162,13 +162,13 @@ test_that("read_cmdstan_csv() returns correct diagonal of inverse mass matrix", 
   skip_on_cran()
   csv_files <- c(test_path("resources", "csv", "model1-2-no-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
-  expect_equal(as.vector(csv_output$inv_metric[[2]]),
+  expect_equal(as.vector(csv_output$inv_metric[[as.character(2)]]),
                c(0.909635, 0.066384))
   csv_files <- c(test_path("resources", "csv", "model1-1-warmup.csv"),test_path("resources", "csv", "model1-2-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
-  expect_equal(as.vector(csv_output$inv_metric[[1]]),
+  expect_equal(as.vector(csv_output$inv_metric[[as.character(1)]]),
                c(1.00098, 0.068748))
-  expect_equal(as.vector(csv_output$inv_metric[[2]]),
+  expect_equal(as.vector(csv_output$inv_metric[[as.character(2)]]),
                c(0.909635, 0.066384))
 })
 
@@ -373,14 +373,14 @@ test_that("read_cmdstan_csv() reads adaptation step size correctly", {
   csv_files <- test_path("resources", "csv", "model1-2-no-warmup.csv")
 
   csv_out <- read_cmdstan_csv(csv_files)
-  expect_equal(csv_out$step_size[[2]], 0.672434)
+  expect_equal(csv_out$step_size[[as.character(2)]], 0.672434)
 
   csv_files <- c(test_path("resources", "csv", "model1-1-dense_e_metric.csv"),
                  test_path("resources", "csv", "model1-2-dense_e_metric.csv"))
 
   csv_out <- read_cmdstan_csv(csv_files)
-  expect_equal(csv_out$step_size[[1]], 0.11757)
-  expect_equal(csv_out$step_size[[2]], 0.232778)
+  expect_equal(csv_out$step_size[[as.character(1)]], 0.11757)
+  expect_equal(csv_out$step_size[[as.character(2)]], 0.232778)
 })
 
 test_that("read_cmdstan_csv() works for optimize", {


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [ ] Declare copyright holder and agree to license (see below)

#### Summary

There appears to be an off-by-one indexing issue in R vs C++. The default index of 0 found in the metadata is invalid for R lists which are 1-indexed. This leads to the following error, which is difficult for the user to comprehend:
```
read_cmdstan_csv('cmdstan.run0.csv')
Error in inv_metric[[metadata$id]] <- metadata$inv_metric :
  attempt to select less than one element in integerOneIndex
```

The right solution to me would seem to be to convert the index into R's 1-index form, where they are used in this manner.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
John Lees


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
