### PR TITLE
Add GITHUB_PAT for repeated access to Github API and a CmdStan tarball check

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -87,6 +87,7 @@ jobs:
           remotes::install_cran("rcmdcheck")
           install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
           install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
+          install.packages("curl")
           cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -30,6 +30,7 @@ jobs:
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      NOT_CRAN: true
 
     steps:
       - uses: n1hility/cancel-previous-runs@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -87,7 +87,7 @@ jobs:
           remotes::install_cran("rcmdcheck")
           install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
           install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
-          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.25.0/cmdstan-2.25.0.tar.gz")
+          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
         shell: Rscript {0}
 
       - name: Session info

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -59,7 +59,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install -y openmpi-bin
-          echo "CMDSTANR_RUN_MPI_TESTS=TRUE" >> $GITHUB_ENV
 
       - uses: r-lib/actions/setup-r@master
         with:

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -30,6 +30,8 @@ jobs:
       - name: Install Ubuntu dependencies
         run: |
           sudo apt-get install libcurl4-openssl-dev
+          sudo apt-get install -y openmpi-bin
+          echo "CMDSTANR_RUN_MPI_TESTS=TRUE" >> $GITHUB_ENV
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -12,7 +12,7 @@ jobs:
   test-coverage-ubuntu:
     name: "Linux"
     if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       NOT_CRAN: true

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -15,6 +15,7 @@ jobs:
     runs-on: ubuntu-16.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      NOT_CRAN: true
     steps:
       - uses: n1hility/cancel-previous-runs@v2
         with:
@@ -29,8 +30,6 @@ jobs:
       - name: Install Ubuntu dependencies
         run: |
           sudo apt-get install libcurl4-openssl-dev
-          sudo apt-get install -y openmpi-bin
-          echo "CMDSTANR_RUN_MPI_TESTS=TRUE" >> $GITHUB_ENV
 
       - name: Query dependencies
         run: |
@@ -64,6 +63,7 @@ jobs:
     runs-on: windows-latest
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      NOT_CRAN: true
     steps:
       - uses: actions/checkout@v2
 

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -31,8 +31,6 @@ jobs:
         run: |
           sudo apt-get install libcurl4-openssl-dev
           sudo apt install openmpi-bin openmpi-common openmpi-doc libopenmpi-dev
-          mpicxx --version
-          echo "CMDSTANR_RUN_MPI_TESTS=TRUE" >> $GITHUB_ENV
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -29,8 +29,8 @@ jobs:
 
       - name: Install Ubuntu dependencies
         run: |
-          sudo apt-get install libcurl4-openssl-dev
-          sudo apt install openmpi-bin openmpi-common openmpi-doc libopenmpi-dev
+          sudo apt-get install -y libcurl4-openssl-dev
+          sudo apt-get install -y openmpi-bin openmpi-common openmpi-doc libopenmpi-dev
 
       - name: Query dependencies
         run: |
