### PR TITLE
only look for "PCH file" not full message

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -505,10 +505,13 @@ compile_method <- function(quiet = TRUE,
     spinner = quiet && interactive(),
     stderr_line_callback = function(x,p) {
       if (!startsWith(x, paste0(make_cmd(), ": *** No rule to make target"))) message(x)
-      if (grepl("PCH file uses an older PCH format that is no longer supported", x, fixed = TRUE)
-          || grepl("PCH file built from a different branch", x, fixed = TRUE)) {
-        warning("Cmdstan encountered an issue with an outdated precompiled header (PCH). Run rebuild_cmdstan() to rebuild the PCH files.\n",
-        "If the issue persists please open a bug report.")
+      if (grepl("PCH file", x)) {
+        warning(
+          "CmdStan encountered an issue with an outdated precompiled header (PCH). ",
+          "Please run rebuild_cmdstan() to rebuild the PCH files.\n",
+          "If the issue persists please open a bug report.",
+          call. = FALSE
+        )
       }
     },
     error_on_status = FALSE

--- a/R/model.R
+++ b/R/model.R
@@ -504,11 +504,13 @@ compile_method <- function(quiet = TRUE,
     echo_cmd = is_verbose_mode(),
     spinner = quiet && interactive(),
     stderr_line_callback = function(x,p) {
-      if (!startsWith(x, paste0(make_cmd(), ": *** No rule to make target"))) message(x)
+      if (!startsWith(x, paste0(make_cmd(), ": *** No rule to make target"))) {
+        message(x)
+      }
       if (grepl("PCH file", x)) {
         warning(
-          "CmdStan encountered an issue with an outdated precompiled header (PCH). ",
-          "Please run rebuild_cmdstan() to rebuild the PCH files.\n",
+          "CmdStan's precompiled header (PCH) files may need to be rebuilt.\n",
+          "If your model failed to compile please run rebuild_cmdstan().\n",
           "If the issue persists please open a bug report.",
           call. = FALSE
         )


### PR DESCRIPTION
fixes #400

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

When detecting problems with the precompiled header, instead of looking for the full message just look for "PCH file" to hopefully catch more cases. We saw an [example on the forum](https://discourse.mc-stan.org/t/struggling-to-get-cmdstan-working-on-mac-os-big-sur/19774/4?u=jonah) where the error message contained "PCH file" but wasn't the same as the full messages we were looking for. 

@rok-cesnovar Is it possible for "PCH file" to appear in a different message that we wouldn't want to catch? If so then maybe we don't want to make this switch, but I'm thinking that's very unlikely right? Just in case, I made the warning message slightly more speculative. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
