### PR TITLE
Always write doubles with decimal point for cmdstan input

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -100,6 +100,7 @@ write_stan_json <- function(data, file) {
     auto_unbox = TRUE,
     factor = "integer",
     digits = NA,
+    always_decimal = TRUE,
     pretty = TRUE
   )
 }


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Make `write_stan_json()` always use decimal points when saving floating point data, so that JSON parser of *cmdstan* can correctly read them as doubles.

Fixes #533, although it would be better to fix the *cmdstan* json parser to treat the input data according to the model `data { ... }` section declarations.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Alexey Stukalov**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
