### PR TITLE
Ignore stdout on refresh=0

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,6 +15,8 @@ in fitting methods. (#281, #294)
 
 * Fix reporting of time after using `fixed_param` method. (#303, #307)
 
+* With `refresh = 0`, no output is printed wirht `$optimize()` and `$variational()`
+
 ### New features
 
 * `install_cmdstan()` gains argument `version` for specifying which version of 

--- a/NEWS.md
+++ b/NEWS.md
@@ -20,14 +20,14 @@ in fitting methods. (#281, #294)
 
 ### New features
 
-* `install_cmdstan()` gains argument `version` for specifying which version of 
+* `install_cmdstan()` gains argument `version` for specifying which version of
 CmdStan to install. (#300, #308)
 
-* New function `check_cmdstan_toolchain()` that checks if the appropriate toolchains are 
-available. (#289)
+* New function `check_cmdstan_toolchain()` that checks if the appropriate
+toolchains are available. (#289)
 
-* `$sample()` method for CmdStanModel objects gains argument `chain_ids` for specifying
- custom chain IDs. (#319)
+* `$sample()` method for CmdStanModel objects gains argument `chain_ids` for
+specifying custom chain IDs. (#319)
 
 
 # cmdstanr 0.1.3

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,8 @@ in fitting methods. (#281, #294)
 
 * Fix reporting of time after using `fixed_param` method. (#303, #307)
 
-* With `refresh = 0`, no output is printed wirht `$optimize()` and `$variational()`
+* With `refresh = 0`, no output other than error messages is printed with
+`$optimize()` and `$variational()`. (#324)
 
 ### New features
 

--- a/R/model.R
+++ b/R/model.R
@@ -987,7 +987,7 @@ optimize_method <- function(data = NULL,
     output_dir = output_dir
   )
 
-  cmdstan_procs <- CmdStanProcs$new(num_procs = 1)
+  cmdstan_procs <- CmdStanProcs$new(num_procs = 1, show_messages = (is.null(refresh) || refresh != 0))
   runset <- CmdStanRun$new(args = cmdstan_args, procs = cmdstan_procs)
   runset$run_cmdstan()
   CmdStanMLE$new(runset)
@@ -1107,7 +1107,7 @@ variational_method <- function(data = NULL,
     output_dir = output_dir
   )
 
-  cmdstan_procs <- CmdStanProcs$new(num_procs = 1)
+  cmdstan_procs <- CmdStanProcs$new(num_procs = 1, show_messages = (is.null(refresh) || refresh != 0))
   runset <- CmdStanRun$new(args = cmdstan_args, procs = cmdstan_procs)
   runset$run_cmdstan()
   CmdStanVB$new(runset)

--- a/R/model.R
+++ b/R/model.R
@@ -897,7 +897,7 @@ sample_method <- function(data = NULL,
     num_procs = chains,
     parallel_procs = parallel_chains,
     threads_per_proc = threads_per_chain,
-    show_messages = show_messages
+    show_stderr_messages = show_messages
   )
   runset <- CmdStanRun$new(args = cmdstan_args, procs = cmdstan_procs)
   runset$run_cmdstan()
@@ -987,7 +987,7 @@ optimize_method <- function(data = NULL,
     output_dir = output_dir
   )
 
-  cmdstan_procs <- CmdStanProcs$new(num_procs = 1, show_messages = (is.null(refresh) || refresh != 0))
+  cmdstan_procs <- CmdStanProcs$new(num_procs = 1, show_stdout_messages = (is.null(refresh) || refresh != 0))
   runset <- CmdStanRun$new(args = cmdstan_args, procs = cmdstan_procs)
   runset$run_cmdstan()
   CmdStanMLE$new(runset)
@@ -1107,7 +1107,7 @@ variational_method <- function(data = NULL,
     output_dir = output_dir
   )
 
-  cmdstan_procs <- CmdStanProcs$new(num_procs = 1, show_messages = (is.null(refresh) || refresh != 0))
+  cmdstan_procs <- CmdStanProcs$new(num_procs = 1, show_stdout_messages = (is.null(refresh) || refresh != 0))
   runset <- CmdStanRun$new(args = cmdstan_args, procs = cmdstan_procs)
   runset$run_cmdstan()
   CmdStanVB$new(runset)

--- a/R/run.R
+++ b/R/run.R
@@ -415,7 +415,7 @@ CmdStanProcs <- R6::R6Class(
     #   Currently for non-sampling this must be set to 1.
     # @param threads_per_proc The number of threads to use per process
     #   to run parallel sections of model.
-    initialize = function(num_procs, parallel_procs = NULL, threads_per_proc = NULL, show_messages = TRUE) {
+    initialize = function(num_procs, parallel_procs = NULL, threads_per_proc = NULL, show_stderr_messages = TRUE, show_stdout_messages = TRUE ) {
       checkmate::assert_integerish(num_procs, lower = 1, len = 1, any.missing = FALSE)
       checkmate::assert_integerish(parallel_procs, lower = 1, len = 1, any.missing = FALSE,
                                    .var.name = "parallel_procs", null.ok = TRUE)
@@ -436,7 +436,8 @@ CmdStanProcs <- R6::R6Class(
       private$proc_state_ = zeros
       private$proc_start_time_ = zeros
       private$proc_total_time_ = zeros
-      private$show_messages_ = show_messages
+      private$show_stderr_messages_ = show_stderr_messages
+      private$show_stdout_messages_ = show_stdout_messages
       invisible(self)
     },
     num_procs = function() {
@@ -589,7 +590,9 @@ CmdStanProcs <- R6::R6Class(
       if (length(err_out)) {
         for (err_line in err_out) {
           private$proc_output_[[id]] <- c(private$proc_output_[[id]], err_line)
-          message("Chain ", id, " ", err_line)
+          if (private$show_stderr_messages_) {
+            message("Chain ", id, " ", err_line)
+          }
         }
       }
     },
@@ -599,7 +602,7 @@ CmdStanProcs <- R6::R6Class(
       }
       for (line in out) {
         private$proc_output_[[id]] <- c(private$proc_output_[[id]], line)
-        if (private$show_messages_) {        
+        if (private$show_stdout_messages_) {        
           cat(line, collapse = "\n")
         }
       }
@@ -629,7 +632,8 @@ CmdStanProcs <- R6::R6Class(
     proc_output_ = list(),
     proc_error_ouput_ = list(),
     total_time_ = numeric(),
-    show_messages_ = TRUE
+    show_stderr_messages_ = TRUE,
+    show_stdout_messages_ = TRUE
   )
 )
 

--- a/R/run.R
+++ b/R/run.R
@@ -589,9 +589,7 @@ CmdStanProcs <- R6::R6Class(
       if (length(err_out)) {
         for (err_line in err_out) {
           private$proc_output_[[id]] <- c(private$proc_output_[[id]], err_line)
-          if (private$show_messages_) {
-            message("Chain ", id, " ", err_line)
-          }
+          message("Chain ", id, " ", err_line)
         }
       }
     },
@@ -601,7 +599,9 @@ CmdStanProcs <- R6::R6Class(
       }
       for (line in out) {
         private$proc_output_[[id]] <- c(private$proc_output_[[id]], line)
-        cat(line, collapse = "\n")
+        if (private$show_messages_) {        
+          cat(line, collapse = "\n")
+        }
       }
       invisible(self)
     },

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -9,7 +9,7 @@
 #'       the appendices in the CmdStan manual for details on using these formats.
 #'   * `seed`: (positive integer) A seed for the (P)RNG to pass to CmdStan.
 #'   * `refresh`: (non-negative integer) The number of iterations between
-#'   printed screen updates.
+#'   printed screen updates. If `refresh = 0`, only error messages will be printed.
 #'   * `init`: (multiple options) The initialization method for the parameters block:
 #'     - A real number `x>0` initializes randomly between `[-x,x]` (on the
 #'       *unconstrained* parameter space);

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -49,7 +49,7 @@ the appendices in the CmdStan manual for details on using these formats.
 }
 \item \code{seed}: (positive integer) A seed for the (P)RNG to pass to CmdStan.
 \item \code{refresh}: (non-negative integer) The number of iterations between
-printed screen updates.
+printed screen updates. If \code{refresh = 0}, only error messages will be printed.
 \item \code{init}: (multiple options) The initialization method for the parameters block:
 \itemize{
 \item A real number \code{x>0} initializes randomly between \verb{[-x,x]} (on the

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -57,7 +57,7 @@ the appendices in the CmdStan manual for details on using these formats.
 }
 \item \code{seed}: (positive integer) A seed for the (P)RNG to pass to CmdStan.
 \item \code{refresh}: (non-negative integer) The number of iterations between
-printed screen updates.
+printed screen updates. If \code{refresh = 0}, only error messages will be printed.
 \item \code{init}: (multiple options) The initialization method for the parameters block:
 \itemize{
 \item A real number \code{x>0} initializes randomly between \verb{[-x,x]} (on the

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -55,7 +55,7 @@ the appendices in the CmdStan manual for details on using these formats.
 }
 \item \code{seed}: (positive integer) A seed for the (P)RNG to pass to CmdStan.
 \item \code{refresh}: (non-negative integer) The number of iterations between
-printed screen updates.
+printed screen updates. If \code{refresh = 0}, only error messages will be printed.
 \item \code{init}: (multiple options) The initialization method for the parameters block:
 \itemize{
 \item A real number \code{x>0} initializes randomly between \verb{[-x,x]} (on the

--- a/tests/testthat/test-fit-shared.R
+++ b/tests/testthat/test-fit-shared.R
@@ -248,3 +248,22 @@ test_that("CmdStanArgs erorrs if idx is out of proc_ids range", {
     "Index \\(5\\) exceeds number of CmdStan processes \\(4\\)."
   )
 })
+
+test_that("no output with refresh = 0", {
+  skip_on_cran()
+  mod <- testing_model("bernoulli")
+  data_list <- testing_data("bernoulli")
+  output <- utils::capture.output(tmp <- mod$variational(data = data_list))
+  expect_gt(length(output), 1)
+  output <- utils::capture.output(tmp <- mod$optimize(data = data_list))
+  expect_gt(length(output), 1)
+  output <- utils::capture.output(tmp <- mod$sample(data = data_list, chains = 1))
+  expect_gt(length(output), 1)
+
+  output <- utils::capture.output(tmp <- mod$variational(data = data_list, refresh = 0))
+  expect_equal(length(output), 1)
+  output <- utils::capture.output(tmp <- mod$optimize(data = data_list, refresh = 0))
+  expect_equal(length(output), 1)
+  output <- utils::capture.output(tmp <- mod$sample(data = data_list, refresh = 0, chains = 1))
+  expect_equal(length(output), 3)
+})


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The newton optimization method does not respect the refresh arg. This PR ignores all stdout when refresh = 0, which seems logical to me as the only reason someone would use refresh = 0, is when they do not want any info printed.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Univ. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
