### PR TITLE
Allow instation of cmdstanmodel with just an executable

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -244,6 +244,9 @@ CmdStanModel <- R6::R6Class(
       private$include_paths_
     },
     code = function() {
+      if (length(self$stan_file()) == 0) {
+        stop("The `CmdStanModel` object was not created with a Stan file. '$code()' can not be used.", call. = FALSE)
+      }
       assert_stan_file_exists(self$stan_file())
       readLines(self$stan_file())
     },

--- a/tests/testthat/test-fit-shared.R
+++ b/tests/testthat/test-fit-shared.R
@@ -476,3 +476,57 @@ test_that("sampling with inits works with include_paths", {
     init = list(list(theta = 0.25), list(theta = 0.25), list(theta = 0.25), list(theta = 0.25))
   )
 })
+
+test_that("CmdStanModel created with exe_file works",{
+  stan_program <- testing_stan_file("bernoulli")
+  data_list <- testing_data("bernoulli")
+
+  mod <- cmdstan_model(stan_file = stan_program)
+  mod_exe <- cmdstan_model(exe_file = mod$exe_file())
+
+  utils::capture.output(
+    fit_optimize <- mod$optimize(data = data_list, seed = 123)
+  )
+  utils::capture.output(
+    fit_optimize_exe <- mod_exe$optimize(data = data_list, seed = 123)
+  )
+  expect_equal(fit_optimize$mle(), fit_optimize_exe$mle())
+
+  utils::capture.output(
+    fit_variational <- mod$variational(data = data_list, seed = 123)
+  )
+  utils::capture.output(
+    fit_variational_exe <- mod_exe$variational(data = data_list, seed = 123)
+  )
+  expect_equal(fit_variational$draws(), fit_variational_exe$draws())
+
+  utils::capture.output(
+    fit_sample <- mod$sample(data = data_list, chains = 1, seed = 123)
+  )
+  utils::capture.output(
+    fit_sample_exe <- mod_exe$sample(data = data_list, chains = 1, seed = 123)
+  )
+  expect_equal(fit_sample$draws(), fit_sample_exe$draws())
+
+  stan_ppc_program <- testing_stan_file("bernoulli_ppc")
+  data_ppc_list <- testing_data("bernoulli_ppc")
+
+  mod_bern_ppc <- cmdstan_model(stan_file = stan_ppc_program)
+  mod_bern_ppc_exe <- cmdstan_model(exe_file = mod_bern_ppc$exe_file())
+
+  utils::capture.output(
+    fit_generate_quantities <- mod_bern_ppc$generate_quantities(fitted_params = fit_sample, data = data_list, seed = 123)
+  )
+  utils::capture.output(
+    fit_generate_quantities_exe <- mod_bern_ppc_exe$generate_quantities(fitted_params = fit_sample, data = data_list, seed = 123)
+  )
+  expect_equal(fit_generate_quantities$draws(), fit_generate_quantities_exe$draws())
+
+  utils::capture.output(
+    fit_diagnose <- mod$diagnose(data = data_list, seed = 123)
+  )
+  utils::capture.output(
+    fit_diagnose_exe <- mod_exe$diagnose(data = data_list, seed = 123)
+  )
+  expect_equal(fit_diagnose$gradients(), fit_diagnose_exe$gradients())
+})

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -563,3 +563,23 @@ test_that("cmdstan_model works with exe_file", {
   expect_true(file.exists(mod$exe_file()))
   expect_false(file.exists(default_exe_file))
 })
+
+test_that("cmdstan_model created only with exe_file errors for check_syntax, code, ... ", {
+  mod <- testing_model("bernoulli")
+  mod_exe <- cmdstan_model(exe_file = mod$exe_file())
+  expect_error(
+    mod_exe$code(),
+    "The `CmdStanModel` object was not created with a Stan file. '$code()' can not be used.",
+    fixed = TRUE
+  )
+  expect_error(
+    mod_exe$check_syntax(),
+    "$check_syntax()' can not be used as the 'CmdStanModel' was not created with a Stan file.",
+    fixed = TRUE
+  )
+  expect_error(
+    mod_exe$variables(),
+    "The `CmdStanModel` object was not created with a Stan file. '$variables()' can not be used.",
+    fixed = TRUE
+  )
+})

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -317,7 +317,6 @@ test_that("*hpp_file() functions work", {
   expect_false(isTRUE(all.equal(mod$hpp_file(), file.path(dirname(mod$stan_file()), "bernoulli.hpp"))))
 })
 
