### PR TITLE
edits to doc and startup messages

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -16,7 +16,9 @@ Authors@R:
 Description: A lightweight interface to 'Stan' <https://mc-stan.org>.
     The 'CmdStanR' interface is an alternative to 'RStan' that calls the command 
     line interface for compilation and running algorithms instead of interfacing 
-    with C++ via 'Rcpp'.
+    with C++ via 'Rcpp'. This has many benefits including always being compatible 
+    with the latest version of Stan, fewer installation errors, fewer unexpected 
+    crashes in RStudio, and a more permissive license. 
 License: BSD_3_clause + file LICENSE
 URL: https://mc-stan.org/cmdstanr, https://discourse.mc-stan.org
 BugReports: https://github.com/stan-dev/cmdstanr/issues

--- a/R/cmdstanr-package.R
+++ b/R/cmdstanr-package.R
@@ -12,7 +12,7 @@
 #'
 #' \pkg{CmdStanR}: the \R interface to CmdStan.
 #'
-#' @details CmdStanR (\pkg{cmdstanr} package) is a lightweight interface to Stan
+#' @details CmdStanR (\pkg{cmdstanr} package) is an interface to Stan
 #'   ([mc-stan.org](https://mc-stan.org)) for \R users. It provides the
 #'   necessary objects and functions to compile a Stan program and run Stan's
 #'   algorithms from \R via CmdStan, the shell interface to Stan
@@ -21,9 +21,9 @@
 #' @includeRmd vignettes/children/comparison-with-rstan.md
 #'
 #' @section Getting started: CmdStanR requires a working version of CmdStan. If
-#'   you already have CmdStan installed see [cmdstan_model()] to get
-#'   started, otherwise see [install_cmdstan()] for help with installation.
-#'   The vignette [_Getting started with CmdStanR_](https://mc-stan.org/cmdstanr/articles/cmdstanr.html)
+#'   you already have CmdStan installed see [cmdstan_model()] to get started,
+#'   otherwise see [install_cmdstan()] to install CmdStan. The vignette
+#'   [_Getting started with CmdStanR_](https://mc-stan.org/cmdstanr/articles/cmdstanr.html)
 #'   demonstrates the basic functionality of the package.
 #'
 #' @template seealso-docs

--- a/R/model.R
+++ b/R/model.R
@@ -1,8 +1,11 @@
 #' Create a new CmdStanModel object
 #'
-#' \if{html}{\figure{logo.png}{options: width="25px" alt="https://mc-stan.org/about/logo/"}}
-#' Create a new [`CmdStanModel`] object from a file containing a Stan program
-#' or from an existing Stan executable.
+#' \if{html}{\figure{logo.png}{options: width="25px"
+#' alt="https://mc-stan.org/about/logo/"}} Create a new [`CmdStanModel`] object
+#' from a file containing a Stan program or from an existing Stan executable.
+#' The [`CmdStanModel`] object stores the path to a Stan program and compiled
+#' executable (once created), and provides methods for fitting the model using
+#' Stan's algorithms.
 #'
 #' @export
 #' @param stan_file (string) The path to a `.stan` file containing a Stan

