### PR TITLE
Deterministic filenames for `write_stan_file`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,7 +31,8 @@ Imports:
     jsonlite (>= 1.2.0),
     posterior (>= 0.1.3),
     processx (>= 3.5.0),
-    R6 (>= 2.4.0)
+    R6 (>= 2.4.0),
+    rlang (>= 0.4.7)
 Suggests: 
     bayesplot,
     knitr,

--- a/man/write_stan_file.Rd
+++ b/man/write_stan_file.Rd
@@ -4,7 +4,13 @@
 \alias{write_stan_file}
 \title{Write Stan code to a file}
 \usage{
-write_stan_file(code, dir = tempdir(), basename = NULL)
+write_stan_file(
+  code,
+  dir = tempdir(),
+  basename = NULL,
+  force_overwrite = FALSE,
+  hash_salt = ""
+)
 }
 \arguments{
 \item{code}{A single string containing a Stan program or a character vector
@@ -15,7 +21,13 @@ If omitted, a \link[base:tempfile]{temporary directory} is used by default.}
 
 \item{basename}{If \code{dir} is specified, an optional string providing the
 basename for the file created. If not specified a file name is generated
-via \code{\link[base:tempfile]{base::tempfile()}}.}
+via \code{\link[rlang:hash]{rlang::hash()}} of the code.}
+
+\item{force_overwrite}{if set to \code{TRUE} the file will always be
+overwritten and thus the resulting model will always be recompiled}
+
+\item{hash_salt}{will be added to model code prior hashing to determine
+filename if the \code{basename} param is not set.}
 }
 \value{
 The path to the file.
@@ -23,6 +35,13 @@ The path to the file.
 \description{
 Convenience function for writing Stan code to a (possibly
 \link[base:tempfile]{temporary}) file with a \code{.stan} extension.
+By default, the filename is chosen deterministically based on the Stan code
+via \code{\link[rlang:hash]{rlang::hash()}},
+and the file is not overwritten if it already has correct contents.
+This means that calling this function multiple times with the same Stan code
+will reuse the compiled model. This also however means that the function
+is potentially not thread-safe. Using \code{hash_salt = Sys.getpid()} should
+ensure thread-safety in the rare cases when it is needed.
 }
 \examples{
 # stan program as a single string

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -67,6 +67,31 @@ test_that("write_stan_file creates dir if necessary", {
   )
 })
 
+test_that("write_stan_file by default creates the same file for the same Stan model", {
+  dir <- file.path(test_path(), "answers")
+
+  f1 <- write_stan_file(stan_program, dir = dir)
+  mtime1 <- file.info(f1)$mtime
+
+  f2 <- write_stan_file(paste0(stan_program, "\n\n"), dir = dir)
+  expect_true(f1 != f2)
+
+  # Test that writing the some model will not touch the file
+  # Wait a tiny bit to make sure the modified time will be different if
+  # overwrite happened
+  Sys.sleep(0.001)
+  f3 <- write_stan_file(stan_program, dir = dir)
+  expect_equal(f1, f3)
+
+  mtime3 <- file.info(f3)$mtime
+  expect_equal(mtime1, mtime3)
+
+  # f4 <- write_stan_file(stan_program, hash_salt = "aaa")
+  # expect_true(f1 != f4)
+
+  try(file.remove(f1, f2, f3, f4), silent = TRUE)
+})
+
 test_that("write_stan_tempfile is deprecated", {
   expect_warning(write_stan_tempfile(stan_program), "deprecated")
 })


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Makes `write_stan_file` choose filenames deterministically based on the code, so that models do not get unnecessarily recompiled  when calling `write_stan_file` multiple times with the same code, as discussed in #483.

To make this work I needed a hashing algorithm. I chose `rlang::hash`, because we already implicitly depend on `rlang` via `posterior`. The dependency for `rlang` has now been made explicit. I think that's not a big burden, but if needed, the dependency can probably be removed and we can have hashing function implemented locally (it doesn't seem that base R has a hashing function exposed).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 

Institute of Microbiology of the Czech Academy of Sciences

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
