### PR TITLE
Faster CSV read with multiple chains

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -688,9 +688,13 @@ check_csv_metadata_matches <- function(a, b) {
 
 bind_list_of_draws_array <- function(draws, along = "chain") {
   if (!is.null(draws) && length(draws) > 0) {
-    draws <- lapply(draws, posterior::as_draws_array)
-    draws[["along"]] <- along
-    draws <- do.call(posterior::bind_draws, draws)
+    if (length(draws) > 1) {
+      draws <- lapply(draws, posterior::as_draws_array)
+      draws[["along"]] <- along
+      draws <- do.call(posterior::bind_draws, draws)
+    } else {
+      draws <- posterior::as_draws_array(draws[[1]])
+    }    
   } else {
     draws <- NULL
   }

--- a/R/csv.R
+++ b/R/csv.R
@@ -400,8 +400,8 @@ CmdStanMCMC_CSV <- R6::R6Class(
   public = list(
     initialize = function(csv_contents, files, check_diagnostics = TRUE) {
       if (check_diagnostics) {
-        check_divergences(csv_contents)
-        check_sampler_transitions_treedepth(csv_contents)
+        check_divergences(csv_contents$post_warmup_sampler_diagnostics)
+        check_sampler_transitions_treedepth(csv_contents$post_warmup_sampler_diagnostics, csv_contents$metadata)
       }
       private$output_files_ <- files
       private$metadata_ <- csv_contents$metadata

--- a/R/fit.R
+++ b/R/fit.R
@@ -708,17 +708,12 @@ CmdStanMCMC <- R6::R6Class(
       } else {
         if (self$runset$args$validate_csv) {
           fixed_param <- runset$args$method_args$fixed_param
-          csv_contents <- read_cmdstan_csv(
-            self$output_files(),
-            variables = "",
-            sampler_diagnostics =
-             if (!fixed_param) c("treedepth__", "divergent__") else ""
-          )
+          private$read_csv_(variables = "",
+                           sampler_diagnostics = if (!fixed_param) c("treedepth__", "divergent__") else "")
           if (!fixed_param) {
-            check_divergences(csv_contents)
-            check_sampler_transitions_treedepth(csv_contents)
+            check_divergences(private$sampler_diagnostics_)
+            check_sampler_transitions_treedepth(private$sampler_diagnostics_, private$metadata_$max_treedepth)
           }
-          private$metadata_ <- csv_contents$metadata
         }
       }
     },

--- a/R/fit.R
+++ b/R/fit.R
@@ -712,7 +712,7 @@ CmdStanMCMC <- R6::R6Class(
                            sampler_diagnostics = if (!fixed_param) c("treedepth__", "divergent__") else "")
           if (!fixed_param) {
             check_divergences(private$sampler_diagnostics_)
-            check_sampler_transitions_treedepth(private$sampler_diagnostics_, private$metadata_$max_treedepth)
+            check_sampler_transitions_treedepth(private$sampler_diagnostics_, private$metadata_)
           }
         }
       }

--- a/R/fit.R
+++ b/R/fit.R
@@ -782,38 +782,54 @@ CmdStanMCMC <- R6::R6Class(
       private$metadata_ <- csv_contents$metadata
 
       if (!is.null(csv_contents$post_warmup_draws)) {
-        missing_variables <- !(posterior::variables(csv_contents$post_warmup_draws) %in% posterior::variables(private$draws_))
-        private$draws_ <- posterior::bind_draws(
-          private$draws_,
-          csv_contents$post_warmup_draws[,,missing_variables],
-          along="variable"
-        )
+        if (is.null(private$draws_)) {
+          private$draws_ <- csv_contents$post_warmup_draws
+        } else {
+          missing_variables <- !(posterior::variables(csv_contents$post_warmup_draws) %in% posterior::variables(private$draws_))
+          private$draws_ <- posterior::bind_draws(
+            private$draws_,
+            csv_contents$post_warmup_draws[,,missing_variables],
+            along="variable"
+          )
+        }        
       }
       if (!is.null(csv_contents$post_warmup_sampler_diagnostics)) {
-        missing_variables <- !(posterior::variables(csv_contents$post_warmup_sampler_diagnostics) %in% posterior::variables(private$sampler_diagnostics_))
-        private$sampler_diagnostics_ <- posterior::bind_draws(
-          private$sampler_diagnostics_,
-          csv_contents$post_warmup_sampler_diagnostics[,,missing_variables],
-          along="variable"
-        )
+        if (is.null(private$sampler_diagnostics_)) {
+          private$sampler_diagnostics_ <- csv_contents$post_warmup_sampler_diagnostics
+        } else {
+          missing_variables <- !(posterior::variables(csv_contents$post_warmup_sampler_diagnostics) %in% posterior::variables(private$sampler_diagnostics_))
+          private$sampler_diagnostics_ <- posterior::bind_draws(
+            private$sampler_diagnostics_,
+            csv_contents$post_warmup_sampler_diagnostics[,,missing_variables],
+            along="variable"
+          )
+        }
       }
       if (!is.null(csv_contents$metadata$save_warmup)
          && csv_contents$metadata$save_warmup) {
         if (!is.null(csv_contents$warmup_draws)) {
-          missing_variables <- !(posterior::variables(csv_contents$warmup_draws) %in% posterior::variables(private$warmup_draws_))
-          private$warmup_draws_ <- posterior::bind_draws(
-            private$warmup_draws_,
-            csv_contents$warmup_draws[,,missing_variables],
-            along="variable"
-          )
+          if (is.null(private$warmup_draws_)) {
+            private$warmup_draws_ <- csv_contents$warmup_draws
+          } else {
+            missing_variables <- !(posterior::variables(csv_contents$warmup_draws) %in% posterior::variables(private$warmup_draws_))
+            private$warmup_draws_ <- posterior::bind_draws(
+              private$warmup_draws_,
+              csv_contents$warmup_draws[,,missing_variables],
+              along="variable"
+            )
+          }
         }
         if (!is.null(csv_contents$warmup_sampler_diagnostics)) {
-          missing_variables <- !(posterior::variables(csv_contents$warmup_sampler_diagnostics) %in% posterior::variables(private$warmup_sampler_diagnostics_))
-          private$warmup_sampler_diagnostics_ <- posterior::bind_draws(
-            private$warmup_sampler_diagnostics_,
-            csv_contents$warmup_sampler_diagnostics[,,missing_variables],
-            along="variable"
-          )
+          if (is.null(private$warmup_sampler_diagnostics_)) {
+            private$warmup_sampler_diagnostics_ <- csv_contents$warmup_sampler_diagnostics
+          } else {
+            missing_variables <- !(posterior::variables(csv_contents$warmup_sampler_diagnostics) %in% posterior::variables(private$warmup_sampler_diagnostics_))
+            private$warmup_sampler_diagnostics_ <- posterior::bind_draws(
+              private$warmup_sampler_diagnostics_,
+              csv_contents$warmup_sampler_diagnostics[,,missing_variables],
+              along="variable"
+            )
+          }
         }
       }
       invisible(self)

--- a/R/utils.R
+++ b/R/utils.R
@@ -274,16 +274,16 @@ check_divergences <- function(post_warmup_sampler_diagnostics) {
   }
 }
 
-check_sampler_transitions_treedepth <- function(post_warmup_sampler_diagnostics, max_treedepth) {
+check_sampler_transitions_treedepth <- function(post_warmup_sampler_diagnostics, metadata) {
   if (!is.null(post_warmup_sampler_diagnostics)) {
     treedepth <- posterior::extract_variable_matrix(post_warmup_sampler_diagnostics, "treedepth__")
     num_of_draws <- length(treedepth)
-    max_treedepth_hit <- sum(treedepth >= max_treedepth)
+    max_treedepth_hit <- sum(treedepth >= metadata$max_treedepth)
     if (!is.na(max_treedepth_hit) && max_treedepth_hit > 0) {
       percentage_max_treedepth <- (max_treedepth_hit)/num_of_draws*100
       message(max_treedepth_hit, " of ", num_of_draws, " (", (format(round(percentage_max_treedepth, 0), nsmall = 1)), "%)",
-              " transitions hit the maximum treedepth limit of ", max_treedepth,
-              " or 2^", max_treedepth, "-1 leapfrog steps.\n",
+              " transitions hit the maximum treedepth limit of ", metadata$max_treedepth,
+              " or 2^", metadata$max_treedepth, "-1 leapfrog steps.\n",
               "Trajectories that are prematurely terminated due to this limit will result in slow exploration.\n",
               "Increasing the max_treedepth limit can avoid this at the expense of more computation.\n",
               "If increasing max_treedepth does not remove warnings, try to reparameterize the model.\n")

--- a/R/utils.R
+++ b/R/utils.R
@@ -253,9 +253,9 @@ set_num_threads <- function(num_threads) {
        call. = FALSE)
 }
 
-check_divergences <- function(csv_contents) {
-  if (!is.null(csv_contents$post_warmup_sampler_diagnostics)) {
-    divergences <- posterior::extract_variable_matrix(csv_contents$post_warmup_sampler_diagnostics, "divergent__")
+check_divergences <- function(post_warmup_sampler_diagnostics) {
+  if (!is.null(post_warmup_sampler_diagnostics)) {
+    divergences <- posterior::extract_variable_matrix(post_warmup_sampler_diagnostics, "divergent__")
     num_of_draws <- length(divergences)
     num_of_divergences <- sum(divergences)
     if (!is.na(num_of_divergences) && num_of_divergences > 0) {
@@ -274,11 +274,10 @@ check_divergences <- function(csv_contents) {
   }
 }
 
-check_sampler_transitions_treedepth <- function(csv_contents) {
-  if (!is.null(csv_contents$post_warmup_sampler_diagnostics)) {
-    treedepth <- posterior::extract_variable_matrix(csv_contents$post_warmup_sampler_diagnostics, "treedepth__")
+check_sampler_transitions_treedepth <- function(post_warmup_sampler_diagnostics, max_treedepth) {
+  if (!is.null(post_warmup_sampler_diagnostics)) {
+    treedepth <- posterior::extract_variable_matrix(post_warmup_sampler_diagnostics, "treedepth__")
     num_of_draws <- length(treedepth)
-    max_treedepth <- csv_contents$metadata$max_treedepth
     max_treedepth_hit <- sum(treedepth >= max_treedepth)
     if (!is.na(max_treedepth_hit) && max_treedepth_hit > 0) {
       percentage_max_treedepth <- (max_treedepth_hit)/num_of_draws*100

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -50,7 +50,7 @@ test_that("draws() works when gradually adding variables", {
   expect_equal(posterior::variables(draws_lp__), c("lp__"))
   expect_type(sampler_diagnostics, "double")
   expect_s3_class(sampler_diagnostics, "draws_array")
-  expect_equal(posterior::variables(sampler_diagnostics), c(c("accept_stat__", "stepsize__", "treedepth__", "n_leapfrog__", "divergent__", "energy__")))
+  expect_equal(posterior::variables(sampler_diagnostics), c(c("treedepth__", "divergent__", "accept_stat__", "stepsize__", "n_leapfrog__", "energy__")))
   draws_alpha <- fit$draws(variables = c("alpha"), inc_warmup = TRUE)
   expect_type(draws_alpha, "double")
   expect_s3_class(draws_alpha, "draws_array")

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -38,6 +38,29 @@ test_that("draws() stops for unkown variables", {
   )
 })
 
+test_that("draws() works when gradually adding variables", {
+  skip_on_cran()
+  fit <- testing_fit("logistic", method = "sample", refresh = 0,
+                     validate_csv = TRUE, save_warmup = TRUE)
+
+  draws_lp__ <- fit$draws(variables = c("lp__"), inc_warmup = TRUE)
+  sampler_diagnostics <- fit$sampler_diagnostics(inc_warmup = TRUE)
+  expect_type(draws_lp__, "double")
+  expect_s3_class(draws_lp__, "draws_array")
+  expect_equal(posterior::variables(draws_lp__), c("lp__"))
+  expect_type(sampler_diagnostics, "double")
+  expect_s3_class(sampler_diagnostics, "draws_array")
+  expect_equal(posterior::variables(sampler_diagnostics), c(c("accept_stat__", "stepsize__", "treedepth__", "n_leapfrog__", "divergent__", "energy__")))
+  draws_alpha <- fit$draws(variables = c("alpha"), inc_warmup = TRUE)
+  expect_type(draws_alpha, "double")
+  expect_s3_class(draws_alpha, "draws_array")
+  expect_equal(posterior::variables(draws_alpha), c("alpha"))
+  draws_beta <- fit$draws(variables = c("beta"), inc_warmup = TRUE)
+  expect_type(draws_beta, "double")
+  expect_s3_class(draws_beta, "draws_array")
+  expect_equal(posterior::variables(draws_beta), c("beta[1]", "beta[2]", "beta[3]"))
+})
+
 test_that("draws() method returns draws_array (reading csv works)", {
   skip_on_cran()
   draws <- fit_mcmc$draws()
@@ -273,3 +296,4 @@ test_that("loo errors if it can't find log lik variables", {
     fixed = TRUE
   )
 })
+

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -11,18 +11,18 @@ test_that("check_divergences() works", {
   csv_files <- c(test_path("resources", "csv", "model1-2-no-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
   output <- "14 of 100 \\(14.0%\\) transitions ended with a divergence."
-  expect_message(check_divergences(csv_contents$post_warmup_sampler_diagnostics), output)
+  expect_message(check_divergences(csv_output$post_warmup_sampler_diagnostics), output)
 
   csv_files <- c(test_path("resources", "csv", "model1-2-no-warmup.csv"),
                  test_path("resources", "csv", "model1-2-no-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
   output <- "28 of 200 \\(14.0%\\) transitions ended with a divergence."
-  expect_message(check_divergences(csv_contents$post_warmup_sampler_diagnostics), output)
+  expect_message(check_divergences(csv_output$post_warmup_sampler_diagnostics), output)
 
   csv_files <- c(test_path("resources", "csv", "model1-2-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
   output <- "1 of 100 \\(1.0%\\) transitions ended with a divergence."
-  expect_message(check_divergences(csv_contents$post_warmup_sampler_diagnostics), output)
+  expect_message(check_divergences(csv_output$post_warmup_sampler_diagnostics), output)
 
 
   fit_wramup_no_samples <- testing_fit("logistic", method = "sample",
@@ -32,7 +32,7 @@ test_that("check_divergences() works", {
                           save_warmup = TRUE,
                           validate_csv = FALSE)
   csv_output <- read_cmdstan_csv(fit_wramup_no_samples$output_files())
-  expect_message(check_divergences(csv_contents$post_warmup_sampler_diagnostics), regexp = NA)
+  expect_message(check_divergences(csv_output$post_warmup_sampler_diagnostics), regexp = NA)
 })
 
 test_that("check_sampler_transitions_treedepth() works", {
@@ -42,8 +42,8 @@ test_that("check_sampler_transitions_treedepth() works", {
   output <- "16 of 100 \\(16.0%\\) transitions hit the maximum treedepth limit of 5 or 2\\^5-1 leapfrog steps."
   expect_message(
     check_sampler_transitions_treedepth(
-      csv_contents$post_warmup_sampler_diagnostics,
-      csv_contents$metadata),
+      csv_output$post_warmup_sampler_diagnostics,
+      csv_output$metadata),
     output
   )
 
@@ -53,8 +53,8 @@ test_that("check_sampler_transitions_treedepth() works", {
   output <- "32 of 200 \\(16.0%\\) transitions hit the maximum treedepth limit of 5 or 2\\^5-1 leapfrog steps."
   expect_message(
     check_sampler_transitions_treedepth(
-      csv_contents$post_warmup_sampler_diagnostics,
-      csv_contents$metadata),
+      csv_output$post_warmup_sampler_diagnostics,
+      csv_output$metadata),
     output
   )
 
@@ -63,8 +63,8 @@ test_that("check_sampler_transitions_treedepth() works", {
   output <- "1 of 100 \\(1.0%\\) transitions hit the maximum treedepth limit of 5 or 2\\^5-1 leapfrog steps."
   expect_message(
     check_sampler_transitions_treedepth(
-      csv_contents$post_warmup_sampler_diagnostics,
-      csv_contents$metadata),
+      csv_output$post_warmup_sampler_diagnostics,
+      csv_output$metadata),
     output
   )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -11,18 +11,18 @@ test_that("check_divergences() works", {
   csv_files <- c(test_path("resources", "csv", "model1-2-no-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
   output <- "14 of 100 \\(14.0%\\) transitions ended with a divergence."
-  expect_message(check_divergences(csv_output), output)
+  expect_message(check_divergences(csv_contents$post_warmup_sampler_diagnostics), output)
 
   csv_files <- c(test_path("resources", "csv", "model1-2-no-warmup.csv"),
                  test_path("resources", "csv", "model1-2-no-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
   output <- "28 of 200 \\(14.0%\\) transitions ended with a divergence."
-  expect_message(check_divergences(csv_output), output)
+  expect_message(check_divergences(csv_contents$post_warmup_sampler_diagnostics), output)
 
   csv_files <- c(test_path("resources", "csv", "model1-2-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
   output <- "1 of 100 \\(1.0%\\) transitions ended with a divergence."
-  expect_message(check_divergences(csv_output), output)
+  expect_message(check_divergences(csv_contents$post_warmup_sampler_diagnostics), output)
 
 
   fit_wramup_no_samples <- testing_fit("logistic", method = "sample",
@@ -32,7 +32,7 @@ test_that("check_divergences() works", {
                           save_warmup = TRUE,
                           validate_csv = FALSE)
   csv_output <- read_cmdstan_csv(fit_wramup_no_samples$output_files())
-  expect_message(check_divergences(csv_output), regexp = NA)
+  expect_message(check_divergences(csv_contents$post_warmup_sampler_diagnostics), regexp = NA)
 })
 
 test_that("check_sampler_transitions_treedepth() works", {
@@ -40,19 +40,33 @@ test_that("check_sampler_transitions_treedepth() works", {
   csv_files <- c(test_path("resources", "csv", "model1-2-no-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
   output <- "16 of 100 \\(16.0%\\) transitions hit the maximum treedepth limit of 5 or 2\\^5-1 leapfrog steps."
-  expect_message(check_sampler_transitions_treedepth(csv_output), output)
+  expect_message(
+    check_sampler_transitions_treedepth(
+      csv_contents$post_warmup_sampler_diagnostics,
+      csv_contents$metadata),
+    output
+  )
 
   csv_files <- c(test_path("resources", "csv", "model1-2-no-warmup.csv"),
                  test_path("resources", "csv", "model1-2-no-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
   output <- "32 of 200 \\(16.0%\\) transitions hit the maximum treedepth limit of 5 or 2\\^5-1 leapfrog steps."
-  expect_message(check_sampler_transitions_treedepth(csv_output), output)
+  expect_message(
+    check_sampler_transitions_treedepth(
+      csv_contents$post_warmup_sampler_diagnostics,
+      csv_contents$metadata),
+    output
+  )
 
   csv_files <- c(test_path("resources", "csv", "model1-2-warmup.csv"))
   csv_output <- read_cmdstan_csv(csv_files)
   output <- "1 of 100 \\(1.0%\\) transitions hit the maximum treedepth limit of 5 or 2\\^5-1 leapfrog steps."
-  expect_message(check_sampler_transitions_treedepth(csv_output), output)
-
+  expect_message(
+    check_sampler_transitions_treedepth(
+      csv_contents$post_warmup_sampler_diagnostics,
+      csv_contents$metadata),
+    output
+  )
 })
 
 test_that("cmdstan_summary works if bin/stansummary deleted file", {


### PR DESCRIPTION
#### Summary

We should not be running posterior::bind_draws when looping over the chains but instead call it a single time once we read in all chains.

For this example:

```r
library(cmdstanr)
model_code <- "
parameters {
  real k;
}

transformed parameters {
  real x[20000] = rep_array(k, 20000);
}

model {
  k ~ normal(0, 1);
}
"
model_file <- write_stan_file(model_code)
mod <- cmdstan_model(model_file)
fit <- mod$sample(iter_sampling = 2000, validate_csv = FALSE, chains = 4)

start <- Sys.time()
f <- fit$draws()
print(Sys.time() - start)
```
the $draws() call goes from 28s to 19s. There is no difference for 1 chain.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
