### PR TITLE
document conversions performed by write_stan_json

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -4,6 +4,31 @@
 #' @param data (list) A named list of \R objects.
 #' @param file (string) The path to where the data file should be written.
 #'
+#' @details
+#' `write_stan_json()` performs several conversions before writing the JSON
+#' file:
+#'
+#' * `logical` -> `integer` (`TRUE` -> `1`, `FALSE` -> `0`)
+#' * `data.frame` -> `matrix` (via [data.matrix()])
+#' * `list` -> `array`
+#'
+#' The `list` to `array` conversion is intended to make it easier to prepare
+#' the data for certain Stan declarations involving arrays:
+#'
+#' * `vector[J] v[K]` (or equivalently `array[K] vector[J] v ` as of Stan 2.27)
+#' can be constructed in \R as a list with `K` elements where each element a
+#' vector of length `J`
+#' * `matrix[I,J] v[K]` (or equivalently `array[K] matrix[I,J] m ` as of Stan
+#' 2.27 ) can be constructed in \R as a list with `K` elements where each element
+#' an `IxJ` matrix
+#'
+#' These can also be passed in from \R as arrays instead of lists but the list
+#' option is provided for convenience. Unfortunately for arrays with more than
+#' one dimension, e.g., `vector[J] v[K,L]` (or equivalently
+#' `array[K,L] vector[J] v ` as of Stan 2.27) it is not possible to use an \R
+#' list and an array must be used instead. For this example the array in \R
+#' should have dimensions `KxLxJ`.
+#'
 #' @examples
 #' x <- matrix(rnorm(10), 5, 2)
 #' y <- rpois(nrow(x), lambda = 10)
@@ -15,6 +40,15 @@
 #' write_stan_json(data, file)
 #'
 #' # check the contents of the file