--- a/R/model.R
+++ b/R/model.R
@@ -358,7 +358,9 @@ CmdStanModel <- R6::R6Class(
 #'   to compile with the Stan model.
 #' @param cpp_options (list) Any makefile options to be used when compiling the
 #'   model (`STAN_THREADS`, `STAN_MPI`, `STAN_OPENCL`, etc.). Anything you would
-#'   otherwise write in the `make/local` file.
+#'   otherwise write in the `make/local` file. For an example of using threading
+#'   see the Stan case study
+#'   [Reduce Sum: A Minimal Example](https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html).
 #' @param stanc_options (list) Any Stan-to-C++ transpiler options to be used
 #'   when compiling the model. See the **Examples** section below as well as the
 #'   `stanc` chapter of the CmdStan Guide for more details on available options:

--- a/R/model.R
+++ b/R/model.R
@@ -760,10 +760,8 @@ CmdStanModel$set("public", name = "check_syntax", value = check_syntax)
 #' @aliases sample
 #' @family CmdStanModel methods
 #'
-#' @description The `$sample()` method of a [`CmdStanModel`] object runs the
-#'   default MCMC algorithm in CmdStan (`algorithm=hmc engine=nuts`), to produce
-#'   a set of draws from the posterior distribution of a model conditioned on
-#'   some data.
+#' @description The `$sample()` method of a [`CmdStanModel`] object runs Stan's
+#'   main Markov chain Monte Carlo algorithm.
 #'
 #'   Any argument left as `NULL` will default to the default value used by the
 #'   installed version of CmdStan. See the
@@ -1555,7 +1553,7 @@ model_variables <- function(stan_file, include_paths = NULL, allow_undefined = F
     allow_undefined_arg <- "--allow-undefined"
   } else {
     allow_undefined_arg <- NULL
-  }  
+  }
   out_file <- tempfile(fileext = ".json")
   run_log <- processx::run(
     command = stanc_cmd(),

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -1,12 +1,12 @@
 startup_messages <- function() {
   packageStartupMessage("This is cmdstanr version ", utils::packageVersion("cmdstanr"))
-  packageStartupMessage("- Online documentation and vignettes at mc-stan.org/cmdstanr")
+  packageStartupMessage("- CmdStanR documentation and vignettes: mc-stan.org/cmdstanr")
   if (is.null(.cmdstanr$PATH)) {
     packageStartupMessage("- Use set_cmdstan_path() to set the path to CmdStan")
     packageStartupMessage("- Use install_cmdstan() to install CmdStan")
   } else {
-    packageStartupMessage("- CmdStan path set to: ", cmdstan_path(), "")
-    packageStartupMessage("- Use set_cmdstan_path() to change the path")
+    packageStartupMessage("- CmdStan path: ", cmdstan_path())
+    packageStartupMessage("- CmdStan version: ", cmdstan_version(error_on_NA = FALSE))
   }
 
   skip_version_check <- isTRUE(getOption(

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -6,7 +6,7 @@
 #'  [write_stan_json()] for details on the conversions performed on \R objects
 #'  before they are passed to Stan.
 #'  * A path to a data file compatible with CmdStan (JSON or \R dump). See the
-#'  appendices in the CmdStan manual for details on using these formats.
+#'  appendices in the CmdStan guide for details on using these formats.
 #'  * `NULL` or an empty list if the Stan program has no data block.
 #'
 #' @param seed (positive integer(s)) A seed for the (P)RNG to pass to CmdStan.
@@ -24,9 +24,10 @@
 #'   printed.
 #'
 #' @param init (multiple options) The initialization method to use for the
-#'   variables declared in the parameters block of the Stan program:
+#'   variables declared in the parameters block of the Stan program. One of
+#'   the following:
 #'  * A real number `x>0`. This initializes _all_ parameters randomly between
-#'  `[-x,x]` (on the _unconstrained_ parameter space);
+#'  `[-x,x]` on the _unconstrained_ parameter space.;
 #'  * The number `0`. This initializes _all_ parameters to `0`;
 #'  * A character vector of paths (one per chain) to JSON or Rdump files
 #'  containing initial values for all or some parameters. See
@@ -68,10 +69,10 @@
 #'   * If a path, then the files are created in `output_dir` with names
 #'   corresponding to the defaults used by `$save_output_files()`.
 #'
-#' @param output_basename (string) A string to use as a prefix for the
-#'   names of the output CSV files of CmdStan.
-#'   * If `NULL` (the default), the basename of the output CSV files
-#'   will be comprised from the model name, timestamp and 5 random characters.
+#' @param output_basename (string) A string to use as a prefix for the names of
+#'   the output CSV files of CmdStan. If `NULL` (the default), the basename of
+#'   the output CSV files will be comprised from the model name, timestamp, and
+#'   5 random characters.
 #'
 #' @param sig_figs (positive integer) The number of significant figures used
 #'   when storing the output values. By default, CmdStan represent the output
@@ -83,5 +84,4 @@
 #'   device IDs of the OpenCL device to use for fitting. The model must
 #'   be compiled with `cpp_options = list(stan_opencl = TRUE)` for this
 #'   argument to have an effect.
-#'
 #'

--- a/man-roxygen/model-sample-args.R
+++ b/man-roxygen/model-sample-args.R
@@ -5,25 +5,26 @@
 #'   is to look for the option `"mc.cores"`, which can be set for an entire \R
 #'   session by `options(mc.cores=value)`. If the `"mc.cores"` option has not
 #'   been set then the default is `1`.
-#' @param chain_ids (integer vector) A vector of chain IDs. Must contain
-#'   `chains` unique positive integers. If not set, the default chain IDs are
-#'   used (integers starting from `1`).
+#' @param chain_ids (integer vector) A vector of chain IDs. Must contain as many
+#'   unique positive integers as the number of chains. If not set, the default
+#'   chain IDs are used (integers starting from `1`).
 #' @param threads_per_chain (positive integer) If the model was
 #'   [compiled][model-method-compile] with threading support, the number of
 #'   threads to use in parallelized sections _within_ an MCMC chain (e.g., when
 #'   using the Stan functions `reduce_sum()` or `map_rect()`). This is in
 #'   contrast with `parallel_chains`, which specifies the number of chains to
-#'   run in parallel. The actual number of CPU cores used use is
+#'   run in parallel. The actual number of CPU cores used is
 #'   `parallel_chains*threads_per_chain`. For an example of using threading see
-#'   the Stan case study [Reduce Sum: A Minimal
-#'   Example](https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html).
+#'   the Stan case study
+#'   [Reduce Sum: A Minimal Example](https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html).
 #'
 #' @param show_messages (logical) When `TRUE` (the default), prints all
 #'   informational messages, for example rejection of the current proposal.
-#'   Disable if you wish silence these messages, but this is not recommended
-#'   unless you are very sure that the model is correct up to numerical error.
-#'   If the messages are silenced then the `$output()` method of the resulting
-#'   fit object can be used to display all the silenced messages.
+#'   Disable if you wish to silence these messages, but this is not usually
+#'   recommended unless you are very confident that the model is correct up to
+#'   numerical error. If the messages are silenced then the
+#'   [`$output()`][fit-method-output] method of the resulting fit object can be
+#'   used to display all the silenced messages.
 #'
 #' @param validate_csv (logical) When `TRUE` (the default), validate the
 #'   sampling results in the csv files. Disable if you wish to manually read in
@@ -37,9 +38,7 @@
 #'   per chain. Note: in the CmdStan User's Guide this is referred to as
 #'   `num_warmup`.
 #' @param save_warmup (logical) Should warmup iterations be saved? The default
-#'   is `FALSE`. If `save_warmup=TRUE` then you can use
-#'   [$draws(inc_warmup=TRUE)][fit-method-draws] to include warmup when
-#'   accessing the draws.
+#'   is `FALSE`.
 #' @param thin (positive integer) The period between saved samples. This should
 #'   typically be left at its default (no thinning) unless memory is a problem.
 #'

--- a/man/cmdstan_model.Rd
+++ b/man/cmdstan_model.Rd
@@ -28,9 +28,12 @@ method.}
 A \code{\link{CmdStanModel}} object.
 }
 \description{
-\if{html}{\figure{logo.png}{options: width="25px" alt="https://mc-stan.org/about/logo/"}}
-Create a new \code{\link{CmdStanModel}} object from a file containing a Stan program
-or from an existing Stan executable.
+\if{html}{\figure{logo.png}{options: width="25px"
+alt="https://mc-stan.org/about/logo/"}} Create a new \code{\link{CmdStanModel}} object
+from a file containing a Stan program or from an existing Stan executable.
+The \code{\link{CmdStanModel}} object stores the path to a Stan program and compiled
+executable (once created), and provides methods for fitting the model using
+Stan's algorithms.
 }
 \examples{
 \dontrun{

--- a/man/cmdstanr-package.Rd
+++ b/man/cmdstanr-package.Rd
@@ -15,7 +15,7 @@
 \pkg{CmdStanR}: the \R interface to CmdStan.
 }
 \details{
-CmdStanR (\pkg{cmdstanr} package) is a lightweight interface to Stan
+CmdStanR (\pkg{cmdstanr} package) is an interface to Stan
 (\href{https://mc-stan.org}{mc-stan.org}) for \R users. It provides the
 necessary objects and functions to compile a Stan program and run Stan's
 algorithms from \R via CmdStan, the shell interface to Stan
@@ -66,9 +66,9 @@ the same license used for CmdStan and the Stan C++ source code.
 }
 \section{Getting started}{
  CmdStanR requires a working version of CmdStan. If
-you already have CmdStan installed see \code{\link[=cmdstan_model]{cmdstan_model()}} to get
-started, otherwise see \code{\link[=install_cmdstan]{install_cmdstan()}} for help with installation.
-The vignette \href{https://mc-stan.org/cmdstanr/articles/cmdstanr.html}{\emph{Getting started with CmdStanR}}
+you already have CmdStan installed see \code{\link[=cmdstan_model]{cmdstan_model()}} to get started,
+otherwise see \code{\link[=install_cmdstan]{install_cmdstan()}} to install CmdStan. The vignette
+\href{https://mc-stan.org/cmdstanr/articles/cmdstanr.html}{\emph{Getting started with CmdStanR}}
 demonstrates the basic functionality of the package.
 }
 

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -43,7 +43,9 @@ to compile with the Stan model.}
 
 \item{cpp_options}{(list) Any makefile options to be used when compiling the
 model (\code{STAN_THREADS}, \code{STAN_MPI}, \code{STAN_OPENCL}, etc.). Anything you would
-otherwise write in the \code{make/local} file.}
+otherwise write in the \code{make/local} file. For an example of using threading
+see the Stan case study
+\href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.}
 
 \item{stanc_options}{(list) Any Stan-to-C++ transpiler options to be used
 when compiling the model. See the \strong{Examples} section below as well as the

--- a/man/model-method-diagnose.Rd
+++ b/man/model-method-diagnose.Rd
@@ -26,7 +26,7 @@ written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json(
 \code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
 before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
-appendices in the CmdStan manual for details on using these formats.
+appendices in the CmdStan guide for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.
 }}
 
@@ -41,10 +41,11 @@ transformed data and the goal is to generate \emph{different} data for each
 chain.}
 
 \item{init}{(multiple options) The initialization method to use for the
-variables declared in the parameters block of the Stan program:
+variables declared in the parameters block of the Stan program. One of
+the following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} (on the \emph{unconstrained} parameter space);
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0};
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
@@ -79,12 +80,10 @@ files are removed when the fitted model object is
 corresponding to the defaults used by \verb{$save_output_files()}.
 }}
 
-\item{output_basename}{(string) A string to use as a prefix for the
-names of the output CSV files of CmdStan.
-\itemize{
-\item If \code{NULL} (the default), the basename of the output CSV files
-will be comprised from the model name, timestamp and 5 random characters.
-}}
+\item{output_basename}{(string) A string to use as a prefix for the names of
+the output CSV files of CmdStan. If \code{NULL} (the default), the basename of
+the output CSV files will be comprised from the model name, timestamp, and
+5 random characters.}
 
 \item{epsilon}{(positive real) The finite difference step size. Default
 value is 1e-6.}

--- a/man/model-method-generate-quantities.Rd
+++ b/man/model-method-generate-quantities.Rd
@@ -36,7 +36,7 @@ written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json(
 \code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
 before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
-appendices in the CmdStan manual for details on using these formats.
+appendices in the CmdStan guide for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.
 }}
 
