### PR TITLE
Move rlang to suggests

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -20,7 +20,7 @@ jobs:
     name: ${{ matrix.config.os }} (${{ matrix.config.r }})
 
     strategy:
-      fail-fast: true
+      fail-fast: false
       matrix:
         config:
           - {os: macOS-latest, r: 'devel'}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -31,12 +31,12 @@ Imports:
     jsonlite (>= 1.2.0),
     posterior (>= 0.1.5),
     processx (>= 3.5.0),
-    R6 (>= 2.4.0),
-    rlang (>= 0.4.7)
+    R6 (>= 2.4.0)
 Suggests: 
     bayesplot,
     knitr,
     loo (>= 2.0.0),
+    rlang (>= 0.4.7),
     rmarkdown,
     testthat (>= 2.1.0)
 Additional_repositories:

--- a/R/example.R
+++ b/R/example.R
@@ -142,8 +142,11 @@ print_example_program <-
 #' f2 <- write_stan_file(lines)
 #' identical(readLines(f), readLines(f2))
 #'
-write_stan_file <- function(code, dir = tempdir(), basename = NULL,
-                            force_overwrite = FALSE, hash_salt = "") {
+write_stan_file <- function(code,
+                            dir = tempdir(),
+                            basename = NULL,
+                            force_overwrite = FALSE,
+                            hash_salt = "") {
   if (!dir.exists(dir)) {
     dir.create(dir, recursive = TRUE)
   }
@@ -155,6 +158,7 @@ write_stan_file <- function(code, dir = tempdir(), basename = NULL,
     }
     file <- file.path(dir, basename)
   } else {
+    require_suggested_package("rlang")
     hash <- rlang::hash(paste0(hash_salt, collapsed_code))
     file <- file.path(dir, paste0("model_", hash, ".stan"))
   }

--- a/R/fit.R
+++ b/R/fit.R
@@ -998,7 +998,7 @@ CmdStanMCMC <- R6::R6Class(
 #' }
 #'
 loo <- function(variables = "log_lik", r_eff = TRUE, ...) {
-  suggest_package("loo")
+  require_suggested_package("loo")
   LLarray <- self$draws(variables)
   if (is.logical(r_eff)) {
     if (isTRUE(r_eff)) {

--- a/R/knitr.R
+++ b/R/knitr.R
@@ -39,7 +39,7 @@
 #' * [knitr's built-in Stan language engine](https://bookdown.org/yihui/rmarkdown/language-engines.html#stan)
 #'
 register_knitr_engine <- function(override = TRUE) {
-  suggest_package("knitr")
+  require_suggested_package("knitr")
   if (override) {
     knitr::knit_engines$set(stan = eng_cmdstan)
   } else {
@@ -63,7 +63,7 @@ register_knitr_engine <- function(override = TRUE) {
 #' }
 #' @export
 eng_cmdstan <- function(options) {
-  suggest_package("knitr")
+  require_suggested_package("knitr")
   output_var <- options$output.var
   if (!is.character(output_var) || length(output_var) != 1L) {
     stop(

--- a/R/utils.R
+++ b/R/utils.R
@@ -2,7 +2,7 @@
 
 require_suggested_package <- function(pkg) {
   if (!requireNamespace(pkg, quietly = TRUE)) {
-    stop("Please install the ", pkg, " package to use this function.",
+    stop("Please install the '", pkg, "' package to use this function.",
          call. = FALSE)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -1,6 +1,6 @@
 # misc --------------------------------------------------------------------
 
-suggest_package <- function(pkg) {
+require_suggested_package <- function(pkg) {
   if (!requireNamespace(pkg, quietly = TRUE)) {
     stop("Please install the ", pkg, " package to use this function.",
          call. = FALSE)

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -35,6 +35,7 @@ stan_program <- "
   "
 
 test_that("write_stan_file writes Stan file correctly", {
+  skip_if_not_installed("rlang")
   f1 <- write_stan_file(stan_program)
   checkmate::expect_file_exists(f1, extension = "stan")
   f1_lines <- readLines(f1)
@@ -48,8 +49,7 @@ test_that("write_stan_file writes Stan file correctly", {
 
 test_that("write_stan_file writes to specified directory and filename", {
   dir <- file.path(test_path(), "answers")
-
-  expect_equal(dirname(f1 <- write_stan_file(stan_program, dir = dir)), dir)
+  expect_equal(dirname(f1 <- write_stan_file(stan_program, dir = dir, basename = "pasta")), dir)
   expect_equal(f2 <- write_stan_file(stan_program, dir = dir, basename = "fruit.stan"),
                file.path(dir, "fruit.stan"))
   expect_equal(f3 <- write_stan_file(stan_program, dir = dir, basename = "vegetable"),
@@ -68,6 +68,7 @@ test_that("write_stan_file creates dir if necessary", {
 })
 
 test_that("write_stan_file by default creates the same file for the same Stan model", {
+  skip_if_not_installed("rlang")
   dir <- file.path(test_path(), "answers")
 
   f1 <- write_stan_file(stan_program, dir = dir)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -171,3 +171,10 @@ test_that("matching_variables() works", {
   )
   expect_equal(length(ret$not_found), 0)
 })
+
+test_that("require_suggested_package() works", {
+  expect_error(
+    require_suggested_package("not_a_real_package"),
+    "Please install the 'not_a_real_package' package to use this function."
+  )
+})


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

* Moves rlang package from Imports to Suggests (it's only required if `basename` isn't specified)
* renames the `suggest_package()` internal function to `require_suggested_package()`, which is why it actually does

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
