### PR TITLE
don't echo the cmd when using cmdstan_[summary/diagnose]

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -171,7 +171,6 @@ CmdStanRun <- R6::R6Class(
         command = target_exe,
         args = c(self$output_files(include_failed = FALSE), flags),
         wd = cmdstan_path(),
-        echo_cmd = FALSE,
         echo = TRUE,
         error_on_status = TRUE
       )

--- a/R/run.R
+++ b/R/run.R
@@ -171,7 +171,7 @@ CmdStanRun <- R6::R6Class(
         command = target_exe,
         args = c(self$output_files(include_failed = FALSE), flags),
         wd = cmdstan_path(),
-        echo_cmd = TRUE,
+        echo_cmd = FALSE,
         echo = TRUE,
         error_on_status = TRUE
       )


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Sets `echo_cmd = FALSE` when using `processx::run()` for `$cmdstan_summary()` and `cmdstan_diagnose()`. There's really no need for us to ever display the command for these methods, it just adds more clutter to the output. 

@mike-lawrence is this what you meant by a "quiet" option in #341? It's still not super "quiet" without echo-ing the command but any quieter and there will be zero printed output which would defeat the purpose of calling it. Or did you really want zero printed output? Or am I totally misunderstanding? ;)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
