### PR TITLE
Fix windows codecov tests

### DIFF
--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -91,6 +91,7 @@ test_that("install_cmdstan() errors if invalid version or URL", {
 
 test_that("install_cmdstan() works with version and release_url", {
   skip_if_offline()
+  if (os_is_windows()) skip_on_covr()
   if (getRversion() < '3.5.0') {
     dir <- tempdir()
   } else {


### PR DESCRIPTION
#### Summary

Fixes #310 

Not sure what codecov does but install tests do not work on Windows in `covr::codecov()`. The version PR added an additional test for installation that needed the skip for windows coverage tests that were added yesterday.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Univ. of Ljubljana


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
