### PR TITLE
Fix issue with reading in CSV for models with spaces in name

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ### Bug fixes
 
+* Fixed issue with retrieving draws with models with spaces in their names. (#453)
+
 ### New features
 
 * New function `as_cmdstan_fit()` that creates CmdStanMCMC/MLE/VB objects

--- a/R/csv.R
+++ b/R/csv.R
@@ -223,9 +223,9 @@ read_cmdstan_csv <- function(files,
     if (length(col_select) > 0) {
       if (os_is_windows()) {
         grep_path <- repair_path(Sys.which("grep.exe"))
-        fread_cmd <- paste0(grep_path, " -v '^#' --color=never ", output_file)
+        fread_cmd <- paste0(grep_path, " -v '^#' --color=never '", output_file, "'")
       } else {
-        fread_cmd <- paste0("grep -v '^#' --color=never ", output_file)
+        fread_cmd <- paste0("grep -v '^#' --color=never '", output_file, "'")
       }
       suppressWarnings(
       draws <- data.table::fread(
@@ -512,9 +512,9 @@ read_csv_metadata <- function(csv_file) {
   total_time <- 0
   if (os_is_windows()) {
     grep_path <- repair_path(Sys.which("grep.exe"))
-    fread_cmd <- paste0(grep_path, " '^[#a-zA-Z]' --color=never ", csv_file)
+    fread_cmd <- paste0(grep_path, " '^[#a-zA-Z]' --color=never '", csv_file, "'")
   } else {
-    fread_cmd <- paste0("grep '^[#a-zA-Z]' --color=never ", csv_file)
+    fread_cmd <- paste0("grep '^[#a-zA-Z]' --color=never '", csv_file, "'")
   }
   suppressWarnings(
     metadata <- data.table::fread(

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -6,7 +6,6 @@ if (not_on_cran()) {
   mod <- cmdstan_model(stan_file = stan_program, compile = FALSE)
 }
 
-
 test_that("object initialized correctly", {
   skip_on_cran()
   expect_equal(mod$stan_file(), stan_program)
@@ -399,4 +398,25 @@ test_that("check_syntax() works with include_paths", {
 
 })
 
+test_that("check_syntax() works with pedantic=TRUE", {
+  skip_on_cran()
+  model_code <- "
+  transformed data {
+    real a;
+    a <- 3;
+  }
+  "
+  stan_file <- write_stan_file(model_code)
+  mod_dep_warning <- cmdstan_model(stan_file, compile = FALSE)
+  expect_message(
+    mod_dep_warning$compile(),
+    "Warning: deprecated language construct used in",
+    fixed = TRUE
+  )
+  expect_message(
+    mod_dep_warning$check_syntax(),
+    "Warning: deprecated language construct used in",
+    fixed = TRUE
+  )
+})
 


### PR DESCRIPTION
#### Summary

This fixes issue with reading in CSV files for models with spaces in name. Issue reported [here](https://discourse.mc-stan.org/t/cmdstanr-cannot-find-fit-output-files-if-stan-file-has-a-space-in-name/20710).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