@@ -66,12 +66,10 @@ files are removed when the fitted model object is
 corresponding to the defaults used by \verb{$save_output_files()}.
 }}
 
-\item{output_basename}{(string) A string to use as a prefix for the
-names of the output CSV files of CmdStan.
-\itemize{
-\item If \code{NULL} (the default), the basename of the output CSV files
-will be comprised from the model name, timestamp and 5 random characters.
-}}
+\item{output_basename}{(string) A string to use as a prefix for the names of
+the output CSV files of CmdStan. If \code{NULL} (the default), the basename of
+the output CSV files will be comprised from the model name, timestamp, and
+5 random characters.}
 
 \item{sig_figs}{(positive integer) The number of significant figures used
 when storing the output values. By default, CmdStan represent the output
@@ -90,9 +88,10 @@ been set then the default is \code{1}.}
 threads to use in parallelized sections \emph{within} an MCMC chain (e.g., when
 using the Stan functions \code{reduce_sum()} or \code{map_rect()}). This is in
 contrast with \code{parallel_chains}, which specifies the number of chains to
-run in parallel. The actual number of CPU cores used use is
+run in parallel. The actual number of CPU cores used is
 \code{parallel_chains*threads_per_chain}. For an example of using threading see
-the Stan case study \href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.}
+the Stan case study
+\href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.}
 
 \item{opencl_ids}{(integer vector of length 2) The platform and
 device IDs of the OpenCL device to use for fitting. The model must

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -37,7 +37,7 @@ written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json(
 \code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
 before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
-appendices in the CmdStan manual for details on using these formats.
+appendices in the CmdStan guide for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.
 }}
 
