### PR TITLE
Refactor the use of $variables() for processing data and inits

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -564,7 +564,7 @@ CmdStanModel$set("public", name = "compile", value = compile)
 #' }
 #'
 variables <- function() {
-  if (cmdstan_version() < "2.27") {
+  if (cmdstan_version() < "2.27.0") {
     stop("$variables() is only supported for CmdStan 2.27 or newer.", call. = FALSE)
   }
   if (is.null(private$variables_)) {
@@ -805,6 +805,10 @@ sample <- function(data = NULL,
     threads_per_proc = assert_valid_threads(threads_per_chain, self$cpp_options(), multiple_chains = TRUE),
     show_stderr_messages = show_messages
   )
+  model_variables <- NULL
+  if (cmdstan_version() >= "2.27.0") {
+    model_variables <- self$variables()
+  }
   sample_args <- SampleArgs$new(
     iter_warmup = iter_warmup,
     iter_sampling = iter_sampling,
@@ -821,14 +825,14 @@ sample <- function(data = NULL,
     term_buffer = term_buffer,
     window = window,
     fixed_param = fixed_param
-  )
+  )  
   args <- CmdStanArgs$new(
     method_args = sample_args,
     stan_file = self$stan_file(),
     model_name = self$model_name(),
     exe_file = self$exe_file(),
     proc_ids = checkmate::assert_integerish(chain_ids, lower = 1, len = chains, unique = TRUE, null.ok = FALSE),
-    data_file = process_data(data, self$stan_file(), self$include_paths()),
+    data_file = process_data(data, model_variables),
     save_latent_dynamics = save_latent_dynamics,
     seed = seed,
     init = init,
@@ -837,8 +841,7 @@ sample <- function(data = NULL,
     output_basename = output_basename,
     sig_figs = sig_figs,
     validate_csv = validate_csv,
-    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options()),
-    include_paths = self$include_paths()
+    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options())
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()
@@ -942,6 +945,10 @@ sample_mpi <- function(data = NULL,
     parallel_procs = 1,
     show_stderr_messages = show_messages
   )
+  model_variables <- NULL
+  if (cmdstan_version() >= "2.27.0") {
+    model_variables <- self$variables()
+  }
   sample_args <- SampleArgs$new(
     iter_warmup = iter_warmup,
     iter_sampling = iter_sampling,
@@ -965,7 +972,7 @@ sample_mpi <- function(data = NULL,
     model_name = self$model_name(),
     exe_file = self$exe_file(),
     proc_ids = checkmate::assert_integerish(chain_ids, lower = 1, len = chains, unique = TRUE, null.ok = FALSE),
-    data_file = process_data(data, self$stan_file(), self$include_paths()),
+    data_file = process_data(data, model_variables),
     save_latent_dynamics = save_latent_dynamics,
     seed = seed,
     init = init,
@@ -973,8 +980,7 @@ sample_mpi <- function(data = NULL,
     output_dir = output_dir,
     output_basename = output_basename,
     validate_csv = validate_csv,
-    sig_figs = sig_figs,
-    include_paths = self$include_paths()
+    sig_figs = sig_figs
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan_mpi(mpi_cmd, mpi_args)
@@ -1055,6 +1061,10 @@ optimize <- function(data = NULL,
     show_stdout_messages = (is.null(refresh) || refresh != 0),
     threads_per_proc = assert_valid_threads(threads, self$cpp_options())
   )
+  model_variables <- NULL
+  if (cmdstan_version() >= "2.27.0") {
+    model_variables <- self$variables()
+  }
   optimize_args <- OptimizeArgs$new(
     algorithm = algorithm,
     init_alpha = init_alpha,
@@ -1072,7 +1082,7 @@ optimize <- function(data = NULL,
     model_name = self$model_name(),
     exe_file = self$exe_file(),
     proc_ids = 1,
-    data_file = process_data(data, self$stan_file(), self$include_paths()),
+    data_file = process_data(data, model_variables),
     save_latent_dynamics = save_latent_dynamics,
     seed = seed,
     init = init,
@@ -1080,8 +1090,7 @@ optimize <- function(data = NULL,
     output_dir = output_dir,
     output_basename = output_basename,
     sig_figs = sig_figs,
-    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options()),
-    include_paths = self$include_paths()
+    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options())
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()
@@ -1166,6 +1175,10 @@ variational <- function(data = NULL,
     show_stdout_messages = (is.null(refresh) || refresh != 0),
     threads_per_proc = assert_valid_threads(threads, self$cpp_options())
   )
+  model_variables <- NULL
+  if (cmdstan_version() >= "2.27.0") {
+    model_variables <- self$variables()
+  }
   variational_args <- VariationalArgs$new(
     algorithm = algorithm,
     iter = iter,
@@ -1184,7 +1197,7 @@ variational <- function(data = NULL,
     model_name = self$model_name(),
     exe_file = self$exe_file(),
     proc_ids = 1,
-    data_file = process_data(data, self$stan_file(), self$include_paths()),
+    data_file = process_data(data, model_variables),
     save_latent_dynamics = save_latent_dynamics,
     seed = seed,
     init = init,
@@ -1192,8 +1205,7 @@ variational <- function(data = NULL,
     output_dir = output_dir,
     output_basename = output_basename,
     sig_figs = sig_figs,
-    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options()),
-    include_paths = self$include_paths()
+    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options())
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()
@@ -1281,6 +1293,10 @@ generate_quantities <- function(fitted_params,
     parallel_procs = checkmate::assert_integerish(parallel_chains, lower = 1, null.ok = TRUE),
     threads_per_proc = assert_valid_threads(threads_per_chain, self$cpp_options(), multiple_chains = TRUE)
   )
+  model_variables <- NULL
+  if (cmdstan_version() >= "2.27.0") {
+    model_variables <- self$variables()
+  }
   gq_args <- GenerateQuantitiesArgs$new(fitted_params = fitted_params_files)
   args <- CmdStanArgs$new(
     method_args = gq_args,
@@ -1288,13 +1304,12 @@ generate_quantities <- function(fitted_params,
     model_name = self$model_name(),
     exe_file = self$exe_file(),
     proc_ids = seq_along(fitted_params_files),
-    data_file = process_data(data, self$stan_file(), self$include_paths()),
+    data_file = process_data(data, model_variables),
     seed = seed,
     output_dir = output_dir,
     output_basename = output_basename,
     sig_figs = sig_figs,
-    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options()),
-    include_paths = self$include_paths()
+    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options())
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()
@@ -1336,6 +1351,10 @@ diagnose_method <- function(data = NULL,
     show_stdout_messages = FALSE,
     show_stderr_messages = TRUE
   )
+  model_variables <- NULL
+  if (cmdstan_version() >= "2.27.0") {
+    model_variables <- self$variables()
+  }
   diagnose_args <- DiagnoseArgs$new(
     epsilon = epsilon,
     error = error
@@ -1346,12 +1365,11 @@ diagnose_method <- function(data = NULL,
     model_name = self$model_name(),
     exe_file = self$exe_file(),
     proc_ids = 1,
-    data_file = process_data(data, self$stan_file(), self$include_paths()),
+    data_file = process_data(data, model_variables),
     seed = seed,
     init = init,
     output_dir = output_dir,
-    output_basename = output_basename,
-    include_paths = self$include_paths()
+    output_basename = output_basename
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()

--- a/R/model.R
+++ b/R/model.R
@@ -841,7 +841,8 @@ sample <- function(data = NULL,
     output_basename = output_basename,
     sig_figs = sig_figs,
     validate_csv = validate_csv,
-    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options())
+    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options()),
+    model_variables = model_variables
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()
@@ -980,7 +981,8 @@ sample_mpi <- function(data = NULL,
     output_dir = output_dir,
     output_basename = output_basename,
     validate_csv = validate_csv,
-    sig_figs = sig_figs
+    sig_figs = sig_figs,
+    model_variables = model_variables
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan_mpi(mpi_cmd, mpi_args)
@@ -1090,7 +1092,8 @@ optimize <- function(data = NULL,
     output_dir = output_dir,
     output_basename = output_basename,
     sig_figs = sig_figs,
-    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options())
+    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options()),
+    model_variables = model_variables
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()
@@ -1205,7 +1208,8 @@ variational <- function(data = NULL,
     output_dir = output_dir,
     output_basename = output_basename,
     sig_figs = sig_figs,
-    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options())
+    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options()),
+    model_variables = model_variables
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()
@@ -1309,7 +1313,8 @@ generate_quantities <- function(fitted_params,
     output_dir = output_dir,
     output_basename = output_basename,
     sig_figs = sig_figs,
-    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options())
+    opencl_ids = assert_valid_opencl(opencl_ids, self$cpp_options()),
+    model_variables = model_variables
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()
@@ -1369,7 +1374,8 @@ diagnose_method <- function(data = NULL,
     seed = seed,
     init = init,
     output_dir = output_dir,
-    output_basename = output_basename
+    output_basename = output_basename,
+    model_variables = model_variables
   )
   runset <- CmdStanRun$new(args, procs)
   runset$run_cmdstan()


### PR DESCRIPTION
#### Summary

Refactors the changes made in https://github.com/stan-dev/cmdstanr/pull/553 and some done prior to that. The main change is that everything now runs through $variables() and thus we wont call stanc3 multiple times.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
