### PR TITLE
fix r cmd check NOTE about assignment to global env for knitr

### DIFF
--- a/R/knitr.R
+++ b/R/knitr.R
@@ -80,7 +80,7 @@ eng_cmdstan <- function(options) {
     }
     file <- write_stan_file(options$code, dir = dir)
     mod <- cmdstan_model(file)
-    assign(output_var, mod, envir = knitr::knit_global())
+    assign(output_var, mod, envir = cmdstanr_knitr_env())
   }
   options$engine <- "stan" # for syntax highlighting
   code <- paste(options$code, collapse = "\n")

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,12 +1,3 @@
-.onAttach <- function(...) {
-  startup_messages()
-}
-
-.onLoad <- function(...) {
-  cmdstanr_initialize()
-}
-
-
 startup_messages <- function() {
   packageStartupMessage("This is cmdstanr version ", utils::packageVersion("cmdstanr"))
   packageStartupMessage("- Online documentation and vignettes at mc-stan.org/cmdstanr")
@@ -64,4 +55,24 @@ cmdstanr_initialize <- function() {
     .cmdstanr$TEMP_DIR <- tempdir(check = TRUE)
   }
   invisible(TRUE)
+}
+
+cmdstanr_knitr_env_function_generator <- function(env1) {
+  function(env2 = NULL) {
+    if (!is.null(env2)) {
+      env1 <<- env2
+    }
+    invisible(env1)
+  }
+}
+cmdstanr_knitr_env <- cmdstanr_knitr_env_function_generator(new.env())
+
+
+.onAttach <- function(...) {
+  startup_messages()
+}
+
+.onLoad <- function(...) {
+  cmdstanr_knitr_env(knitr::knit_global())
+  cmdstanr_initialize()
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes a Note from R cmd check that I've been ignoring for a while but we need to fix before submitting to CRAN: 

```
❯ checking R code for possible problems ... NOTE
  Found the following assignments to the global environment:
  File ‘cmdstanr/R/knitr.R’:
    assign(output_var, mod, envir = knitr::knit_global())
```

This is required for the knitr engine so we can't fix this by not doing the assignment. To get around the NOTE I borrowed an idea from https://github.com/yihui/knitr/issues/1824#issuecomment-647333232 to create a function that returns the environment and gets populated with the knitr::knit_global() during .onLoad(). 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
