### PR TITLE
Fix macOS CI issue

### DIFF
--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -12,7 +12,7 @@ if (not_on_cran()) {
                             refresh = 0, save_warmup = TRUE)
   fit_mcmc_2 <- testing_fit("logistic", method = "sample",
                             seed = 1234, chains = 1,
-                            iter_sampling = 100000,
+                            iter_sampling = 10000,
                             refresh = 0, metric = "dense_e")
   fit_mcmc_3 <- testing_fit("logistic", method = "sample",
                             seed = 1234, chains = 1,
@@ -212,11 +212,11 @@ test_that("inc_warmup in draws() works", {
 test_that("inc_warmup in draws() works", {
   skip_on_cran()
   x3 <- fit_mcmc_2$draws(inc_warmup = FALSE)
-  expect_equal(dim(x3), c(100000, 1, 5))
+  expect_equal(dim(x3), c(10000, 1, 5))
   expect_error(fit_mcmc_2$draws(inc_warmup = TRUE),
                "Warmup draws were requested from a fit object without them! Please rerun the model with save_warmup = TRUE.")
   y3 <- fit_mcmc_2$sampler_diagnostics(inc_warmup = FALSE)
-  expect_equal(dim(y3), c(100000, 1, 6))
+  expect_equal(dim(y3), c(10000, 1, 6))
 })
 
 test_that("output() shows informational messages depening on show_messages", {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This fixes the occasional but annoying macOS CI false positive. 

It turns out the problem is with sampling with 100k iterations we had in one test. Reducing that to 10k fixes the occasional CI failures on MacOS. I ran ~50 tests on my fork and got zero fails. There might be other cases where we are close to the memory limit on the mac agents and we will see those pop-up now. But we now at least know what to look at and that these are in fact false positives.

The segfault that occurred happened in the test where we read the 100k draws in memory. I am assuming the virtual machine runs out of memory. If we really want to test with 100k iterations, the fit would have to be split in a separate test file. I don't think it is necessary to test for 100k so I just reduced it to 10k.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
