### PR TITLE
Fix #449

### DIFF
--- a/R/data.R
+++ b/R/data.R
@@ -191,7 +191,7 @@ process_data <- function(data, model_variables = NULL) {
       }
     }
     path <- tempfile(pattern = "standata-", fileext = ".json")
-    write_stan_json(data = data, file = path, always_decimal = (cmdstan_version() > "2.26.1"))
+    write_stan_json(data = data, file = path, always_decimal = !is.null(model_variables))
   } else {
     stop("'data' should be a path or a named list.", call. = FALSE)
   }

--- a/R/install.R
+++ b/R/install.R
@@ -239,14 +239,14 @@ cmdstan_make_local <- function(dir = cmdstan_path(),
     for (i in seq_len(length(cpp_options))) {
       option_name <- names(cpp_options)[i]
       if (isTRUE(as.logical(cpp_options[[i]]))) {
-        built_flags <- c(built_flags, paste0(option_name, "=true"))
+        built_flags <- c(built_flags, paste0(toupper(option_name), "=true"))
       } else if (isFALSE(as.logical(cpp_options[[i]]))) {
-        built_flags <- c(built_flags, paste0(option_name, "=false"))
+        built_flags <- c(built_flags, paste0(toupper(option_name), "=false"))
       } else {
         if (is.null(option_name) || !nzchar(option_name)) {
           built_flags <- c(built_flags, paste0(cpp_options[[i]]))
         } else {
-          built_flags <- c(built_flags, paste0(option_name, "=", cpp_options[[i]]))
+          built_flags <- c(built_flags, paste0(toupper(option_name), "=", cpp_options[[i]]))
         }
       }
     }

--- a/R/model.R
+++ b/R/model.R
@@ -193,7 +193,6 @@ CmdStanModel <- R6::R6Class(
     cpp_options_ = list(),
     stanc_options_ = list(),
     include_paths_ = NULL,
-    compile_info_ = NULL,
     precompile_cpp_options_ = NULL,
     precompile_stanc_options_ = NULL,
     precompile_include_paths_ = NULL,
@@ -1526,13 +1525,13 @@ model_compile_info <- function(exe_file) {
           if (!is.na(as.logical(val))) {
             val <- as.logical(val)
           }
-          info[[tolower(key_val[1])]] <- val
+          info[[toupper(key_val[1])]] <- val
         }
       }
-      info[["stan_version"]] <- paste0(info[["stan_version_major"]], ".", info[["stan_version_minor"]], ".", info[["stan_version_patch"]])
-      info[["stan_version_major"]] <- NULL
-      info[["stan_version_minor"]] <- NULL
-      info[["stan_version_patch"]] <- NULL
+      info[["STAN_VERSION"]] <- paste0(info[["STAN_VERSION_MAJOR"]], ".", info[["STAN_VERSION_MINOR"]], ".", info[["STAN_VERSION_PATCH"]])
+      info[["STAN_VERSION_MAJOR"]] <- NULL
+      info[["STAN_VERSION_MINOR"]] <- NULL
+      info[["STAN_VERSION_PATCH"]] <- NULL
     }
   }
   info

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -482,3 +482,29 @@ test_that("include_paths_stanc3_args() works", {
     )
   )
 })
+
+test_that("cpp_options work with settings in make/local", {
+  backup <- cmdstan_make_local()
+
+  if (length(mod$exe_file()) > 0 && file.exists(mod$exe_file())) {
+    file.remove(mod$exe_file())
+  }
+
+  cmdstan_make_local(cpp_options = list(), append = FALSE)
+
+  mod <- cmdstan_model(stan_file = stan_program)
+  expect_null(mod$cpp_options()$STAN_THREADS)
+
+  file.remove(mod$exe_file())
+
+  cmdstan_make_local(cpp_options = list(stan_threads = TRUE))
+
+  file <- file.path(cmdstan_path(), "examples", "bernoulli", "bernoulli.stan")
+  mod <- cmdstan_model(file)
+  expect_true(mod$cpp_options()$STAN_THREADS)
+
+  file.remove(mod$exe_file())
+
+  # restore
+  cmdstan_make_local(cpp_options = backup, append = FALSE)
+})


### PR DESCRIPTION
#### Summary

Fixes #449 or at least a major part of it by handling the C++ compiler options when they are supplied via the make/local file.

As that issue states, if you add `STAN_THREADS=true` to the make/local file `mod$cpp_options()` will not return `STAN_THREADS` as `mod$cpp_options()` only handles what is supplied to cmdstan_model or $compile().

#449 suggests handling the entire make/local file, but that is not really doable.

What this PR adds can be best explained with an example:

```r
library(cmdstanr)

backup <- cmdstan_make_local()

cmdstan_make_local(cpp_options = list(), append = FALSE)

file <- file.path(cmdstan_path(), "examples", "bernoulli", "bernoulli.stan")
mod <- cmdstan_model(file)
# should obviously not print anything about stan threads (on master or this PR)
print(mod$cpp_options()) 

file.remove(mod$exe_file())

cmdstan_make_local(cpp_options = list(stan_threads = TRUE))

file <- file.path(cmdstan_path(), "examples", "bernoulli", "bernoulli.stan")
mod <- cmdstan_model(file)
# should print that stan threads are on on this branch, but would not print anything on master
print(mod$cpp_options())

file.remove(mod$exe_file())

# restore
cmdstan_make_local(cpp_options = backup, append = FALSE)
```

Once we also address https://github.com/stan-dev/cmdstanr/issues/488 $cpp_options() will also print Stan C++ options for already created files (provided they were compiled with 2.27+.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
