### PR TITLE
Fix the use of seed for multi chain sampling

### DIFF
--- a/R/args.R
+++ b/R/args.R
@@ -837,10 +837,9 @@ validate_seed <- function(seed, num_procs) {
 #' @return An integer vector of length `num_procs`.
 maybe_generate_seed <- function(seed, num_procs) {
   if (is.null(seed)) {
-    seed <- base::sample(.Machine$integer.max, num_procs)
+    seed <- rep(base::sample(.Machine$integer.max, 1), num_procs)
   } else if (length(seed) == 1 && num_procs > 1) {
-    seed <- as.integer(seed)
-    seed <- c(seed, seed + 1:(num_procs -1))
+    seed <- rep(as.integer(seed), num_procs)
   }
   seed
 }

--- a/R/args.R
+++ b/R/args.R
@@ -837,9 +837,9 @@ validate_seed <- function(seed, num_procs) {
 #' @return An integer vector of length `num_procs`.
 maybe_generate_seed <- function(seed, num_procs) {
   if (is.null(seed)) {
-    seed <- rep(base::sample(.Machine$integer.max, 1), num_procs)
+    seed <- base::rep(base::sample(.Machine$integer.max, 1), num_procs)
   } else if (length(seed) == 1 && num_procs > 1) {
-    seed <- rep(as.integer(seed), num_procs)
+    seed <- base::rep(as.integer(seed), num_procs)
   }
   seed
 }

--- a/R/csv.R
+++ b/R/csv.R
@@ -168,6 +168,7 @@ read_cmdstan_csv <- function(files,
     }
   }
   metadata <- csv_metadata[[1]]
+  metadata$seed <- unique(metadata$seed)
   if (is.null(variables)) { # variables = NULL returns all
     variables <- metadata$model_params
   } else if (!any(nzchar(variables))) { # if variables = "" returns none

--- a/R/csv.R
+++ b/R/csv.R
@@ -168,7 +168,10 @@ read_cmdstan_csv <- function(files,
     }
   }
   metadata <- csv_metadata[[1]]
-  metadata$seed <- unique(metadata$seed)
+  uniq_seed <- unique(metadata$seed)
+  if (length(uniq_seed) == 1) {
+    metadata$seed <- uniq_seed
+  }  
   if (is.null(variables)) { # variables = NULL returns all
     variables <- metadata$model_params
   } else if (!any(nzchar(variables))) { # if variables = "" returns none

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -6,13 +6,15 @@
 #'  appendices in the CmdStan manual for details on using these formats.
 #'  * `NULL` or an empty list if the Stan program has no `data` block.
 #'
-#' @param seed (positive integer) A seed for the (P)RNG to pass to CmdStan.
-#'   The seed is used in the transformed data block and together with
-#'   the run (chain) ID to augment the seed used for sampling, optimization
-#'   or variational inference. A single seed value is recommended for multi-chain
-#'   sampling with multiple seed values required only if RNG functions are used
-#'   in the transformed data block and the goal is to generate different
-#'   data for each chain.
+#' @param seed (positive integer(s)) A seed for the (P)RNG to pass to CmdStan.
+#'   In the case of multi-chain sampling the single `seed` will automatically be
+#'   augmented by the the run (chain) ID so that each chain uses a different
+#'   seed. The exception is the `transformed data` block, which defaults to
+#'   using same seed for all chains so that the same data is generated for all
+#'   chains if RNG functions are used. The only time `seed` should be specified
+#'   as a vector (one element per chain) is if RNG functions are used in
+#'   `transformed data` and the goal is to generate *different* data for each
+#'   chain.
 #'
 #' @param refresh (non-negative integer) The number of iterations between
 #'   printed screen updates. If `refresh = 0`, only error messages will be
@@ -67,7 +69,7 @@
 #'   names of the output CSV files of CmdStan.
 #'   * If `NULL` (the default), the basename of the output CSV files
 #'   will be comprised from the model name, timestamp and 5 random characters.
-#' 
+#'
 #' @param sig_figs (positive integer) The number of significant figures used
 #'   when storing the output values. By default, CmdStan represent the output
 #'   values with 6 significant figures. The upper limit for `sig_figs` is 18.

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -7,6 +7,12 @@
 #'  * `NULL` or an empty list if the Stan program has no `data` block.
 #'
 #' @param seed (positive integer) A seed for the (P)RNG to pass to CmdStan.
+#'   The seed is used in the transformed data block and together with
+#'   the run (chain) ID to augment the seed used for sampling, optimization
+#'   or variational inference. A single seed value is recommended for multi-chain
+#'   sampling with multiple seed values required only if RNG functions are used
+#'   in the transformed data block and the goal is to generate different
+#'   data for each chain.
 #'
 #' @param refresh (non-negative integer) The number of iterations between
 #'   printed screen updates. If `refresh = 0`, only error messages will be

--- a/man/model-method-generate-quantities.Rd
+++ b/man/model-method-generate-quantities.Rd
@@ -36,7 +36,13 @@ appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no \code{data} block.
 }}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.}
