### PR TITLE
New error_on_NA argument for cmdstan_version()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,7 +11,8 @@ Authors@R:
       person(given = "Mitzi", family = "Morris", role = "ctb"), 
       person(given = "Mikhail", family = "Popov", role = "ctb"), 
       person(given = "Mike", family = "Lawrence", role = "ctb"), 
-      person(given = "Will", family = "Landau", role = "ctb")) 
+      person(given = c("William", "Michael"), family = "Landau", role = "ctb",
+           email = "will.landau@gmail.com", comment = c(ORCID = "0000-0003-1878-3253")))
 Description: A lightweight interface to 'Stan' <https://mc-stan.org>.
     The 'CmdStanR' interface is an alternative to 'RStan' that calls the command 
     line interface for compilation and running algorithms instead of interfacing 

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -10,7 +10,8 @@ Authors@R:
       person(given = "Ben", family = "Bales", role = "ctb"),     
       person(given = "Mitzi", family = "Morris", role = "ctb"), 
       person(given = "Mikhail", family = "Popov", role = "ctb"), 
-      person(given = "Mike", family = "Lawrence", role = "ctb")) 
+      person(given = "Mike", family = "Lawrence", role = "ctb"), 
+      person(given = "Will", family = "Landau", role = "ctb")) 
 Description: A lightweight interface to 'Stan' <https://mc-stan.org>.
     The 'CmdStanR' interface is an alternative to 'RStan' that calls the command 
     line interface for compilation and running algorithms instead of interfacing 

--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,9 @@ Stan programs requires CmdStan >= 2.26. (#434)
 
 * Suppressing compilation messages when not in interactive mode. (#462, @wlandau)
 
+* Add a new `error_on_NA` argument to `cmdstan_version()` to optionally return `NULL`
+if the CmdStan path is not found (#467, @wlandau).
+
 # cmdstanr 0.3.0
 
 ### Bug fixes

--- a/R/path.R
+++ b/R/path.R
@@ -63,8 +63,18 @@ cmdstan_path <- function() {
 
 #' @rdname set_cmdstan_path
 #' @export
-cmdstan_version <- function() {
-  .cmdstanr$VERSION %||% stop_no_path()
+#' @return CmdStan version string if available. If CmdStan
+#'   is not found and `error_on_NA` is `FALSE`,
+#'   `cmdstan_version()` returns `NULL`.
+#' @param error_on_NA Logical of length 1, whether to
+#'   throw an error if CmdStan is not found.
+#'   If `FALSE`, `cmdstan_version()` returns `NULL`.
+cmdstan_version <- function(error_on_NA = TRUE) {
+  version <- .cmdstanr$VERSION
+  if (is.null(version) && error_on_NA) {
+    stop_no_path()
+  }
+  version
 }
 
 

--- a/man/set_cmdstan_path.Rd
+++ b/man/set_cmdstan_path.Rd
@@ -10,16 +10,24 @@ set_cmdstan_path(path = NULL)
 
 cmdstan_path()
 
-cmdstan_version()
+cmdstan_version(error_on_NA = TRUE)
 }
 \arguments{
 \item{path}{The full file path to the CmdStan installation as a string. If
 \code{NULL} (the default) then the path is set to the default path used by
 \code{\link[=install_cmdstan]{install_cmdstan()}} if it exists.}
+
+\item{error_on_NA}{Logical of length 1, whether to
+throw an error if CmdStan is not found.
+If \code{FALSE}, \code{cmdstan_version()} returns \code{NULL}.}
 }
 \value{
 A string. Either the file path to the CmdStan installation or the
 CmdStan version number.
+
+CmdStan version string if available. If CmdStan
+is not found and \code{error_on_NA} is \code{FALSE},
+\code{cmdstan_version()} returns \code{NULL}.
 }
 \description{
 Use the \code{set_cmdstan_path()} function to tell CmdStanR where the

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -86,6 +86,14 @@ test_that("CmdStan version detected when setting path", {
   expect_equal(cmdstan_version(), VERSION)
 })
 
+test_that("cmdstan_version() behavior when version is not set", {
+  version <- .cmdstanr$VERSION
+  on.exit(.cmdstanr$VERSION <- version)
+  .cmdstanr$VERSION <- NULL
+  expect_error(cmdstan_version())
+  expect_null(cmdstan_version(error_on_NA = FALSE))
+})
+
 test_that("Warning message is thrown if can't detect version number", {
   path <- testthat::test_path("answers") # valid path but not cmdstan
   expect_warning(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

In this PR, `cmdstan_version(error_on_NA = FALSE)` returns `NULL` if the CmdStan path is not set. The default `error_on_NA` is `TRUE`, which is the original behavior. Fixes #467.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 

Eli Lilly and Company

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
