### PR TITLE
global max_rows option for print method

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -17,7 +17,7 @@ CmdStanFit <- R6::R6Class(
     num_procs = function() {
       self$runset$num_procs()
     },
-    print = function(variables = NULL, ..., digits = 2, max_rows = 10) {
+    print = function(variables = NULL, ..., digits = 2, max_rows = getOption("cmdstanr_max_rows", 10)) {
       if (is.null(private$draws_) &&
           !length(self$output_files(include_failed = FALSE))) {
         stop("Fitting failed. Unable to print.", call. = FALSE)
@@ -54,7 +54,7 @@ CmdStanFit <- R6::R6Class(
       base::print(out, row.names = FALSE)
       if (max_rows < total_rows) {
         cat("\n # showing", max_rows, "of", total_rows,
-            "rows (change via 'max_rows' argument)\n")
+            "rows (change via 'max_rows' argument or 'cmdstanr_max_rows' option)\n")
       }
       invisible(self)
     }
@@ -706,7 +706,7 @@ CmdStanFit$set("public", name = "return_codes", value = return_codes)
 #'
 #' fit$profiles()
 #' }
-#' 
+#'
 profiles <- function() {
   profiles <- list()
   i <- 1

--- a/vignettes/cmdstanr.Rmd
+++ b/vignettes/cmdstanr.Rmd
@@ -159,7 +159,7 @@ fit <- mod$sample(
   data = data_list, 
   seed = 123, 
   chains = 4, 
-  parallel_chains = 2,
+  parallel_chains = 4,
   refresh = 500
 )
 ```


### PR DESCRIPTION
closes #469

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Allows `options(cmdstanr_max_rows = value)` to set `max_rows` argument of print method for an entire R session (or until changing the option). 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
