### PR TITLE
Change default directory to .cmdstan

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -96,7 +96,7 @@ jobs:
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
           install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
-          install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
+          remotes::install_local(path = ".")
           install.packages("curl")
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -40,7 +40,7 @@ jobs:
     steps:
       - name: cmdstan env vars
         run: |
-          echo "CMDSTAN_PATH=${HOME}/.cmdstanr" >> $GITHUB_ENV
+          echo "CMDSTAN_PATH=${HOME}/.cmdstan" >> $GITHUB_ENV
         shell: bash
 
       - uses: n1hility/cancel-previous-runs@v2

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -25,7 +25,7 @@ jobs:
     steps:
       - name: cmdstan env vars
         run: |
-          echo "CMDSTAN_PATH=${HOME}/.cmdstanr" >> $GITHUB_ENV
+          echo "CMDSTAN_PATH=${HOME}/.cmdstan" >> $GITHUB_ENV
         shell: bash
 
       - uses: n1hility/cancel-previous-runs@v2

--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -59,7 +59,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages(c("posterior", "cmdstanr", "remotes", "curl"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
+          install.packages(c("posterior", "remotes", "curl"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
+          remotes::install_local(path = ".")
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")
           remotes::install_cran("gridExtra")
@@ -121,7 +122,8 @@ jobs:
 
       - name: Install dependencies
         run: |
-          install.packages(c("posterior", "cmdstanr", "remotes", "curl"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
+          install.packages(c("posterior", "remotes", "curl"),repos = c("https://mc-stan.org/r-packages/", getOption("repos")), dependencies = TRUE)
+          remotes::install_local(path = ".")
           cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("covr")

--- a/.github/workflows/cmdstan-tarball-check.yaml
+++ b/.github/workflows/cmdstan-tarball-check.yaml
@@ -79,7 +79,7 @@ jobs:
           remotes::install_deps(dependencies = TRUE)
           remotes::install_cran("rcmdcheck")
           install.packages("posterior", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
-          install.packages("cmdstanr", repos = c("https://mc-stan.org/r-packages/", getOption("repos")), type="source")
+          remotes::install_local(path = ".")
           if (Sys.getenv("CMDSTAN_TEST_TARBALL_URL") == "latest") {
             cmdstanr::install_cmdstan(cores = 2, overwrite = TRUE)
           } else {

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # cmdstanr 0.4.0.9000
 
+* Default directory changed to `.cmdstan` instead of `.cmdstanr` so that
+CmdStanPy and CmdStanR can use the same CmdStan installations. (#454)
+
 * Expose CmdStan's `diagnose` method that compares Stan's gradient computations
 to gradients computed via finite differences. (#485)
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,10 @@
 # cmdstanr 0.4.0.9000
 
 * Default directory changed to `.cmdstan` instead of `.cmdstanr` so that
-CmdStanPy and CmdStanR can use the same CmdStan installations. (#454)
+CmdStanPy and CmdStanR can use the same CmdStan installations. Using `.cmdstanr`
+will continue to be supported until version 1.0 but `install_cmdstan()` will now
+default to `.cmdstan` and CmdStanR will first look for `.cmdstan` before falling
+back on `.cmdstanr`. (#454)
 
 * Expose CmdStan's `diagnose` method that compares Stan's gradient computations
 to gradients computed via finite differences. (#485)

--- a/R/install.R
+++ b/R/install.R
@@ -25,8 +25,8 @@
 #'
 #' @export
 #' @param dir (string) The path to the directory in which to install CmdStan.
-#'   The default is to install it in a directory called `.cmdstanr` within the
-#'   user's home directory (i.e, `file.path(Sys.getenv("HOME"), ".cmdstanr")`).
+#'   The default is to install it in a directory called `.cmdstan` within the
+#'   user's home directory (i.e, `file.path(Sys.getenv("HOME"), ".cmdstan")`).
 #' @param cores (integer) The number of CPU cores to use to parallelize building
 #'   CmdStan and speed up installation. If `cores` is not specified then the
 #'   default is to look for the option `"mc.cores"`, which can be set for an

--- a/R/path.R
+++ b/R/path.R
@@ -35,7 +35,7 @@
 #'
 set_cmdstan_path <- function(path = NULL) {
   if (is.null(path)) {
-    path <- cmdstan_default_path()
+    path <- cmdstan_default_path() || cmdstan_default_path(old = TRUE)
   }
   if (dir.exists(path)) {
     path <- absolute_path(path)

--- a/R/path.R
+++ b/R/path.R
@@ -35,7 +35,7 @@
 #'
 set_cmdstan_path <- function(path = NULL) {
   if (is.null(path)) {
-    path <- cmdstan_default_path() || cmdstan_default_path(old = TRUE)
+    path <- cmdstan_default_path() %||% cmdstan_default_path(old = TRUE)
   }
   if (dir.exists(path)) {
     path <- absolute_path(path)

--- a/R/path.R
+++ b/R/path.R
@@ -23,7 +23,7 @@
 #' then its value will be automatically set as the default path to CmdStan for
 #' the \R session.
 #' * If no environment variable is found when loaded but any directory in the
-#' form `".cmdstanr/cmdstan-[version]"` (e.g., `".cmdstanr/cmdstan-2.23.0"`),
+#' form `".cmdstan/cmdstan-[version]"` (e.g., `".cmdstan/cmdstan-2.23.0"`),
 #' exists in the user's home directory (`Sys.getenv("HOME")`, *not* the current
 #' working directory) then the path to the cmdstan with the largest version
 #' number will be set as the path to CmdStan for the \R session. This is the
@@ -103,7 +103,7 @@ stop_no_path <- function() {
 #' @return The installation path.
 #' @export
 cmdstan_default_install_path <- function() {
-  file.path(Sys.getenv("HOME"), ".cmdstanr")
+  file.path(Sys.getenv("HOME"), ".cmdstan")
 }
 
 #' cmdstan_default_path

--- a/R/path.R
+++ b/R/path.R
@@ -100,10 +100,16 @@ stop_no_path <- function() {
 #' Path to where  [install_cmdstan()] with default settings installs CmdStan.
 #'
 #' @keywords internal
+#' @param old Should the old default path (.cmdstanr) be used instead of the new
+#'   one (.cmdstan)? Defaults to `FALSE` and may be removed in a future release.
 #' @return The installation path.
 #' @export
-cmdstan_default_install_path <- function() {
-  file.path(Sys.getenv("HOME"), ".cmdstan")
+cmdstan_default_install_path <- function(old = FALSE) {
+  if (old) {
+    file.path(Sys.getenv("HOME"), ".cmdstanr")
+  } else {
+    file.path(Sys.getenv("HOME"), ".cmdstan")
+  }
 }
 
 #' cmdstan_default_path
@@ -113,11 +119,12 @@ cmdstan_default_install_path <- function() {
 #'
 #' @export
 #' @keywords internal
+#' @param old See [cmdstan_default_install_path()].
 #' @return Path to the CmdStan installation with the most recent release
 #'   version, or `NULL` if no installation found.
 #'
-cmdstan_default_path <- function() {
-  installs_path <- cmdstan_default_install_path()
+cmdstan_default_path <- function(old = FALSE) {
+  installs_path <- cmdstan_default_install_path(old)
   if (dir.exists(installs_path)) {
     cmdstan_installs <- list.dirs(path = installs_path, recursive = FALSE, full.names = FALSE)
     # if installed in cmdstan folder with no version move to cmdstan-version folder

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -45,7 +45,7 @@ cmdstanr_initialize <- function() {
     }
 
   } else { # environment variable not found
-    path <- cmdstan_default_path()
+    path <- cmdstan_default_path() %||% cmdstan_default_path(old = TRUE)
     if (!is.null(path)) {
       suppressMessages(set_cmdstan_path(path))
     }

--- a/man/cmdstan_default_install_path.Rd
+++ b/man/cmdstan_default_install_path.Rd
@@ -4,7 +4,11 @@
 \alias{cmdstan_default_install_path}
 \title{cmdstan_default_install_path}
 \usage{
-cmdstan_default_install_path()
+cmdstan_default_install_path(old = FALSE)
+}
+\arguments{
+\item{old}{Should the old default path (.cmdstanr) be used instead of the new
+one (.cmdstan)? Defaults to \code{FALSE} and may be removed in a future release.}
 }
 \value{
 The installation path.

--- a/man/cmdstan_default_path.Rd
+++ b/man/cmdstan_default_path.Rd
@@ -4,7 +4,10 @@
 \alias{cmdstan_default_path}
 \title{cmdstan_default_path}
 \usage{
-cmdstan_default_path()
+cmdstan_default_path(old = FALSE)
+}
+\arguments{
+\item{old}{See \code{\link[=cmdstan_default_install_path]{cmdstan_default_install_path()}}.}
 }
 \value{
 Path to the CmdStan installation with the most recent release

--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -32,8 +32,8 @@ check_cmdstan_toolchain(fix = FALSE, quiet = FALSE)
 }
 \arguments{
 \item{dir}{(string) The path to the directory in which to install CmdStan.
-The default is to install it in a directory called \code{.cmdstanr} within the
-user's home directory (i.e, \code{file.path(Sys.getenv("HOME"), ".cmdstanr")}).}
+The default is to install it in a directory called \code{.cmdstan} within the
+user's home directory (i.e, \code{file.path(Sys.getenv("HOME"), ".cmdstan")}).}
 
 \item{cores}{(integer) The number of CPU cores to use to parallelize building
 CmdStan and speed up installation. If \code{cores} is not specified then the

--- a/man/set_cmdstan_path.Rd
+++ b/man/set_cmdstan_path.Rd
@@ -44,7 +44,7 @@ this to avoid having to manually set the path every session:
 then its value will be automatically set as the default path to CmdStan for
 the \R session.
 \item If no environment variable is found when loaded but any directory in the
-form \code{".cmdstanr/cmdstan-[version]"} (e.g., \code{".cmdstanr/cmdstan-2.23.0"}),
+form \code{".cmdstan/cmdstan-[version]"} (e.g., \code{".cmdstan/cmdstan-2.23.0"}),
 exists in the user's home directory (\code{Sys.getenv("HOME")}, \emph{not} the current
 working directory) then the path to the cmdstan with the largest version
 number will be set as the path to CmdStan for the \R session. This is the

--- a/vignettes/cmdstanr.Rmd
+++ b/vignettes/cmdstanr.Rmd
@@ -84,7 +84,7 @@ is useful if your CmdStan installation is not located in the default directory
 that would have been used by `install_cmdstan()` (see #2).
 
 2. If no environment variable is found when loaded but any directory in the form
-`".cmdstanr/cmdstan-[version]"`, for example `".cmdstanr/cmdstan-2.23.0"`,
+`".cmdstan/cmdstan-[version]"`, for example `".cmdstan/cmdstan-2.23.0"`,
 exists in the user's home directory (`Sys.getenv("HOME")`,
 *not* the current working directory) then the path to the CmdStan with the
 largest version number will be set as the path to CmdStan for the R session.


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Closes #454 

Changes default directory to `.cmdstan` instead of `.cmdstanr` so that CmdStanPy and CmdStanR can use same installation. If `.cmdstan` isn't found we still look for `.cmdstanr`, but we should eliminate that for version 1.0. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
