### PR TITLE
try to get test to error in order to investigate #589

### DIFF
--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -95,7 +95,7 @@ test_that("install_cmdstan() works with version and release_url", {
   expect_message(
     expect_output(
       install_cmdstan(dir = dir, overwrite = TRUE, cores = 4,
-                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.24.0/cmdstan-2.24.0.tar.gz"),
+                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.25.0/cmdstan-2.25.0.tar.gz"),
       "Compiling, linking C++ code",
       fixed = TRUE
     ),
@@ -106,9 +106,9 @@ test_that("install_cmdstan() works with version and release_url", {
     expect_message(
       expect_output(
         install_cmdstan(dir = dir, overwrite = TRUE, cores = 4,
-                        version = "2.23.0",
+                        version = "2.26.1",
                         # the URL is intentionally invalid to test that the version has higher priority
-                        release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.23.2/cmdstan-2.23.2.tar.gz"),
+                        release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.26.3/cmdstan-2.26.3.tar.gz"),
         "Compiling, linking C++ code",
         fixed = TRUE
       ),

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -6,7 +6,6 @@ if (!nzchar(cmdstan_test_tarball_url)) {
 }
 
 test_that("install_cmdstan() successfully installs cmdstan", {
-  skip_if_offline()
   if (getRversion() < '3.5.0') {
     dir <- tempdir()
   } else {
@@ -25,10 +24,6 @@ test_that("install_cmdstan() successfully installs cmdstan", {
 })
 
 test_that("install_cmdstan() errors if installation already exists", {
-  # skip_if_offline()
-  if (not_on_cran()) {
-    print("foo")
-  }
   install_dir <- cmdstan_default_install_path()
   dir <- file.path(install_dir, "cmdstan-2.23.0")
   if (!dir.exists(dir)) {
@@ -43,7 +38,6 @@ test_that("install_cmdstan() errors if installation already exists", {
 })
 
 test_that("install_cmdstan() errors if it times out", {
-  skip_if_offline()
   if (getRversion() < '3.5.0') {
     dir <- tempdir()
   } else {
@@ -77,7 +71,6 @@ test_that("install_cmdstan() errors if it times out", {
 })
 
 test_that("install_cmdstan() errors if invalid version or URL", {
-  skip_if_offline()
   expect_error(
     install_cmdstan(version = "2.23.2"),
     "Download of CmdStan failed. Please check if the supplied version number is valid."
@@ -93,7 +86,6 @@ test_that("install_cmdstan() errors if invalid version or URL", {
 })
 
 test_that("install_cmdstan() works with version and release_url", {
-  skip_if_offline()
   if (getRversion() < '3.5.0') {
     dir <- tempdir()
   } else {

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -25,7 +25,7 @@ test_that("install_cmdstan() successfully installs cmdstan", {
 })
 
 test_that("install_cmdstan() errors if installation already exists", {
-  skip_if_offline()
+  # skip_if_offline()
   if (not_on_cran()) {
     print("foo")
   }

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -95,7 +95,7 @@ test_that("install_cmdstan() works with version and release_url", {
   expect_message(
     expect_output(
       install_cmdstan(dir = dir, overwrite = TRUE, cores = 4,
-                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.25.0/cmdstan-2.25.0.tar.gz"),
+                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.26.1/cmdstan-2.26.1.tar.gz"),
       "Compiling, linking C++ code",
       fixed = TRUE
     ),
@@ -106,9 +106,9 @@ test_that("install_cmdstan() works with version and release_url", {
     expect_message(
       expect_output(
         install_cmdstan(dir = dir, overwrite = TRUE, cores = 4,
-                        version = "2.26.1",
+                        version = "2.27.0",
                         # the URL is intentionally invalid to test that the version has higher priority
-                        release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.26.3/cmdstan-2.26.3.tar.gz"),
+                        release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.27.3/cmdstan-2.27.3.tar.gz"),
         "Compiling, linking C++ code",
         fixed = TRUE
       ),
@@ -118,7 +118,7 @@ test_that("install_cmdstan() works with version and release_url", {
     "version and release_url shouldn't both be specified",
     fixed = TRUE
   )
-  expect_true(dir.exists(file.path(dir, "cmdstan-2.26.1")))
+  expect_true(dir.exists(file.path(dir, "cmdstan-2.27.0")))
   set_cmdstan_path(cmdstan_default_path())
 })
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -26,6 +26,9 @@ test_that("install_cmdstan() successfully installs cmdstan", {
 
 test_that("install_cmdstan() errors if installation already exists", {
   skip_if_offline()
+  if (not_on_cran()) {
+    print("foo")
+  }
   install_dir <- cmdstan_default_install_path()
   dir <- file.path(install_dir, "cmdstan-2.23.0")
   if (!dir.exists(dir)) {

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -118,7 +118,7 @@ test_that("install_cmdstan() works with version and release_url", {
     "version and release_url shouldn't both be specified",
     fixed = TRUE
   )
-  expect_true(dir.exists(file.path(dir, "cmdstan-2.23.0")))
+  expect_true(dir.exists(file.path(dir, "cmdstan-2.26.1")))
   set_cmdstan_path(cmdstan_default_path())
 })
 


### PR DESCRIPTION
This PR should _not_ be merged, just using it to trigger the CI.  I'm trying to investigate the question in #589 as to why a test that should have failed in all runs only failed in test coverage on linux. This attempts to recreate the problem. 