@@ -56,10 +56,11 @@ printed screen updates. If \code{refresh = 0}, only error messages will be
 printed.}
 
 \item{init}{(multiple options) The initialization method to use for the
-variables declared in the parameters block of the Stan program:
+variables declared in the parameters block of the Stan program. One of
+the following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} (on the \emph{unconstrained} parameter space);
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0};
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
@@ -104,12 +105,10 @@ files are removed when the fitted model object is
 corresponding to the defaults used by \verb{$save_output_files()}.
 }}
 
-\item{output_basename}{(string) A string to use as a prefix for the
-names of the output CSV files of CmdStan.
-\itemize{
-\item If \code{NULL} (the default), the basename of the output CSV files
-will be comprised from the model name, timestamp and 5 random characters.
-}}
+\item{output_basename}{(string) A string to use as a prefix for the names of
+the output CSV files of CmdStan. If \code{NULL} (the default), the basename of
+the output CSV files will be comprised from the model name, timestamp, and
+5 random characters.}
 
 \item{sig_figs}{(positive integer) The number of significant figures used
 when storing the output values. By default, CmdStan represent the output

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -56,7 +56,7 @@ written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json(
 \code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
 before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
-appendices in the CmdStan manual for details on using these formats.
+appendices in the CmdStan guide for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.
 }}
 