-
 test_that("check_syntax() works", {
   skip_on_cran()
   stan_file <- testing_stan_file("fail")
@@ -365,8 +364,16 @@ test_that("check_syntax() works", {
   file.remove(stan_file_tmp)
   expect_error(
     mod_removed_stan_file$check_syntax(),
-    "The Stan file used to create the `CmdStanModel` object does not exist."
+    "The Stan file used to create the `CmdStanModel` object does not exist.",
+    fixed = TRUE
   )
+  mod_exe <- cmdstan_model(exe_file = mod_removed_stan_file$exe_file())
+  expect_error(
+    mod_exe$check_syntax(),
+    "'$check_syntax()' can not be used as the 'CmdStanModel' was not created with a Stan file.",
+    fixed = TRUE
+  )
+
 })
 
 test_that("check_syntax() works with pedantic=TRUE", {
@@ -525,4 +532,34 @@ test_that("cpp_options work with settings in make/local", {
 
   # restore
   cmdstan_make_local(cpp_options = backup, append = FALSE)
+})
+
+test_that("cmdstan_model works with exe_file", {
+  stan_file <- testing_stan_file("bernoulli")
+  mod <- cmdstan_model(stan_file)
+  expect_true(file.exists(mod$exe_file()))
+  default_exe_file <- mod$exe_file()
+  file.remove(mod$exe_file())
+
+  tmp_exe_file <- tempfile()
+  mod <- cmdstan_model(
+    stan_file = stan_file,
+    exe_file = tmp_exe_file
+  )
+  expect_match(
+    mod$exe_file(),
+    tmp_exe_file
+  )
+  expect_true(file.exists(mod$exe_file()))
+  expect_false(file.exists(default_exe_file))
+
+  mod <- cmdstan_model(
+    exe_file = tmp_exe_file
+  )
+  expect_match(
+    mod$exe_file(),
+    tmp_exe_file
+  )
+  expect_true(file.exists(mod$exe_file()))
+  expect_false(file.exists(default_exe_file))
 })

--- a/tests/testthat/test-model-sample.R
+++ b/tests/testthat/test-model-sample.R
@@ -101,6 +101,12 @@ test_that("code() and print() methods work", {
     mod_removed_stan_file$code(),
     "The Stan file used to create the `CmdStanModel` object does not exist."
   )
+  mod_exe <- cmdstan_model(exe_file = mod_removed_stan_file$exe_file())
+  expect_error(
+    mod_exe$check_syntax(),
+    "'$check_syntax()' can not be used as the 'CmdStanModel' was not created with a Stan file.",
+    fixed = TRUE
+  )
 })
 
 test_that("sample() method works with data list", {
@@ -356,4 +362,3 @@ generated quantities  {
   expect_null(fit$sampler_diagnostics())
   expect_equal(posterior::variables(fit$draws()), "y")
 })
-

--- a/tests/testthat/test-model-variables.R
+++ b/tests/testthat/test-model-variables.R
@@ -91,6 +91,13 @@ test_that("$variables() errors on no stan_file", {
   file.remove(stan_file)
   expect_error(
     mod$variables(),
-    "The Stan file used to create the `CmdStanModel` object does not exist."
+    "The Stan file used to create the `CmdStanModel` object does not exist.",
+    fixed = TRUE
+  )
+  mod_exe <- cmdstan_model(exe_file = mod$exe_file())
+  expect_error(
+    mod_exe$variables(),
+    "The `CmdStanModel` object was not created with a Stan file. '$variables()' can not be used.",
+    fixed = TRUE
   )
 })

--- a/tests/testthat/test-model-variational.R
+++ b/tests/testthat/test-model-variational.R
@@ -73,7 +73,7 @@ test_that("variational() method errors for any invalid argument before calling c
   }
 })
 
-test_that("sample() method runs when the stan file is removed", {
+test_that("variational() method runs when the stan file is removed", {
   skip_on_cran()
   stan_file_tmp <- tempfile(pattern = "tmp", fileext = ".stan")
   file.copy(testing_stan_file("bernoulli"), stan_file_tmp)


### PR DESCRIPTION
#### Summary

Fixes #488 

With this we could do the following:


```r
library(cmdstanr)

stan_file <- file.path(path.package("cmdstanr"), "logistic.stan")
# the current way
mod <- cmdstan_model(stan_file = stan_file)

new_loc <- "~/logistic"
file.copy(mod$exe_file(), new_loc)

# create if with exe file only
mod_exe <- cmdstan_model(exe_file = new_loc)
data_file <- file.path(path.package("cmdstanr"), "logistic.data.json")
mod_exe$sample(data = data_file)


# you can also specify both
# it will compile it to the exe_file location if compilation is needed
mod_exe <- cmdstan_model(stan_file = stan_file, exe_file = new_loc)
data_file <- file.path(path.package("cmdstanr"), "logistic.data.json")
mod_exe$sample(data = data_file)
```



#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
