### PR TITLE
new line after message about max_rows

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -127,7 +127,7 @@ CmdStanFit <- R6::R6Class(
       print(out, row.names=FALSE)
       if (max_rows < total_rows) {
         cat("\n # showing", max_rows, "of", total_rows,
-            "rows (change via 'max_rows' argument)")
+            "rows (change via 'max_rows' argument)\n")
       }
       invisible(self)
     },


### PR DESCRIPTION
fixes #402

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

For the print method, adds a new line after the message about using the `max_rows` argument to print more rows.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
