### PR TITLE
Suppress some compilation messages in non-interactive R sessions

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -422,7 +422,9 @@ compile <- function(quiet = TRUE,
   }
 
   if (!force_recompile) {
-    message("Model executable is up to date!")
+    if (interactive()) {
+      message("Model executable is up to date!")
+    }
     private$cpp_options_ <- cpp_options
     private$precompile_cpp_options_ <- NULL
     private$precompile_stanc_options_ <- NULL
@@ -430,7 +432,9 @@ compile <- function(quiet = TRUE,
     self$exe_file(exe)
     return(invisible(self))
   } else {
-    message("Compiling Stan program...")
+    if (interactive()) {
+      message("Compiling Stan program...")
+    }
   }
 
   temp_stan_file <- tempfile(pattern = "model-", fileext = ".stan")

--- a/tests/testthat/helper-custom-expectations.R
+++ b/tests/testthat/helper-custom-expectations.R
@@ -37,3 +37,11 @@ expect_gq_output <- function(object, num_chains = NULL) {
   }
   expect_output(object, output)
 }
+
+expect_interactive_message <- function(object, regexp = NULL) {
+  if (interactive()) {
+    expect_message(object = object, regexp = regexp)
+  } else {
+    expect_silent(object = object)
+  }
+}

--- a/tests/testthat/test-knitr.R
+++ b/tests/testthat/test-knitr.R
@@ -15,7 +15,7 @@ test_that("eng_cmdstan works", {
     cache = TRUE,
     cache.path = tempdir()
   ))
-  expect_message(eng_cmdstan(opts), "Compiling Stan program")
+  expect_interactive_message(eng_cmdstan(opts), "Compiling Stan program")
 
   opts$eval <- FALSE
   expect_silent(eng_cmdstan(opts))

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -33,8 +33,8 @@ test_that("compile() method works", {
   if (file.exists(exe)) {
     file.remove(exe)
   }
-  expect_message(mod$compile(quiet = TRUE), "Compiling Stan program...")
-  expect_message(mod$compile(quiet = TRUE), "Model executable is up to date!")
+  expect_interactive_message(mod$compile(quiet = TRUE), "Compiling Stan program...")
+  expect_interactive_message(mod$compile(quiet = TRUE), "Model executable is up to date!")
   checkmate::expect_file_exists(mod$hpp_file())
   checkmate::expect_file_exists(exe)
   file.remove(exe)
@@ -45,7 +45,10 @@ test_that("compile() method works", {
 test_that("compile() method forces recompilation force_recompile = TRUE", {
   skip_on_cran()
   mod$compile(quiet = TRUE)
-  expect_message(mod$compile(quiet = TRUE, force_recompile = TRUE), "Compiling Stan program...")
+  expect_interactive_message(
+    mod$compile(quiet = TRUE, force_recompile = TRUE),
+    "Compiling Stan program..."
+  )
 })
 
 test_that("compile() method forces recompilation if model modified", {
@@ -56,7 +59,7 @@ test_that("compile() method forces recompilation if model modified", {
     mod$compile(quiet = TRUE)
   }
   Sys.setFileTime(mod$stan_file(), Sys.time() + 1) #touch file to trigger recompile
-  expect_message(mod$compile(quiet = TRUE), "Compiling Stan program...")
+  expect_interactive_message(mod$compile(quiet = TRUE), "Compiling Stan program...")
 })
 
 test_that("compile() method works with spaces in path", {
@@ -75,7 +78,7 @@ test_that("compile() method works with spaces in path", {
   if (file.exists(exe)) {
     file.remove(exe)
   }
-  expect_message(mod_spaces$compile(), "Compiling Stan program...")
+  expect_interactive_message(mod_spaces$compile(), "Compiling Stan program...")
   file.remove(stan_model_with_spaces)
   file.remove(exe)
   file.remove(dir_with_spaces)
@@ -111,7 +114,7 @@ test_that("compilation works with include_paths", {
     )
   )
 
-  expect_message(
+  expect_interactive_message(
     mod_w_include <- cmdstan_model(stan_file = stan_program_w_include, quiet = TRUE,
                                    include_paths = test_path("resources", "stan")),
     "Compiling Stan program"
@@ -170,15 +173,15 @@ test_that("switching threads on and off works without rebuild", {
 test_that("multiple cpp_options work", {
   skip_on_cran()
   stan_file <- testing_stan_file("bernoulli")
-  expect_message(
+  expect_interactive_message(
     mod <- cmdstan_model(stan_file, cpp_options = list("DUMMY_TEST2"="1", "DUMMY_TEST2"="1",  "DUMMY_TEST3"="1"), force_recompile = TRUE),
     "Compiling Stan program..."
   )
-  expect_message(
+  expect_interactive_message(
     mod$compile(cpp_options = list("DUMMY_TEST2"="1", "DUMMY_TEST2"="1",  "DUMMY_TEST3"="1"), force_recompile = TRUE),
     "Compiling Stan program..."
   )
-  expect_message(
+  expect_interactive_message(
     mod$compile(cpp_options = list(), force_recompile = TRUE),
     "Compiling Stan program..."
   )


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Omit compilation messages "Compiling Stan program..." and "Model executable is up to date!" for non-interactive R sessions. Fixed #429.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 

Eli Lilly and Company

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