+\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
+The seed is used in the transformed data block and together with
+the run (chain) ID to augment the seed used for sampling, optimization
+or variational inference. A single seed value is recommended for multi-chain
+sampling with multiple seed values required only if RNG functions are used
+in the transformed data block and the goal is to generate different
+data for each chain.}
 
 \item{output_dir}{(string) A path to a directory where CmdStan should write
 its output CSV files. For interactive use this can typically be left at

--- a/man/model-method-generate-quantities.Rd
+++ b/man/model-method-generate-quantities.Rd
@@ -36,13 +36,15 @@ appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no \code{data} block.
 }}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
-The seed is used in the transformed data block and together with
-the run (chain) ID to augment the seed used for sampling, optimization
-or variational inference. A single seed value is recommended for multi-chain
-sampling with multiple seed values required only if RNG functions are used
-in the transformed data block and the goal is to generate different
-data for each chain.}
+\item{seed}{(positive integer(s)) A seed for the (P)RNG to pass to CmdStan.
+In the case of multi-chain sampling the single \code{seed} will automatically be
+augmented by the the run (chain) ID so that each chain uses a different
+seed. The exception is the \verb{transformed data} block, which defaults to
+using same seed for all chains so that the same data is generated for all
+chains if RNG functions are used. The only time \code{seed} should be specified
+as a vector (one element per chain) is if RNG functions are used in
+\verb{transformed data} and the goal is to generate \emph{different} data for each
+chain.}
 
 \item{output_dir}{(string) A path to a directory where CmdStan should write
 its output CSV files. For interactive use this can typically be left at

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -37,13 +37,15 @@ appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no \code{data} block.
 }}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
-The seed is used in the transformed data block and together with
-the run (chain) ID to augment the seed used for sampling, optimization
-or variational inference. A single seed value is recommended for multi-chain
-sampling with multiple seed values required only if RNG functions are used
-in the transformed data block and the goal is to generate different
-data for each chain.}
+\item{seed}{(positive integer(s)) A seed for the (P)RNG to pass to CmdStan.
+In the case of multi-chain sampling the single \code{seed} will automatically be
+augmented by the the run (chain) ID so that each chain uses a different
+seed. The exception is the \verb{transformed data} block, which defaults to
+using same seed for all chains so that the same data is generated for all
+chains if RNG functions are used. The only time \code{seed} should be specified
+as a vector (one element per chain) is if RNG functions are used in
+\verb{transformed data} and the goal is to generate \emph{different} data for each
+chain.}
 
 \item{refresh}{(non-negative integer) The number of iterations between
 printed screen updates. If \code{refresh = 0}, only error messages will be

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -37,7 +37,13 @@ appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no \code{data} block.
 }}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.}
+\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
+The seed is used in the transformed data block and together with
+the run (chain) ID to augment the seed used for sampling, optimization
+or variational inference. A single seed value is recommended for multi-chain
+sampling with multiple seed values required only if RNG functions are used
+in the transformed data block and the goal is to generate different
+data for each chain.}
 
 \item{refresh}{(non-negative integer) The number of iterations between
 printed screen updates. If \code{refresh = 0}, only error messages will be

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -56,7 +56,13 @@ appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no \code{data} block.
 }}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.}
+\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
+The seed is used in the transformed data block and together with
+the run (chain) ID to augment the seed used for sampling, optimization
+or variational inference. A single seed value is recommended for multi-chain
+sampling with multiple seed values required only if RNG functions are used
+in the transformed data block and the goal is to generate different
+data for each chain.}
 
 \item{refresh}{(non-negative integer) The number of iterations between
 printed screen updates. If \code{refresh = 0}, only error messages will be

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -56,13 +56,15 @@ appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no \code{data} block.
 }}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