@@ -75,10 +75,11 @@ printed screen updates. If \code{refresh = 0}, only error messages will be
 printed.}
 
 \item{init}{(multiple options) The initialization method to use for the
-variables declared in the parameters block of the Stan program:
+variables declared in the parameters block of the Stan program. One of
+the following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} (on the \emph{unconstrained} parameter space);
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0};
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
@@ -123,12 +124,10 @@ files are removed when the fitted model object is
 corresponding to the defaults used by \verb{$save_output_files()}.
 }}
 
-\item{output_basename}{(string) A string to use as a prefix for the
-names of the output CSV files of CmdStan.
-\itemize{
-\item If \code{NULL} (the default), the basename of the output CSV files
-will be comprised from the model name, timestamp and 5 random characters.
-}}
+\item{output_basename}{(string) A string to use as a prefix for the names of
+the output CSV files of CmdStan. If \code{NULL} (the default), the basename of
+the output CSV files will be comprised from the model name, timestamp, and
+5 random characters.}
 
 \item{sig_figs}{(positive integer) The number of significant figures used
 when storing the output values. By default, CmdStan represent the output
@@ -145,18 +144,19 @@ is to look for the option \code{"mc.cores"}, which can be set for an entire \R
 session by \code{options(mc.cores=value)}. If the \code{"mc.cores"} option has not
 been set then the default is \code{1}.}
 
