### PR TITLE
Bump GHA Linux test runner version

### DIFF
--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -16,7 +16,7 @@ jobs:
   test-coverage-ubuntu:
     name: "Linux"
     if: "! contains(github.event.head_commit.message, '[ci skip]')"
-    runs-on: ubuntu-16.04
+    runs-on: ubuntu-20.04
     env:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       NOT_CRAN: true
@@ -65,13 +65,6 @@ jobs:
           remotes::install_cran("covr")
           remotes::install_cran("gridExtra")
         shell: Rscript {0}
-
-      - name: Cache cmdstan
-        uses: actions/cache@v2
-        with:
-          path: ${{ env.CMDSTAN_PATH }}
-          key: ${{ runner.os }}-codecov-cmdstan-${{ env.CMDSTAN_VERSION }}
-          restore-keys: ${{ runner.os }}-codecov-cmdstan-
 
       - name: Install cmdstan
         run: |


### PR DESCRIPTION
#### Summary

Test coverage is using Ubuntu 16.04 (~~I forget why we use that~~ we use it because there is an issue with 20.04), while other tests run with the latest Ubuntu). Seems that Github no longer has those machines, so we need to bump up. Once tests pass I will merge this.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