-The seed is used in the transformed data block and together with
-the run (chain) ID to augment the seed used for sampling, optimization
-or variational inference. A single seed value is recommended for multi-chain
-sampling with multiple seed values required only if RNG functions are used
-in the transformed data block and the goal is to generate different
-data for each chain.}
+\item{seed}{(positive integer(s)) A seed for the (P)RNG to pass to CmdStan.
+In the case of multi-chain sampling the single \code{seed} will automatically be
+augmented by the the run (chain) ID so that each chain uses a different
+seed. The exception is the \verb{transformed data} block, which defaults to
+using same seed for all chains so that the same data is generated for all
+chains if RNG functions are used. The only time \code{seed} should be specified
+as a vector (one element per chain) is if RNG functions are used in
+\verb{transformed data} and the goal is to generate \emph{different} data for each
+chain.}
 
 \item{refresh}{(non-negative integer) The number of iterations between
 printed screen updates. If \code{refresh = 0}, only error messages will be

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -56,7 +56,13 @@ processes. For example, \code{mpi_args = list("n" = 4)} launches the executable
 as \verb{mpiexec -n 4 model_executable}, followed by CmdStan arguments for the
 model executable.}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.}
+\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
+The seed is used in the transformed data block and together with
+the run (chain) ID to augment the seed used for sampling, optimization
+or variational inference. A single seed value is recommended for multi-chain
+sampling with multiple seed values required only if RNG functions are used
+in the transformed data block and the goal is to generate different
+data for each chain.}
 
 \item{refresh}{(non-negative integer) The number of iterations between
 printed screen updates. If \code{refresh = 0}, only error messages will be

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -56,13 +56,15 @@ processes. For example, \code{mpi_args = list("n" = 4)} launches the executable
 as \verb{mpiexec -n 4 model_executable}, followed by CmdStan arguments for the
 model executable.}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
-The seed is used in the transformed data block and together with
-the run (chain) ID to augment the seed used for sampling, optimization
-or variational inference. A single seed value is recommended for multi-chain
-sampling with multiple seed values required only if RNG functions are used
-in the transformed data block and the goal is to generate different
-data for each chain.}
+\item{seed}{(positive integer(s)) A seed for the (P)RNG to pass to CmdStan.
+In the case of multi-chain sampling the single \code{seed} will automatically be
+augmented by the the run (chain) ID so that each chain uses a different
+seed. The exception is the \verb{transformed data} block, which defaults to
+using same seed for all chains so that the same data is generated for all
+chains if RNG functions are used. The only time \code{seed} should be specified
+as a vector (one element per chain) is if RNG functions are used in
+\verb{transformed data} and the goal is to generate \emph{different} data for each
+chain.}
 
 \item{refresh}{(non-negative integer) The number of iterations between
 printed screen updates. If \code{refresh = 0}, only error messages will be

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -38,7 +38,13 @@ appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no \code{data} block.
 }}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.}
+\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
+The seed is used in the transformed data block and together with
+the run (chain) ID to augment the seed used for sampling, optimization
+or variational inference. A single seed value is recommended for multi-chain
+sampling with multiple seed values required only if RNG functions are used
+in the transformed data block and the goal is to generate different
+data for each chain.}
 
 \item{refresh}{(non-negative integer) The number of iterations between
 printed screen updates. If \code{refresh = 0}, only error messages will be

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -38,13 +38,15 @@ appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no \code{data} block.
 }}
 
-\item{seed}{(positive integer) A seed for the (P)RNG to pass to CmdStan.
-The seed is used in the transformed data block and together with
-the run (chain) ID to augment the seed used for sampling, optimization
-or variational inference. A single seed value is recommended for multi-chain
-sampling with multiple seed values required only if RNG functions are used
-in the transformed data block and the goal is to generate different
-data for each chain.}
+\item{seed}{(positive integer(s)) A seed for the (P)RNG to pass to CmdStan.
+In the case of multi-chain sampling the single \code{seed} will automatically be
+augmented by the the run (chain) ID so that each chain uses a different
+seed. The exception is the \verb{transformed data} block, which defaults to
+using same seed for all chains so that the same data is generated for all
+chains if RNG functions are used. The only time \code{seed} should be specified
+as a vector (one element per chain) is if RNG functions are used in
+\verb{transformed data} and the goal is to generate \emph{different} data for each
+chain.}
 
 \item{refresh}{(non-negative integer) The number of iterations between
 printed screen updates. If \code{refresh = 0}, only error messages will be

--- a/tests/testthat/test-csv.R
+++ b/tests/testthat/test-csv.R
@@ -556,3 +556,14 @@ test_that("as_cmdstan_fit creates fitted model objects from csv", {
     }
   }
 })
+
+test_that("read_cmdstan_csv reads seed correctly", {
+  opt <- read_cmdstan_csv(fit_bernoulli_optimize$output_files())
+  vi <- read_cmdstan_csv(fit_bernoulli_variational$output_files())
+  smp <- read_cmdstan_csv(fit_bernoulli_diag_e_no_samples$output_files())
+  expect_equal(opt$metadata$seed, 123)
+  expect_equal(vi$metadata$seed, 123)
+  expect_equal(smp$metadata$seed, 123)
+})
+
+