-\item{chain_ids}{(integer vector) A vector of chain IDs. Must contain
-\code{chains} unique positive integers. If not set, the default chain IDs are
-used (integers starting from \code{1}).}
+\item{chain_ids}{(integer vector) A vector of chain IDs. Must contain as many
+unique positive integers as the number of chains. If not set, the default
+chain IDs are used (integers starting from \code{1}).}
 
 \item{threads_per_chain}{(positive integer) If the model was
 \link[=model-method-compile]{compiled} with threading support, the number of
 threads to use in parallelized sections \emph{within} an MCMC chain (e.g., when
 using the Stan functions \code{reduce_sum()} or \code{map_rect()}). This is in
 contrast with \code{parallel_chains}, which specifies the number of chains to
-run in parallel. The actual number of CPU cores used use is
+run in parallel. The actual number of CPU cores used is
 \code{parallel_chains*threads_per_chain}. For an example of using threading see
-the Stan case study \href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.}
+the Stan case study
+\href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.}
 
 \item{opencl_ids}{(integer vector of length 2) The platform and
 device IDs of the OpenCL device to use for fitting. The model must
@@ -172,9 +172,7 @@ to run per chain. Note: in the CmdStan User's Guide this is referred to as
 \code{num_samples}.}
 
 \item{save_warmup}{(logical) Should warmup iterations be saved? The default
-is \code{FALSE}. If \code{save_warmup=TRUE} then you can use
-\link[=fit-method-draws]{$draws(inc_warmup=TRUE)} to include warmup when
-accessing the draws.}
+is \code{FALSE}.}
 
 \item{thin}{(positive integer) The period between saved samples. This should
 typically be left at its default (no thinning) unless memory is a problem.}
@@ -243,10 +241,11 @@ the sampling results and validate them yourself, for example using
 
 \item{show_messages}{(logical) When \code{TRUE} (the default), prints all
 informational messages, for example rejection of the current proposal.
-Disable if you wish silence these messages, but this is not recommended
-unless you are very sure that the model is correct up to numerical error.
-If the messages are silenced then the \verb{$output()} method of the resulting
-fit object can be used to display all the silenced messages.}
+Disable if you wish to silence these messages, but this is not usually
+recommended unless you are very confident that the model is correct up to
+numerical error. If the messages are silenced then the
+\code{\link[=fit-method-output]{$output()}} method of the resulting fit object can be
+used to display all the silenced messages.}
 
 \item{cores, num_cores, num_chains, num_warmup, num_samples, save_extra_diagnostics, max_depth, stepsize}{Deprecated and will be removed in a future release.}
 }
@@ -254,10 +253,8 @@ fit object can be used to display all the silenced messages.}
 A \code{\link{CmdStanMCMC}} object.
 }
 \description{
-The \verb{$sample()} method of a \code{\link{CmdStanModel}} object runs the
-default MCMC algorithm in CmdStan (\verb{algorithm=hmc engine=nuts}), to produce
-a set of draws from the posterior distribution of a model conditioned on
-some data.
+The \verb{$sample()} method of a \code{\link{CmdStanModel}} object runs Stan's
+main Markov chain Monte Carlo algorithm.
 
 Any argument left as \code{NULL} will default to the default value used by the
 installed version of CmdStan. See the

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -47,7 +47,7 @@ written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json(
 \code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
 before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
-appendices in the CmdStan manual for details on using these formats.
+appendices in the CmdStan guide for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.
 }}
 
@@ -74,10 +74,11 @@ printed screen updates. If \code{refresh = 0}, only error messages will be
 printed.}
 
 \item{init}{(multiple options) The initialization method to use for the
-variables declared in the parameters block of the Stan program:
+variables declared in the parameters block of the Stan program. One of
+the following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} (on the \emph{unconstrained} parameter space);
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0};
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
@@ -122,19 +123,17 @@ files are removed when the fitted model object is
 corresponding to the defaults used by \verb{$save_output_files()}.
 }}
 
-\item{output_basename}{(string) A string to use as a prefix for the
-names of the output CSV files of CmdStan.
-\itemize{
-\item If \code{NULL} (the default), the basename of the output CSV files
-will be comprised from the model name, timestamp and 5 random characters.
-}}
+\item{output_basename}{(string) A string to use as a prefix for the names of
+the output CSV files of CmdStan. If \code{NULL} (the default), the basename of
+the output CSV files will be comprised from the model name, timestamp, and
+5 random characters.}
 
 \item{chains}{(positive integer) The number of Markov chains to run. The
 default is 4.}
 
