### PR TITLE
GHA: yaml: Lint all workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -64,11 +64,11 @@ jobs:
         run: |
           sudo apt-get install -y openmpi-bin
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
       - name: Query dependencies
         run: |
@@ -79,7 +79,7 @@ jobs:
 
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -115,7 +115,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -1,4 +1,8 @@
-on:
+---
+# Github Actions workflow to check CmdStanR
+# yamllint disable rule:line-length
+
+'on':
   push:
     branches:
       - master
@@ -19,14 +23,14 @@ jobs:
       fail-fast: true
       matrix:
         config:
-          - {os: macOS-latest,   r: 'devel'}
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macOS-latest, r: 'devel'}
+          - {os: macOS-latest, r: 'release'}
           - {os: windows-latest, r: 'devel'}
           - {os: windows-latest, r: 'release'}
           - {os: windows-latest, r: 'oldrel'}
-          - {os: ubuntu-20.04,   r: 'devel'}
-          - {os: ubuntu-20.04,   r: 'release'}
-          - {os: ubuntu-20.04,   r: 'oldrel'}
+          - {os: ubuntu-20.04, r: 'devel'}
+          - {os: ubuntu-20.04, r: 'release'}
+          - {os: ubuntu-20.04, r: 'oldrel'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -44,7 +48,7 @@ jobs:
       - name: Set path for RTools 4.0
         if: runner.os == 'Windows'
         run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-      
+
       - name: Install mingw32-make and check toolchain path
         if: runner.os == 'Windows'
         run: |
@@ -54,7 +58,7 @@ jobs:
           mingw32-make --version
           Get-Command mingw32-make | Select-Object -ExpandProperty Definition
         shell: powershell
-      
+
       - name: Install MPI
         if: runner.os == 'Linux'
         run: |

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,7 +40,6 @@ jobs:
       - uses: n1hility/cancel-previous-runs@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: R-CMD-check.yaml
         if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
 
       - uses: actions/checkout@v2

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -2,6 +2,8 @@
 # Github Actions workflow to check CmdStanR
 # yamllint disable rule:line-length
 
+name: Unit tests
+
 'on':
   push:
     branches:
@@ -9,8 +11,6 @@
   pull_request:
     branches:
       - master
-
-name: Unit tests
 
 jobs:
   R-CMD-check:

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -28,8 +28,8 @@ jobs:
         if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
       - uses: actions/checkout@v2
 
-      - uses: r-lib/actions/setup-r@master
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-r@v1
+      - uses: r-lib/actions/setup-pandoc@v1
 
       - name: Install Ubuntu dependencies
         run: |
@@ -43,7 +43,7 @@ jobs:
         shell: Rscript {0}
 
       - name: Cache R packages
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ubuntu-r-4.0-1-${{ hashFiles('.github/depends.Rds') }}
@@ -86,11 +86,11 @@ jobs:
           Get-Command mingw32-make | Select-Object -ExpandProperty Definition
         shell: powershell
 
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: 'release'
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
       - name: Query dependencies
         run: |

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -88,7 +88,7 @@ jobs:
 
       - uses: r-lib/actions/setup-r@master
         with:
-              r-version: 'release'
+          r-version: 'release'
 
       - uses: r-lib/actions/setup-pandoc@master
 

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -1,4 +1,8 @@
-on:
+---
+# Github Actions workflow to analyze CmdStanR code, test coverage
+# yamllint disable rule:line-length
+
+'on':
   push:
     branches:
       - master

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -2,6 +2,8 @@
 # Github Actions workflow to analyze CmdStanR code, test coverage
 # yamllint disable rule:line-length
 
+name: Test coverage
+
 'on':
   push:
     branches:
@@ -9,8 +11,6 @@
   pull_request:
     branches:
       - master
-
-name: Test coverage
 
 jobs:
   test-coverage-ubuntu:

--- a/.github/workflows/cmdstan-tarball-check.yaml
+++ b/.github/workflows/cmdstan-tarball-check.yaml
@@ -2,6 +2,8 @@
 # Github Actions workflow to check CmdStanR tarball
 # yamllint disable rule:line-length
 
+name: Custom CmdStan tarball unit tests
+
 'on':
   workflow_dispatch:
     inputs:
@@ -9,8 +11,6 @@
         description: 'CmdStan tarball URL to test with.'
         required: true
         default: 'latest'
-
-name: Custom CmdStan tarball unit tests
 
 jobs:
   tarball-check:

--- a/.github/workflows/cmdstan-tarball-check.yaml
+++ b/.github/workflows/cmdstan-tarball-check.yaml
@@ -52,11 +52,11 @@ jobs:
         if: runner.os == 'Linux'
         run: |
           sudo apt-get install -y openmpi-bin
-      - uses: r-lib/actions/setup-r@master
+      - uses: r-lib/actions/setup-r@v1
         with:
           r-version: ${{ matrix.config.r }}
 
-      - uses: r-lib/actions/setup-pandoc@master
+      - uses: r-lib/actions/setup-pandoc@v1
 
       - name: Query dependencies
         run: |
@@ -67,7 +67,7 @@ jobs:
 
       - name: Cache R packages
         if: runner.os != 'Windows'
-        uses: actions/cache@v1
+        uses: actions/cache@v2
         with:
           path: ${{ env.R_LIBS_USER }}
           key: ${{ runner.os }}-${{ hashFiles('.github/R-version') }}-1-${{ hashFiles('.github/depends.Rds') }}
@@ -106,7 +106,7 @@ jobs:
 
       - name: Upload check results
         if: failure()
-        uses: actions/upload-artifact@master
+        uses: actions/upload-artifact@v2
         with:
           name: ${{ runner.os }}-r${{ matrix.config.r }}-results
           path: check

--- a/.github/workflows/cmdstan-tarball-check.yaml
+++ b/.github/workflows/cmdstan-tarball-check.yaml
@@ -1,4 +1,8 @@
-on: 
+---
+# Github Actions workflow to check CmdStanR tarball
+# yamllint disable rule:line-length
+
+'on':
   workflow_dispatch:
     inputs:
       tarball_url:
@@ -18,9 +22,9 @@ jobs:
       fail-fast: true
       matrix:
         config:
-          - {os: macOS-latest,   r: 'release'}
+          - {os: macOS-latest, r: 'release'}
           - {os: windows-latest, r: 'release'}
-          - {os: ubuntu-20.04,   r: 'release'}
+          - {os: ubuntu-20.04, r: 'release'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -33,7 +37,7 @@ jobs:
       - name: Set path for RTools 4.0
         if: runner.os == 'Windows'
         run: echo "C:/rtools40/usr/bin;C:/rtools40/mingw64/bin" | Out-File -Append -FilePath $env:GITHUB_PATH -Encoding utf8
-      
+
       - name: Install mingw32-make and check toolchain path
         if: runner.os == 'Windows'
         run: |
@@ -43,7 +47,7 @@ jobs:
           mingw32-make --version
           Get-Command mingw32-make | Select-Object -ExpandProperty Definition
         shell: powershell
-      
+
       - name: Install MPI
         if: runner.os == 'Linux'
         run: |


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests
- [X] Declare copyright holder and agree to license (see below)

#### Summary

This addresses the following `yamllint` errors/warnings for all `CmdStanR` GitHub Actions workflows:

> yamllint -f parsable .github/workflows/R-CMD-check.yaml

```
.github/workflows/R-CMD-check.yaml:1:1: [warning] missing document start "---" (document-start)
.github/workflows/R-CMD-check.yaml:1:1: [warning] truthy value should be one of [false, true] (truthy)
.github/workflows/R-CMD-check.yaml:22:33: [error] too many spaces after comma (commas)
.github/workflows/R-CMD-check.yaml:23:33: [error] too many spaces after comma (commas)
.github/workflows/R-CMD-check.yaml:27:33: [error] too many spaces after comma (commas)
.github/workflows/R-CMD-check.yaml:28:33: [error] too many spaces after comma (commas)
.github/workflows/R-CMD-check.yaml:29:33: [error] too many spaces after comma (commas)
.github/workflows/R-CMD-check.yaml:40:81: [error] line too long (88 > 80 characters) (line-length)
.github/workflows/R-CMD-check.yaml:46:81: [error] line too long (124 > 80 characters) (line-length)
.github/workflows/R-CMD-check.yaml:47:1: [error] trailing spaces (trailing-spaces)
.github/workflows/R-CMD-check.yaml:57:1: [error] trailing spaces (trailing-spaces)
.github/workflows/R-CMD-check.yaml:72:81: [error] line too long (101 > 80 characters) (line-length)
.github/workflows/R-CMD-check.yaml:73:81: [error] line too long (103 > 80 characters) (line-length)
.github/workflows/R-CMD-check.yaml:81:81: [error] line too long (111 > 80 characters) (line-length)
.github/workflows/R-CMD-check.yaml:82:81: [error] line too long (81 > 80 characters) (line-length)
.github/workflows/R-CMD-check.yaml:88:81: [error] line too long (120 > 80 characters) (line-length)
.github/workflows/R-CMD-check.yaml:89:81: [error] line too long (119 > 80 characters) (line-length)
.github/workflows/R-CMD-check.yaml:104:81: [error] line too long (176 > 80 characters) (line-length)
```

> yamllint -f parsable .github/workflows/cmdstan-tarball-check.yaml

```
.github/workflows/cmdstan-tarball-check.yaml:1:1: [warning] missing document start "---" (document-start)
.github/workflows/cmdstan-tarball-check.yaml:1:1: [warning] truthy value should be one of [false, true] (truthy)
.github/workflows/cmdstan-tarball-check.yaml:1:4: [error] trailing spaces (trailing-spaces)
.github/workflows/cmdstan-tarball-check.yaml:21:33: [error] too many spaces after comma (commas)
.github/workflows/cmdstan-tarball-check.yaml:23:33: [error] too many spaces after comma (commas)
.github/workflows/cmdstan-tarball-check.yaml:35:81: [error] line too long (124 > 80 characters) (line-length)
.github/workflows/cmdstan-tarball-check.yaml:36:1: [error] trailing spaces (trailing-spaces)
.github/workflows/cmdstan-tarball-check.yaml:46:1: [error] trailing spaces (trailing-spaces)
.github/workflows/cmdstan-tarball-check.yaml:60:81: [error] line too long (101 > 80 characters) (line-length)
.github/workflows/cmdstan-tarball-check.yaml:61:81: [error] line too long (103 > 80 characters) (line-length)
.github/workflows/cmdstan-tarball-check.yaml:69:81: [error] line too long (111 > 80 characters) (line-length)
.github/workflows/cmdstan-tarball-check.yaml:70:81: [error] line too long (81 > 80 characters) (line-length)
.github/workflows/cmdstan-tarball-check.yaml:76:81: [error] line too long (120 > 80 characters) (line-length)
.github/workflows/cmdstan-tarball-check.yaml:77:81: [error] line too long (119 > 80 characters) (line-length)
.github/workflows/cmdstan-tarball-check.yaml:81:81: [error] line too long (122 > 80 characters) (line-length)
.github/workflows/cmdstan-tarball-check.yaml:95:81: [error] line too long (176 > 80 characters) (line-length)
```

> yamllint -f parsable .github/workflows/Test-coverage.yaml

```
.github/workflows/Test-coverage.yaml:1:1: [warning] missing document start "---" (document-start)
.github/workflows/Test-coverage.yaml:1:1: [warning] truthy value should be one of [false, true] (truthy)
.github/workflows/Test-coverage.yaml:24:81: [error] line too long (88 > 80 characters) (line-length)
.github/workflows/Test-coverage.yaml:33:81: [error] line too long (87 > 80 characters) (line-length)
.github/workflows/Test-coverage.yaml:38:81: [error] line too long (101 > 80 characters) (line-length)
.github/workflows/Test-coverage.yaml:50:81: [error] line too long (159 > 80 characters) (line-length)
.github/workflows/Test-coverage.yaml:73:81: [error] line too long (124 > 80 characters) (line-length)
.github/workflows/Test-coverage.yaml:87:15: [error] wrong indentation: expected 10 but found 14 (indentation)
.github/workflows/Test-coverage.yaml:94:81: [error] line too long (101 > 80 characters) (line-length)
.github/workflows/Test-coverage.yaml:99:81: [error] line too long (159 > 80 characters) (line-length)
```

#### Copyright and Licensing

Hamada S. Badr <badr@jhu.edu>