--- a/tests/testthat/test-failed-chains.R
+++ b/tests/testthat/test-failed-chains.R
@@ -16,14 +16,17 @@ if (not_on_cran()) {
 
   make_some_fail <- function(x) {
     num_files <- 0
+    attempt <- 1
     while (num_files == 0 || num_files == 4) {
       utils::capture.output(
         check_some_fail <- x$sample(
           data = list(pr_fail = 0.5),
-          save_latent_dynamics = TRUE
+          save_latent_dynamics = TRUE,
+          seed = sample.int(attempt*1000, 4)
         )
       )
       num_files <- length(check_some_fail$output_files(include_failed = FALSE))
+      attempt <- attempt + 1
     }
     check_some_fail
   }

--- a/tests/testthat/test-failed-chains.R
+++ b/tests/testthat/test-failed-chains.R
@@ -22,7 +22,7 @@ if (not_on_cran()) {
         check_some_fail <- x$sample(
           data = list(pr_fail = 0.5),
           save_latent_dynamics = TRUE,
-          seed = sample.int(attempt*1000, 4)
+          seed = base::sample(.Machine$integer.max, 4)
         )
       )
       num_files <- length(check_some_fail$output_files(include_failed = FALSE))

--- a/tests/testthat/test-model-sample.R
+++ b/tests/testthat/test-model-sample.R
@@ -265,51 +265,51 @@ test_that("print statements in transformed data work", {
   expect_true(any(grepl("*N = 2*", out)))
 })
 
-test_that("seed works for multi chain sampling", {
-  skip_on_cran()
-  m <- "
-  transformed data {
-    int N = 100;
-    vector[N] a;
-    for (i in 1:N) {
-      a[i] = uniform_rng(0, 1);
-    }
-  }
-  parameters {
-    real y;
-  }
-  model {
-    y ~ std_normal();
-  }
-  generated quantities {
-    vector[N] tdata = a;
-    vector[N] gq;
-    for (i in 1:N) {
-      gq[i] = uniform_rng(0, 4);
-    }
-  }
-  "
-  f <- write_stan_file(m, basename = "rngs.stan")
-  mod <- cmdstan_model(f)
-  utils::capture.output(
-    fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100, seed = 2)
-  )
-  chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)
-  chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 2)
-  expect_equal(chain_tdata_1, chain_tdata_2)
-  chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 1)
-  chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 2)
-  expect_false(all(chain_tdata_1 == chain_tdata_2))
+# test_that("seed works for multi chain sampling", {
+#   skip_on_cran()
+#   m <- "
+#   transformed data {
+#     int N = 100;
+#     vector[N] a;
+#     for (i in 1:N) {
+#       a[i] = uniform_rng(0, 1);
+#     }
+#   }
+#   parameters {
+#     real y;
+#   }
+#   model {
+#     y ~ std_normal();
+#   }
+#   generated quantities {
+#     vector[N] tdata = a;
+#     vector[N] gq;
+#     for (i in 1:N) {
+#       gq[i] = uniform_rng(0, 4);
+#     }
+#   }
+#   "
+#   f <- write_stan_file(m, basename = "rngs.stan")
+#   mod <- cmdstan_model(f)
+#   utils::capture.output(
+#     fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100, seed = 2)
+#   )
+#   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)
+#   chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 2)
+#   expect_equal(chain_tdata_1, chain_tdata_2)
+#   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 1)
+#   chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 2)
+#   expect_false(all(chain_tdata_1 == chain_tdata_2))
 
-  utils::capture.output(
-    fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100,
-                             seed = c(1, 2))
-  )
-  chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)
-  chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 2)
-  expect_false(all(chain_tdata_1 == chain_tdata_2))
-  chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 1)
-  chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 2)
-  expect_false(all(chain_tdata_1 == chain_tdata_2))
-})
+#   utils::capture.output(
+#     fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100,
+#                              seed = c(1, 2))
+#   )
+#   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)
+#   chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 2)
+#   expect_false(all(chain_tdata_1 == chain_tdata_2))
+#   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 1)
+#   chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 2)
+#   expect_false(all(chain_tdata_1 == chain_tdata_2))
+# })
 

--- a/tests/testthat/test-model-sample.R
+++ b/tests/testthat/test-model-sample.R
@@ -265,51 +265,51 @@ test_that("print statements in transformed data work", {
   expect_true(any(grepl("*N = 2*", out)))
 })
 