-\item{chain_ids}{(integer vector) A vector of chain IDs. Must contain
-\code{chains} unique positive integers. If not set, the default chain IDs are
-used (integers starting from \code{1}).}
+\item{chain_ids}{(integer vector) A vector of chain IDs. Must contain as many
+unique positive integers as the number of chains. If not set, the default
+chain IDs are used (integers starting from \code{1}).}
 
 \item{iter_warmup}{(positive integer) The number of warmup iterations to run
 per chain. Note: in the CmdStan User's Guide this is referred to as
@@ -145,9 +144,7 @@ to run per chain. Note: in the CmdStan User's Guide this is referred to as
 \code{num_samples}.}
 
 \item{save_warmup}{(logical) Should warmup iterations be saved? The default
-is \code{FALSE}. If \code{save_warmup=TRUE} then you can use
-\link[=fit-method-draws]{$draws(inc_warmup=TRUE)} to include warmup when
-accessing the draws.}
+is \code{FALSE}.}
 
 \item{thin}{(positive integer) The period between saved samples. This should
 typically be left at its default (no thinning) unless memory is a problem.}
@@ -222,10 +219,11 @@ the sampling results and validate them yourself, for example using
 
 \item{show_messages}{(logical) When \code{TRUE} (the default), prints all
 informational messages, for example rejection of the current proposal.
-Disable if you wish silence these messages, but this is not recommended
-unless you are very sure that the model is correct up to numerical error.
-If the messages are silenced then the \verb{$output()} method of the resulting
-fit object can be used to display all the silenced messages.}
+Disable if you wish to silence these messages, but this is not usually
+recommended unless you are very confident that the model is correct up to
+numerical error. If the messages are silenced then the
+\code{\link[=fit-method-output]{$output()}} method of the resulting fit object can be
+used to display all the silenced messages.}
 }
 \value{
 A \code{\link{CmdStanMCMC}} object.

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -38,7 +38,7 @@ written to JSON for CmdStan using \code{\link[=write_stan_json]{write_stan_json(
 \code{\link[=write_stan_json]{write_stan_json()}} for details on the conversions performed on \R objects
 before they are passed to Stan.
 \item A path to a data file compatible with CmdStan (JSON or \R dump). See the
-appendices in the CmdStan manual for details on using these formats.
+appendices in the CmdStan guide for details on using these formats.
 \item \code{NULL} or an empty list if the Stan program has no data block.
 }}
 
@@ -57,10 +57,11 @@ printed screen updates. If \code{refresh = 0}, only error messages will be
 printed.}
 
 \item{init}{(multiple options) The initialization method to use for the
-variables declared in the parameters block of the Stan program:
+variables declared in the parameters block of the Stan program. One of
+the following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} (on the \emph{unconstrained} parameter space);
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0};
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
@@ -105,12 +106,10 @@ files are removed when the fitted model object is
 corresponding to the defaults used by \verb{$save_output_files()}.
 }}
 
-\item{output_basename}{(string) A string to use as a prefix for the
-names of the output CSV files of CmdStan.
-\itemize{
-\item If \code{NULL} (the default), the basename of the output CSV files
-will be comprised from the model name, timestamp and 5 random characters.
-}}
+\item{output_basename}{(string) A string to use as a prefix for the names of
+the output CSV files of CmdStan. If \code{NULL} (the default), the basename of
+the output CSV files will be comprised from the model name, timestamp, and
+5 random characters.}
 
 \item{sig_figs}{(positive integer) The number of significant figures used
 when storing the output values. By default, CmdStan represent the output


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Doing some doc edits to prepare for v1.0. I also changed the package startup messages a bit. 

Old version: 

```
This is cmdstanr version 0.4.0.9000
- Online documentation and vignettes at mc-stan.org/cmdstanr
- CmdStan path set to: /Users/jgabry/.cmdstan/cmdstan-2.28.1
- Use set_cmdstan_path() to change the path
``` 

New version: 

```
This is cmdstanr version 0.4.0.9000
- CmdStanR documentation and vignettes: mc-stan.org/cmdstanr
- CmdStan path: /Users/jgabry/.cmdstan/cmdstan-2.28.1
- CmdStan version: 2.28.1
```

@rok-cesnovar What do you think of this change? If you prefer the old version we can keep it, or if you have suggestions for the new version I can add those. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