@@ -47,7 +47,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages(c("posterior", "cmdstanr", "remotes"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
+          install.packages(c("posterior", "cmdstanr", "remotes", "curl"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
           cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")
@@ -96,7 +96,7 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages(c("posterior", "cmdstanr", "remotes"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
+          install.packages(c("posterior", "cmdstanr", "remotes", "curl"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
           cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -48,7 +48,7 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages(c("posterior", "cmdstanr", "remotes"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.25.0/cmdstan-2.25.0.tar.gz")
+          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")
           remotes::install_cran("gridExtra")
@@ -96,7 +96,7 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages(c("posterior", "cmdstanr", "remotes"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.25.0/cmdstan-2.25.0.tar.gz")
+          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")
           remotes::install_cran("gridExtra")

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -12,7 +12,7 @@ jobs:
   test-coverage-ubuntu:
     name: "Linux"
     if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-16.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       NOT_CRAN: true
@@ -30,7 +30,8 @@ jobs:
       - name: Install Ubuntu dependencies
         run: |
           sudo apt-get install libcurl4-openssl-dev
-          sudo apt-get install -y openmpi-bin
+          sudo apt install openmpi-bin openmpi-common openmpi-doc libopenmpi-dev
+          mpicxx --version
           echo "CMDSTANR_RUN_MPI_TESTS=TRUE" >> $GITHUB_ENV
 
       - name: Query dependencies
@@ -56,7 +57,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Test coverage
-        run: covr::codecov(type = "all", function_exclusions = "sample_mpi")
+        run: covr::codecov(type = "all")
         shell: Rscript {0}
 
   test-coverage-windows:

--- a/.github/workflows/cmdstan-tarball-check.yaml
+++ b/.github/workflows/cmdstan-tarball-check.yaml
@@ -25,6 +25,7 @@ jobs:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       CMDSTAN_TEST_TARBALL_URL: ${{ github.event.inputs.tarball_url }}
+      NOT_CRAN: true
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/cmdstan-tarball-check.yaml
+++ b/.github/workflows/cmdstan-tarball-check.yaml
@@ -48,8 +48,6 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install -y openmpi-bin
-          echo "CMDSTANR_RUN_MPI_TESTS=TRUE" >> $GITHUB_ENV
-
       - uses: r-lib/actions/setup-r@master
         with:
           r-version: ${{ matrix.config.r }}

--- a/.github/workflows/cmdstan-tarball-check.yaml
+++ b/.github/workflows/cmdstan-tarball-check.yaml
@@ -1,0 +1,109 @@
+on: 
+  workflow_dispatch:
+    inputs:
+      tarball_url:
+        description: 'CmdStan tarball URL to test with.'
+        required: true
+        default: 'latest'
+
+name: Custom CmdStan tarball unit tests
+
+jobs:
+  tarball-check:
+    runs-on: ${{ matrix.config.os }}
+
+    name: ${{ matrix.config.os }} (${{ matrix.config.r }})
+
+    strategy:
+      fail-fast: true
+      matrix:
+        config:
+          - {os: macOS-latest,   r: 'release'}
+          - {os: windows-latest, r: 'release'}
+          - {os: ubuntu-20.04,   r: 'release'}
+    env:
+      R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
+      GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
+      CMDSTAN_TEST_TARBALL_URL: ${{ github.event.inputs.tarball_url }}
+
+    steps:
+      - uses: actions/checkout@v2
+
+      - name: Set path for RTools 4.0
+        if: runner.os == 'Windows'
+        run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
+      
+      - name: Install mingw32-make and check toolchain path
+        if: runner.os == 'Windows'
+        run: |
+          pacman -Syu mingw-w64-x86_64-make --noconfirm
+          g++ --version
+          Get-Command g++ | Select-Object -ExpandProperty Definition
+          mingw32-make --version
+          Get-Command mingw32-make | Select-Object -ExpandProperty Definition
+        shell: powershell
+      
+      - name: Install MPI
+        if: runner.os == 'Linux'
+        run: |
+          sudo apt-get install -y openmpi-bin
+          echo "CMDSTANR_RUN_MPI_TESTS=TRUE" >> $GITHUB_ENV
+
+      - uses: r-lib/actions/setup-r@master
+        with:
+          r-version: ${{ matrix.config.r }}
+
+      - uses: r-lib/actions/setup-pandoc@master
+
+      - name: Query dependencies
+        run: |
+          install.packages('remotes')
+          saveRDS(remotes::dev_package_deps(dependencies = TRUE), ".github/depends.Rds", version = 2)
+          writeLines(sprintf("R-%i.%i", getRversion()$major, getRversion()$minor), ".github/R-version")
+        shell: Rscript {0}
+
+      - name: Cache R packages
+        if: runner.os != 'Windows'
+        uses: actions/cache@v1
+        with:
+          path: ${{ env.R_LIBS_USER }}
+          key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
+          restore-keys: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-
+
+      - name: Install dependencies
+        run: |
+          remotes::install_deps(dependencies = TRUE)
+          remotes::install_cran("rcmdcheck")
+          install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
+          install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
+          if (Sys.getenv("CMDSTAN_TEST_TARBALL_URL") == "latest") {
+            cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
+          } else {
+            cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, release_url = "${{ github.event.inputs.tarball_url }}")
+          }
+        shell: Rscript {0}
+
+      - name: Session info
+        run: |
+          options(width = 100)
+          pkgs <- installed.packages()[, "Package"]
+          sessioninfo::session_info(pkgs, include_base = TRUE)
+        shell: Rscript {0}
+
+      - name: Check
+        env:
+          _R_CHECK_CRAN_INCOMING_: false
+        run: rcmdcheck::rcmdcheck(args = c("--no-manual", "--as-cran", "--ignore-vignettes"), build_args = c("--no-build-vignettes"), error_on = "warning", check_dir = "check")
+        shell: Rscript {0}
+
+      - name: Show testthat output
+        if: always()
+        run: find check -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload check results
+        if: failure()
+        uses: actions/upload-artifact@master
+        with:
+          name: ${{ runner.os }}-r${{ matrix.config.r }}-results
+          path: check

--- a/R/install.R
+++ b/R/install.R
@@ -196,7 +196,8 @@ install_cmdstan <- function(dir = NULL,
         file.remove(dest_macos_inc)
         utils::download.file(url = macos_inc,
                              destfile = dest_macos_inc,
-                             quiet = quiet)
+                             quiet = quiet,
+                             headers = github_auth_token())
       }),
       silent = TRUE
     )
@@ -286,6 +287,16 @@ check_install_dir <- function(dir_cmdstan, overwrite = FALSE) {
   TRUE
 }
 
+github_auth_token <- function() {
+  github_pat <- Sys.getenv("GITHUB_PAT")
+  if (nzchar(access_token)) {
+    auth_token <- c(Authorization = paste0("token ", github_pat))
+  } else {
+    auth_token <- NULL
+  }
+  auth_token
+}
+
 # construct url for download from cmdstan version number
 github_download_url <- function(version_number) {
   base_url <- "https://github.com/stan-dev/cmdstan/releases/download/"
@@ -311,13 +322,15 @@ download_with_retries <- function(download_url,
                                   retries = 5,
                                   pause_sec = 5,
                                   quiet = TRUE) {
+        
     download_rc <- 1
     while (retries > 0 && download_rc != 0) {
       try(
         suppressWarnings(
           download_rc <- utils::download.file(url = download_url,
                                             destfile = destination_file,
-                                            quiet = quiet)
+                                            quiet = quiet,
+                                            headers = github_auth_token())
         ),
         silent = TRUE
       )

--- a/R/install.R
+++ b/R/install.R
@@ -289,7 +289,7 @@ check_install_dir <- function(dir_cmdstan, overwrite = FALSE) {
 
 github_auth_token <- function() {
   github_pat <- Sys.getenv("GITHUB_PAT")
-  if (nzchar(access_token)) {
+  if (nzchar(github_pat)) {
     auth_token <- c(Authorization = paste0("token ", github_pat))
   } else {
     auth_token <- NULL

--- a/tests/testthat/helper-envvars-and-paths.R
+++ b/tests/testthat/helper-envvars-and-paths.R
@@ -10,6 +10,16 @@ not_on_cran <- function() {
   on_ci() || identical(Sys.getenv("NOT_CRAN"), "true")
 }
 
+mpi_toolchain_present <- function() {
+  tryCatch(
+    processx::run(command = "mpicxx", args = "--version")$status == 0 &&
+    processx::run(command = "mpiexec", args = "--version")$status == 0,
+    error=function(cond) {
+      FALSE
+    }
+  )
+}
+
 delete_extensions <- function() {
   if (os_is_windows()) {
     c(".exe", ".o", ".hpp")

--- a/tests/testthat/helper-envvars-and-paths.R
+++ b/tests/testthat/helper-envvars-and-paths.R
@@ -10,10 +10,6 @@ not_on_cran <- function() {
   on_ci() || identical(Sys.getenv("NOT_CRAN"), "true")
 }
 
-test_release_url <- function() {
-  "https://github.com/stan-dev/cmdstan/releases/download/v2.25.0/cmdstan-2.25.0.tar.gz"
-}
-
 delete_extensions <- function() {
   if (os_is_windows()) {
     c(".exe", ".o", ".hpp")

--- a/tests/testthat/test-csv.R
+++ b/tests/testthat/test-csv.R
@@ -310,6 +310,8 @@ test_that("remaining_columns_to_read() works", {
   expect_equal(remaining_columns_to_read(NULL, c("a", "b", "c"), NULL), NULL)
   expect_equal(remaining_columns_to_read(NULL, NULL, c("a", "b", "c")), c("a", "b", "c"))
   expect_equal(remaining_columns_to_read(c("a", "b", "c"), c("a", "b", "c"), NULL), "")
+  expect_equal(remaining_columns_to_read(c(""), c("a", "b", "c"), NULL), "")
+  expect_equal(remaining_columns_to_read(c("", "a"), c("a", "b", "c"), NULL), "")
   expect_equal(remaining_columns_to_read(c("a", "b", "c"), NULL, c("a", "b", "c")), c("a", "b", "c"))
 
   # with vector and matrix variables

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -10,7 +10,6 @@ if (not_on_cran()) {
 test_that("install_cmdstan() successfully installs cmdstan", {
   skip_on_cran()
   skip_if_offline()
-  if (os_is_windows()) skip_on_covr()
   if (getRversion() < '3.5.0') {
     dir <- tempdir()
   } else {
@@ -31,7 +30,6 @@ test_that("install_cmdstan() successfully installs cmdstan", {
 test_that("install_cmdstan() errors if installation already exists", {
   skip_if_offline()
   skip_on_cran()
-  if (os_is_windows()) skip_on_covr()
   if (not_on_cran()) {
     # want to test passing NULL to install_cmdstan but need a real dir to
     # check in dir.exists() below so also create dir_check
@@ -56,7 +54,6 @@ test_that("install_cmdstan() errors if installation already exists", {
 test_that("install_cmdstan() errors if it times out", {
   skip_on_cran()
   skip_if_offline()
-  if (os_is_windows()) skip_on_covr()
   if (getRversion() < '3.5.0') {
     dir <- tempdir()
   } else {
@@ -108,7 +105,6 @@ test_that("install_cmdstan() errors if invalid version or URL", {
 test_that("install_cmdstan() works with version and release_url", {
   skip_on_cran()
   skip_if_offline()
-  if (os_is_windows()) skip_on_covr()
   if (getRversion() < '3.5.0') {
     dir <- tempdir()
   } else {
@@ -245,7 +241,6 @@ test_that("toolchain checks without fixes on Windows with RTools 4.0 work", {
 
 test_that("clean and rebuild works", {
   skip_on_cran()
-  if (os_is_windows()) skip_on_covr()
   expect_output(
     rebuild_cmdstan(),
     paste0("CmdStan v", cmdstan_version(), " built"),

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -122,7 +122,8 @@ test_that("install_cmdstan() works with version and release_url", {
       "Compiling, linking C++ code",
       fixed = TRUE
     ),
-    "Finished installing CmdStan"
+    "Finished installing CmdStan",
+    fixed = TRUE
   )
   expect_warning(
     expect_message(
@@ -134,9 +135,11 @@ test_that("install_cmdstan() works with version and release_url", {
         "Compiling, linking C++ code",
         fixed = TRUE
       ),
-      "Finished installing CmdStan"
+      "Finished installing CmdStan",
+    fixed = TRUE
     ),
-    "version and release_url shouldn't both be specified"
+    "version and release_url shouldn't both be specified",
+    fixed = TRUE
   )
   expect_true(dir.exists(file.path(dir, "cmdstan-2.23.0")))
   set_cmdstan_path(cmdstan_default_path())
@@ -245,7 +248,8 @@ test_that("clean and rebuild works", {
   if (os_is_windows()) skip_on_covr()
   expect_output(
     rebuild_cmdstan(),
-    paste0("CmdStan v", cmdstan_version(), " built")
+    paste0("CmdStan v", cmdstan_version(), " built"),
+    fixed = TRUE
   )
 })
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,5 +1,12 @@
 context("install")
 
+if (not_on_cran()) {
+  cmdstan_test_tarball_url <- Sys.getenv("CMDSTAN_TEST_TARBALL_URL")
+  if (!nzchar(cmdstan_test_tarball_url)) {
+    cmdstan_test_tarball_url <- NULL
+  }
+}
+
 test_that("install_cmdstan() successfully installs cmdstan", {
   skip_on_cran()
   skip_if_offline()
@@ -9,10 +16,6 @@ test_that("install_cmdstan() successfully installs cmdstan", {
   } else {
     dir <- tempdir(check = TRUE)
   }
-  cmdstan_test_tarball_url <- Sys.getenv("CMDSTAN_TEST_TARBALL_URL")
-  if (!nzchar(cmdstan_test_tarball_url)) {
-    cmdstan_test_tarball_url <- NULL
-  }
   expect_message(
     expect_output(
       install_cmdstan(dir = dir, cores = 2, quiet = FALSE, overwrite = TRUE,
@@ -20,7 +23,8 @@ test_that("install_cmdstan() successfully installs cmdstan", {
       "Compiling, linking C++ code",
       fixed = TRUE
     ),
-    "CmdStan path set"
+    "CmdStan path set",
+    fixed = TRUE
   )
 })
 
@@ -44,7 +48,8 @@ test_that("install_cmdstan() errors if installation already exists", {
   expect_warning(
     install_cmdstan(dir = install_dir, overwrite = FALSE,
                     release_url = cmdstan_test_tarball_url),
-    "An installation already exists"
+    "An installation already exists",
+    fixed = TRUE
   )
 })
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -240,7 +240,7 @@ test_that("clean and rebuild works", {
   if (os_is_windows()) skip_on_covr()
   expect_output(
     rebuild_cmdstan(),
-    paste0("CmdStan v", latest_released_version(), " built")
+    paste0("CmdStan v", cmdstan_version(), " built")
   )
 })
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -9,10 +9,11 @@ test_that("install_cmdstan() successfully installs cmdstan", {
   } else {
     dir <- tempdir(check = TRUE)
   }
+  cmdstan_test_tarball_url <- getOption("CMDSTAN_TEST_TARBALL_URL")
   expect_message(
     expect_output(
       install_cmdstan(dir = dir, cores = 2, quiet = FALSE, overwrite = TRUE,
-                      release_url = test_release_url()),
+                      release_url = cmdstan_test_tarball_url),
       "Compiling, linking C++ code",
       fixed = TRUE
     ),
@@ -39,7 +40,7 @@ test_that("install_cmdstan() errors if installation already exists", {
   }
   expect_warning(
     install_cmdstan(dir = install_dir, overwrite = FALSE,
-                    release_url = test_release_url()),
+                    release_url = cmdstan_test_tarball_url),
     "An installation already exists"
   )
 })
@@ -59,7 +60,7 @@ test_that("install_cmdstan() errors if it times out", {
   expect_warning(
     expect_message(
       install_cmdstan(dir = dir, timeout = 1, quiet = TRUE, overwrite = dir_exists,
-                      release_url = test_release_url()),
+                      release_url = cmdstan_test_tarball_url),
       if (dir_exists) "* Removing the existing installation" else "* * Installing CmdStan from https://github.com",
       fixed = TRUE
     ),
@@ -71,7 +72,7 @@ test_that("install_cmdstan() errors if it times out", {
   expect_warning(
     expect_message(
       install_cmdstan(dir = dir, timeout = 1, quiet = FALSE, overwrite = dir_exists,
-                      release_url = test_release_url()),
+                      release_url = cmdstan_test_tarball_url),
       if (dir_exists) "* Removing the existing installation" else "* * Installing CmdStan from https://github.com",
       fixed = TRUE
     ),

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -9,7 +9,10 @@ test_that("install_cmdstan() successfully installs cmdstan", {
   } else {
     dir <- tempdir(check = TRUE)
   }
-  cmdstan_test_tarball_url <- getOption("CMDSTAN_TEST_TARBALL_URL")
+  cmdstan_test_tarball_url <- Sys.getenv("CMDSTAN_TEST_TARBALL_URL")
+  if (!nzchar(cmdstan_test_tarball_url)) {
+    cmdstan_test_tarball_url <- NULL
+  }
   expect_message(
     expect_output(
       install_cmdstan(dir = dir, cores = 2, quiet = FALSE, overwrite = TRUE,

--- a/tests/testthat/test-model-sample_mpi.R
+++ b/tests/testthat/test-model-sample_mpi.R
@@ -2,7 +2,7 @@ context("model-sample_mpi")
 
 test_that("sample_mpi() works", {
   skip_on_cran()
-  skip_if(!nzchar(Sys.getenv("CMDSTANR_RUN_MPI_TESTS")))
+  skip_if(!mpi_toolchain_present())
   mpi_file <- write_stan_file("
   functions {
     vector test(vector beta, vector theta, real[] x, int[] y) {
@@ -25,7 +25,12 @@ test_that("sample_mpi() works", {
     vector[20] c = map_rect(test, a, b, x, y);
   }
   ")
-  cpp_options = list(cxx="mpicxx", stan_mpi = TRUE, tbb_cxx_type="gcc")
+  if (os_is_macos()) {
+    tbb_cxx_type <- "clang"
+  } else {
+    tbb_cxx_type <- "gcc"
+  }
+  cpp_options = list(cxx="mpicxx", stan_mpi = TRUE, tbb_cxx_type=tbb_cxx_type)
   mod_mpi <- cmdstan_model(mpi_file, cpp_options = cpp_options)
   utils::capture.output(
     f <- mod_mpi$sample_mpi(chains = 1, mpi_args = list("n" = 1))

--- a/tests/testthat/test-model-sample_mpi.R
+++ b/tests/testthat/test-model-sample_mpi.R
@@ -2,7 +2,6 @@ context("model-sample_mpi")
 
 test_that("sample_mpi() works", {
   skip_on_cran()
-  skip_on_covr()
   skip_if(!nzchar(Sys.getenv("CMDSTANR_RUN_MPI_TESTS")))
   mpi_file <- write_stan_file("
   functions {


### PR DESCRIPTION
#### Summary

Fixes #380 and cleans up our CI: 

- add the use of a Github authentication token for API requests
- always automatically test the latest release without the need to update the URL in Github Actions workflow file (doable now that we added the above)
- we now test MPI in codecov as well
- skip_if_offline checks in some tests required the curl package but was not installed. we now install it manually
- install tests are now also run on codecov

Any user that would get their IP restricted due to too much version checks or other Github API requests can use the new environment variable GITHUB_PAT (personal access token).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar, Uni. of Ljubljana

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