-# test_that("seed works for multi chain sampling", {
-#   skip_on_cran()
-#   m <- "
-#   transformed data {
-#     int N = 100;
-#     vector[N] a;
-#     for (i in 1:N) {
-#       a[i] = uniform_rng(0, 1);
-#     }
-#   }
-#   parameters {
-#     real y;
-#   }
-#   model {
-#     y ~ std_normal();
-#   }
-#   generated quantities {
-#     vector[N] tdata = a;
-#     vector[N] gq;
-#     for (i in 1:N) {
-#       gq[i] = uniform_rng(0, 4);
-#     }
-#   }
-#   "
-#   f <- write_stan_file(m, basename = "rngs.stan")
-#   mod <- cmdstan_model(f)
-#   utils::capture.output(
-#     fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100, seed = 2)
-#   )
-#   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)
-#   chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 2)
-#   expect_equal(chain_tdata_1, chain_tdata_2)
-#   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 1)
-#   chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 2)
-#   expect_false(all(chain_tdata_1 == chain_tdata_2))
+test_that("seed works for multi chain sampling", {
+  skip_on_cran()
+  m <- "
+  transformed data {
+    int N = 100;
+    vector[N] a;
+    for (i in 1:N) {
+      a[i] = uniform_rng(0, 1);
+    }
+  }
+  parameters {
+    real y;
+  }
+  model {
+    y ~ std_normal();
+  }
+  generated quantities {
+    vector[N] tdata = a;
+    vector[N] gq;
+    for (i in 1:N) {
+      gq[i] = uniform_rng(0, 4);
+    }
+  }
+  "
+  f <- write_stan_file(m, basename = "rngs.stan")
+  mod <- cmdstan_model(f)
+  utils::capture.output(
+    fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100, seed = 2)
+  )
+  chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)
+  chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 2)
+  expect_equal(chain_tdata_1, chain_tdata_2)
+  chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 1)
+  chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 2)
+  expect_false(all(chain_tdata_1 == chain_tdata_2))
 
-#   utils::capture.output(
-#     fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100,
-#                              seed = c(1, 2))
-#   )
-#   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)
-#   chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 2)
-#   expect_false(all(chain_tdata_1 == chain_tdata_2))
-#   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 1)
-#   chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 2)
-#   expect_false(all(chain_tdata_1 == chain_tdata_2))
-# })
+  utils::capture.output(
+    fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100,
+                             seed = c(1, 2))
+  )
+  chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)
+  chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 2)
+  expect_false(all(chain_tdata_1 == chain_tdata_2))
+  chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 1)
+  chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("gq"), chain = 2)
+  expect_false(all(chain_tdata_1 == chain_tdata_2))
+})
 


### PR DESCRIPTION
#### Summary

Right now, cmdstanr sets different seeds for each of the cmdstan process call even if only one seed is given.
```
fit <- mod$sample(..., seed = 2)
```
will set seeds 2,3,4,5 for the 4 chains. This is not ok in the case where transformed uses any _rng functions as
that means that the 4 chains would not have the same data. Even if we set the same seed for all chains, the 
seed used in the rest of the model is actually the seed with a stride defined by the id. See https://github.com/stan-dev/stan/blob/develop/src/stan/services/util/create_rng.hpp#L27
So what we need to do is set the same seeds for all subprocesses.

Test model:
  
```stan
transformed data {
  int N = 100;
  vector[N] a;
  for (i in 1:N) {
    a[i] = uniform_rng(0, 1);
  }
}
parameters {
  real y;
}
model {
  y ~ std_normal();
}
generated quantities {
  vector[N] tdata = a;
  vector[N] gq;
  for (i in 1:N) {
    gq[i] = uniform_rng(0, 4);
  }
}
```

```R
mod <- cmdstan_model("model.stan")
fit <- mod$sample(iter_sampling = 1)
> fit$draws("tdata")
# A draws_array: 1 iterations, 4 chains, and 100 variables
, , variable = tdata[1]

chain
iteration    1    2    3   4
1 0.19 0.62 0.42 0.4

, , variable = tdata[2]

chain
iteration    1    2    3    4
1 0.74 0.67 0.49 0.31

, , variable = tdata[3]

chain
iteration    1    2    3     4
1 0.66 0.95 0.12 0.073

, , variable = tdata[4]

chain
iteration     1    2 3    4
1 0.011 0.82 1 0.45

# ... with 96 more variables

```

This PR fixes this so that these are the same across chains. A test was added to make sure chains actually have a different seed outside of data.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
