### PR TITLE
Cache installation of CmdStan in check and coverage workflows

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -38,6 +38,11 @@ jobs:
       CMDSTAN_VERSION: "2.26.1"
 
     steps:
+      - name: cmdstan env vars
+        run: |
+          echo "CMDSTAN_PATH=${HOME}/.cmdstanr" >> $GITHUB_ENV
+        shell: bash
+
       - uses: n1hility/cancel-previous-runs@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -93,7 +98,20 @@ jobs:
           install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
           install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
           install.packages("curl")
-          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE, version = Sys.getenv("CMDSTAN_VERSION"))
+        shell: Rscript {0}
+
+      - name: Cache cmdstan
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CMDSTAN_PATH }}
+          key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
+          restore-keys: ${{ runner.os }}-cmdstan-
+
+      - name: Install cmdstan
+        run: |
+          version <- Sys.getenv("CMDSTAN_VERSION")
+          url <- sprintf("https://github.com/stan-dev/cmdstan/releases/download/v%s/cmdstan-%s.tar.gz", version, version)
+          cmdstanr::install_cmdstan(cores = 2, release_url = url)
         shell: Rscript {0}
 
       - name: Session info

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -20,7 +20,14 @@ jobs:
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       NOT_CRAN: true
+      CMDSTAN_VERSION: "2.26.1"
+
     steps:
+      - name: cmdstan env vars
+        run: |
+          echo "CMDSTAN_PATH=${HOME}/.cmdstanr" >> $GITHUB_ENV
+        shell: bash
+
       - uses: n1hility/cancel-previous-runs@v2
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
@@ -53,10 +60,23 @@ jobs:
       - name: Install dependencies
         run: |
           install.packages(c("posterior", "cmdstanr", "remotes", "curl"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
-          cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")
           remotes::install_cran("gridExtra")
+        shell: Rscript {0}
+
+      - name: Cache cmdstan
+        uses: actions/cache@v2
+        with:
+          path: ${{ env.CMDSTAN_PATH }}
+          key: ${{ runner.os }}-cmdstan-${{ env.CMDSTAN_VERSION }}
+          restore-keys: ${{ runner.os }}-cmdstan-
+
+      - name: Install cmdstan
+        run: |
+          version <- Sys.getenv("CMDSTAN_VERSION")
+          url <- sprintf("https://github.com/stan-dev/cmdstan/releases/download/v%s/cmdstan-%s.tar.gz", version, version)
+          cmdstanr::install_cmdstan(cores = 2, release_url = url)
         shell: Rscript {0}
 
       - name: Test coverage


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This PR uses the [cache action](https://github.com/actions/cache) to avoid redundant installations of CmdStan in GitHub Actions workflows. I only implemented it in `R-CMD-check.yaml` and `Test-coverage.yaml` because it looks like `cmdstan-tarball-check.yaml` has its own way of only running when CmdStan updates (is that right?). Addresses #463.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 

Eli Lilly and Company

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