+#' cat(readLines(file), sep = "\n")
+#'
+#'
+#' # demonstrating list to array conversion
+#' # suppose x is declared as `vector[3] x[2]` (or equivalently `array[2] vector[3] x`)
+#' # we can use a list of length 2 where each element is a vector of length 3
+#' data <- list(x = list(1:3, 4:6))
+#' file <- tempfile(fileext = ".json")
+#' write_stan_json(data, file)
 #' cat(readLines(file), sep = "\n")
 #'
 write_stan_json <- function(data, file) {

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -1,7 +1,10 @@
 #' @param data (multiple options) The data to use for the variables specified in
 #'   the data block of the Stan program. One of the following:
-#'  * A named list of \R objects (like for RStan). Internally this list is then
-#'  written to JSON for CmdStan using [write_stan_json()].
+#'  * A named list of \R objects with the names corresponding to variables
+#'  declared in the data block of the Stan program. Internally this list is then
+#'  written to JSON for CmdStan using [write_stan_json()]. See
+#'  [write_stan_json()] for details on the conversions performed on \R objects
+#'  before they are passed to Stan.
 #'  * A path to a data file compatible with CmdStan (JSON or \R dump). See the
 #'  appendices in the CmdStan manual for details on using these formats.
 #'  * `NULL` or an empty list if the Stan program has no data block.

--- a/man/model-method-diagnose.Rd
+++ b/man/model-method-diagnose.Rd
@@ -20,8 +20,11 @@ diagnose_method(
 \item{data}{(multiple options) The data to use for the variables specified in
 the data block of the Stan program. One of the following:
 \itemize{
-\item A named list of \R objects (like for RStan). Internally this list is then
-written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}.
+\item A named list of \R objects with the names corresponding to variables
+declared in the data block of the Stan program. Internally this list is then
+written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}. See
+\code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
+before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
 appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.

--- a/man/model-method-generate-quantities.Rd
+++ b/man/model-method-generate-quantities.Rd
@@ -30,8 +30,11 @@ VB) object returned by CmdStanR's \code{\link[=fit-method-draws]{$draws()}} meth
 \item{data}{(multiple options) The data to use for the variables specified in
 the data block of the Stan program. One of the following:
 \itemize{
-\item A named list of \R objects (like for RStan). Internally this list is then
-written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}.
+\item A named list of \R objects with the names corresponding to variables
+declared in the data block of the Stan program. Internally this list is then
+written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}. See
+\code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
+before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
 appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -31,8 +31,11 @@ optimize(
 \item{data}{(multiple options) The data to use for the variables specified in
 the data block of the Stan program. One of the following:
 \itemize{
-\item A named list of \R objects (like for RStan). Internally this list is then
-written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}.
+\item A named list of \R objects with the names corresponding to variables
+declared in the data block of the Stan program. Internally this list is then
+written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}. See
+\code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
+before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
 appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -50,8 +50,11 @@ sample(
 \item{data}{(multiple options) The data to use for the variables specified in
 the data block of the Stan program. One of the following:
 \itemize{
-\item A named list of \R objects (like for RStan). Internally this list is then
-written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}.
+\item A named list of \R objects with the names corresponding to variables
+declared in the data block of the Stan program. Internally this list is then
+written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}. See
+\code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
+before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
 appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -41,8 +41,11 @@ sample_mpi(
 \item{data}{(multiple options) The data to use for the variables specified in
 the data block of the Stan program. One of the following:
 \itemize{
-\item A named list of \R objects (like for RStan). Internally this list is then
-written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}.
+\item A named list of \R objects with the names corresponding to variables
+declared in the data block of the Stan program. Internally this list is then
+written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}. See
+\code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
+before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
 appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -32,8 +32,11 @@ variational(
 \item{data}{(multiple options) The data to use for the variables specified in
 the data block of the Stan program. One of the following:
 \itemize{
-\item A named list of \R objects (like for RStan). Internally this list is then
-written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}.
+\item A named list of \R objects with the names corresponding to variables
+declared in the data block of the Stan program. Internally this list is then
+written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json()}}. See
+\code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
+before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
 appendices in the CmdStan manual for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.

--- a/man/write_stan_json.Rd
+++ b/man/write_stan_json.Rd
@@ -14,6 +14,33 @@ write_stan_json(data, file)
 \description{
 Write data to a JSON file readable by CmdStan
 }
+\details{
+\code{write_stan_json()} performs several conversions before writing the JSON
+file:
+\itemize{
+\item \code{logical} -> \code{integer} (\code{TRUE} -> \code{1}, \code{FALSE} -> \code{0})
+\item \code{data.frame} -> \code{matrix} (via \code{\link[=data.matrix]{data.matrix()}})
+\item \code{list} -> \code{array}
+}
+
+The \code{list} to \code{array} conversion is intended to make it easier to prepare
+the data for certain Stan declarations involving arrays:
+\itemize{
+\item \verb{vector[J] v[K]} (or equivalently \verb{array[K] vector[J] v } as of Stan 2.27)
+can be constructed in \R as a list with \code{K} elements where each element a
+vector of length \code{J}
+\item \verb{matrix[I,J] v[K]} (or equivalently \verb{array[K] matrix[I,J] m } as of Stan
+2.27 ) can be constructed in \R as a list with \code{K} elements where each element
+an \code{IxJ} matrix
+}
+
+These can also be passed in from \R as arrays instead of lists but the list
+option is provided for convenience. Unfortunately for arrays with more than
+one dimension, e.g., \verb{vector[J] v[K,L]} (or equivalently
+\verb{array[K,L] vector[J] v } as of Stan 2.27) it is not possible to use an \R
+list and an array must be used instead. For this example the array in \R
+should have dimensions \code{KxLxJ}.
+}
 \examples{
 x <- matrix(rnorm(10), 5, 2)
 y <- rpois(nrow(x), lambda = 10)
@@ -25,6 +52,15 @@ file <- tempfile(fileext = ".json")
 write_stan_json(data, file)
 
 # check the contents of the file
+cat(readLines(file), sep = "\n")
+
+
+# demonstrating list to array conversion
+# suppose x is declared as `vector[3] x[2]` (or equivalently `array[2] vector[3] x`)
+# we can use a list of length 2 where each element is a vector of length 3
+data <- list(x = list(1:3, 4:6))
+file <- tempfile(fileext = ".json")
+write_stan_json(data, file)
 cat(readLines(file), sep = "\n")
 
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Documents the different conversions (e.g. list -> array) performed by `write_stan_json()`. I was going to add a note about this issue described in #513 but I decided not too since @rok-cesnovar pointed out that we can solve that problem automatically using the new info about types provided by Stan v2.27. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
