### PR TITLE
Improve error and informational messages

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -644,7 +644,7 @@ check_cmdstan_toolchain <- function(fix = FALSE, quiet = FALSE) {
     stop("No write permissions to the temporary folder! Please change the permissions or location of the temporary folder.", call. = FALSE)
   }
   if (!quiet) {
-    message("The CmdStan toolchain is setup properly!")
+    message("The C++ toolchain required for CmdStan is setup properly!")
   }
   invisible(NULL)
 }

--- a/R/run.R
+++ b/R/run.R
@@ -759,7 +759,7 @@ CmdStanProcs <- R6::R6Class(
     },
     report_time = function(id = NULL) {
       if (self$proc_state(id) == 7) {
-        warning("Fitting finished unexpectedly!\n", immediate. = TRUE, call. = FALSE)
+        warning("Fitting finished unexpectedly! Use the '$output()' method for more information.\n", immediate. = TRUE, call. = FALSE)
       } else {
         cat("Finished in ",
             format(round(self$total_time(), 1), nsmall = 1),
@@ -916,8 +916,8 @@ CmdStanMCMCProcs <- R6::R6Class(
                 format(round(self$total_time(), 1), nsmall = 1),
                 "seconds.\n")
           } else if (num_failed == num_chains) {
-            warning("All chains finished unexpectedly!\n", call. = FALSE)
-            warning("Use read_cmdstan_csv() to read the results of the failed chains.",
+            warning("All chains finished unexpectedly! Use the '$output(chain_id)' method for more information.\n", call. = FALSE)
+            warning("Use 'read_cmdstan_csv()' to read the results of the failed chains.",
                     immediate. = TRUE,
                     call. = FALSE)
           } else {
@@ -927,9 +927,11 @@ CmdStanMCMCProcs <- R6::R6Class(
             cat("The remaining chains had a mean execution time of",
                 format(round(mean(self$total_time()), 1), nsmall = 1),
                 "seconds.\n")
-            warning("The returned fit object will only read in results of successful chains. Please use read_cmdstan_csv() to read the results of the failed chains separately.",
-                    immediate. = TRUE,
-                    call. = FALSE)
+            warning("The returned fit object will only read in results of successful chains. "
+              "Please use 'read_cmdstan_csv()' to read the results of the failed chains separately.",
+              "Use the '$output(chain_id)' for more output of the failed chains."
+              immediate. = TRUE,
+              call. = FALSE)
           }
         }
         return(invisible(NULL))
@@ -1008,6 +1010,7 @@ CmdStanGQProcs <- R6::R6Class(
           } else if (num_failed == num_chains) {
             warning("All chains finished unexpectedly!\n", call. = FALSE)
             warning("Use read_cmdstan_csv() to read the results of the failed chains.",
+                    "Use '$output(chain_id)' on the fit object for more output of the failed chains."
                     immediate. = TRUE,
                     call. = FALSE)
           } else {
@@ -1017,7 +1020,9 @@ CmdStanGQProcs <- R6::R6Class(
             cat("The remaining chains had a mean execution time of",
                 format(round(mean(self$total_time()), 1), nsmall = 1),
                 "seconds.\n")
-            warning("The returned fit object will only read in results of successful chains. Please use read_cmdstan_csv() to read the results of the failed chains separately.",
+            warning("The returned fit object will only read in results of successful chains. "
+                    "Please use read_cmdstan_csv() to read the results of the failed chains separately.",
+                    "Use '$output(chain_id)' on the fit object for more output of the failed chains."
                     immediate. = TRUE,
                     call. = FALSE)
           }

--- a/R/run.R
+++ b/R/run.R
@@ -929,7 +929,7 @@ CmdStanMCMCProcs <- R6::R6Class(
                 "seconds.\n")
             warning("The returned fit object will only read in results of successful chains. "
               "Please use 'read_cmdstan_csv()' to read the results of the failed chains separately.",
-              "Use the '$output(chain_id)' for more output of the failed chains."
+              "Use the '$output(chain_id)' method for more output of the failed chains."
               immediate. = TRUE,
               call. = FALSE)
           }

--- a/R/run.R
+++ b/R/run.R
@@ -759,7 +759,7 @@ CmdStanProcs <- R6::R6Class(
     },
     report_time = function(id = NULL) {
       if (self$proc_state(id) == 7) {
-        warning("Fitting finished unexpectedly! Use the '$output()' method for more information.\n", immediate. = TRUE, call. = FALSE)
+        warning("Fitting finished unexpectedly! Use the $output() method for more information.\n", immediate. = TRUE, call. = FALSE)
       } else {
         cat("Finished in ",
             format(round(self$total_time(), 1), nsmall = 1),
@@ -916,8 +916,8 @@ CmdStanMCMCProcs <- R6::R6Class(
                 format(round(self$total_time(), 1), nsmall = 1),
                 "seconds.\n")
           } else if (num_failed == num_chains) {
-            warning("All chains finished unexpectedly! Use the '$output(chain_id)' method for more information.\n", call. = FALSE)
-            warning("Use 'read_cmdstan_csv()' to read the results of the failed chains.",
+            warning("All chains finished unexpectedly! Use the $output(chain_id) method for more information.\n", call. = FALSE)
+            warning("Use read_cmdstan_csv() to read the results of the failed chains.",
                     immediate. = TRUE,
                     call. = FALSE)
           } else {
@@ -928,8 +928,8 @@ CmdStanMCMCProcs <- R6::R6Class(
                 format(round(mean(self$total_time()), 1), nsmall = 1),
                 "seconds.\n")
             warning("The returned fit object will only read in results of successful chains. "
-              "Please use 'read_cmdstan_csv()' to read the results of the failed chains separately.",
-              "Use the '$output(chain_id)' method for more output of the failed chains."
+              "Please use read_cmdstan_csv() to read the results of the failed chains separately.",
+              "Use the $output(chain_id) method for more output of the failed chains."
               immediate. = TRUE,
               call. = FALSE)
           }
@@ -1010,7 +1010,7 @@ CmdStanGQProcs <- R6::R6Class(
           } else if (num_failed == num_chains) {
             warning("All chains finished unexpectedly!\n", call. = FALSE)
             warning("Use read_cmdstan_csv() to read the results of the failed chains.",
-                    "Use '$output(chain_id)' on the fit object for more output of the failed chains."
+                    "Use $output(chain_id) on the fit object for more output of the failed chains."
                     immediate. = TRUE,
                     call. = FALSE)
           } else {
@@ -1020,9 +1020,9 @@ CmdStanGQProcs <- R6::R6Class(
             cat("The remaining chains had a mean execution time of",
                 format(round(mean(self$total_time()), 1), nsmall = 1),
                 "seconds.\n")
-            warning("The returned fit object will only read in results of successful chains. "
+            warning("The returned fit object will only read in results of successful chains. ",
                     "Please use read_cmdstan_csv() to read the results of the failed chains separately.",
-                    "Use '$output(chain_id)' on the fit object for more output of the failed chains."
+                    "Use $output(chain_id) on the fit object for more output of the failed chains."
                     immediate. = TRUE,
                     call. = FALSE)
           }

--- a/R/run.R
+++ b/R/run.R
@@ -929,7 +929,7 @@ CmdStanMCMCProcs <- R6::R6Class(
                 "seconds.\n")
             warning("The returned fit object will only read in results of successful chains. ",
               "Please use read_cmdstan_csv() to read the results of the failed chains separately.",
-              "Use the $output(chain_id) method for more output of the failed chains."
+              "Use the $output(chain_id) method for more output of the failed chains.",
               immediate. = TRUE,
               call. = FALSE)
           }
@@ -1010,7 +1010,7 @@ CmdStanGQProcs <- R6::R6Class(
           } else if (num_failed == num_chains) {
             warning("All chains finished unexpectedly!\n", call. = FALSE)
             warning("Use read_cmdstan_csv() to read the results of the failed chains.",
-                    "Use $output(chain_id) on the fit object for more output of the failed chains."
+                    "Use $output(chain_id) on the fit object for more output of the failed chains.",
                     immediate. = TRUE,
                     call. = FALSE)
           } else {
@@ -1022,7 +1022,7 @@ CmdStanGQProcs <- R6::R6Class(
                 "seconds.\n")
             warning("The returned fit object will only read in results of successful chains. ",
                     "Please use read_cmdstan_csv() to read the results of the failed chains separately.",
-                    "Use $output(chain_id) on the fit object for more output of the failed chains."
+                    "Use $output(chain_id) on the fit object for more output of the failed chains.",
                     immediate. = TRUE,
                     call. = FALSE)
           }

--- a/R/run.R
+++ b/R/run.R
@@ -927,7 +927,7 @@ CmdStanMCMCProcs <- R6::R6Class(
             cat("The remaining chains had a mean execution time of",
                 format(round(mean(self$total_time()), 1), nsmall = 1),
                 "seconds.\n")
-            warning("The returned fit object will only read in results of successful chains. "
+            warning("The returned fit object will only read in results of successful chains. ",
               "Please use read_cmdstan_csv() to read the results of the failed chains separately.",
               "Use the $output(chain_id) method for more output of the failed chains."
               immediate. = TRUE,


### PR DESCRIPTION
#### Summary

Fixes #444 and fixes #405 by adding a suggestion for using `$output()` in case of failed chains and to improve the install message 
from `"The CmdStan toolchain is setup properly!"` to 
`"The C++ toolchain required for CmdStan is setup properly!"`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
