### PR TITLE
Make cmdstan_model doc more clear about compile options

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -1,11 +1,14 @@
 #' Create a new CmdStanModel object
 #'
-#' \if{html}{\figure{logo.png}{options: width="25px"
-#' alt="https://mc-stan.org/about/logo/"}} Create a new [`CmdStanModel`] object
-#' from a file containing a Stan program or from an existing Stan executable.
-#' The [`CmdStanModel`] object stores the path to a Stan program and compiled
-#' executable (once created), and provides methods for fitting the model using
-#' Stan's algorithms.
+#' @description \if{html}{\figure{logo.png}{options: width="25px"
+#'   alt="https://mc-stan.org/about/logo/"}} Create a new [`CmdStanModel`]
+#'   object from a file containing a Stan program or from an existing Stan
+#'   executable. The [`CmdStanModel`] object stores the path to a Stan program
+#'   and compiled executable (once created), and provides methods for fitting
+#'   the model using Stan's algorithms.
+#'
+#'   See the `compile` and `...` arguments for control over whether and how
+#'   compilation happens.
 #'
 #' @export
 #' @param stan_file (string) The path to a `.stan` file containing a Stan
@@ -20,7 +23,10 @@
 #'   compilation can be done later via the [`$compile()`][model-method-compile]
 #'   method.
 #' @param ... Optionally, additional arguments to pass to the
-#'   [`$compile()`][model-method-compile] method if `compile=TRUE`.
+#'   [`$compile()`][model-method-compile] method if `compile=TRUE`. These
+#'   options include specifying the directory for saving the executable, turning
+#'   on pedantic mode, specifying include paths, configuring C++ options, and
+#'   more. See [`$compile()`][model-method-compile] for details.
 #'
 #' @return A [`CmdStanModel`] object.
 #'
@@ -349,8 +355,8 @@ CmdStanModel <- R6::R6Class(
 #'   Stan program beyond syntax errors. For details see the [*Pedantic mode*
 #'   chapter](https://mc-stan.org/docs/reference-manual/pedantic-mode.html) in
 #'   the Stan Reference Manual. **Note:** to do a pedantic check for a model
-#'   that is already compiled use the
-#'   [`$check_syntax()`][model-method-check_syntax] method instead.
+#'   without compiling it or for a model that is already compiled the
+#'   [`$check_syntax()`][model-method-check_syntax] method can be used instead.
 #' @param include_paths (character vector) Paths to directories where Stan
 #'   should look for files specified in `#include` directives in the Stan
 #'   program.

--- a/man/cmdstan_model.Rd
+++ b/man/cmdstan_model.Rd
@@ -22,18 +22,24 @@ compilation can be done later via the \code{\link[=model-method-compile]{$compil
 method.}
 
 \item{...}{Optionally, additional arguments to pass to the
-\code{\link[=model-method-compile]{$compile()}} method if \code{compile=TRUE}.}
+\code{\link[=model-method-compile]{$compile()}} method if \code{compile=TRUE}. These
+options include specifying the directory for saving the executable, turning
+on pedantic mode, specifying include paths, configuring C++ options, and
+more. See \code{\link[=model-method-compile]{$compile()}} for details.}
 }
 \value{
 A \code{\link{CmdStanModel}} object.
 }
 \description{
 \if{html}{\figure{logo.png}{options: width="25px"
-alt="https://mc-stan.org/about/logo/"}} Create a new \code{\link{CmdStanModel}} object
-from a file containing a Stan program or from an existing Stan executable.
-The \code{\link{CmdStanModel}} object stores the path to a Stan program and compiled
-executable (once created), and provides methods for fitting the model using
-Stan's algorithms.
+  alt="https://mc-stan.org/about/logo/"}} Create a new \code{\link{CmdStanModel}}
+object from a file containing a Stan program or from an existing Stan
+executable. The \code{\link{CmdStanModel}} object stores the path to a Stan program
+and compiled executable (once created), and provides methods for fitting
+the model using Stan's algorithms.
+
+See the \code{compile} and \code{...} arguments for control over whether and how
+compilation happens.
 }
 \examples{
 \dontrun{

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -31,8 +31,8 @@ same location as the Stan program.}
 \code{FALSE}. Pedantic mode attempts to warn you about potential issues in your
 Stan program beyond syntax errors. For details see the \href{https://mc-stan.org/docs/reference-manual/pedantic-mode.html}{\emph{Pedantic mode} chapter} in
 the Stan Reference Manual. \strong{Note:} to do a pedantic check for a model
-that is already compiled use the
-\code{\link[=model-method-check_syntax]{$check_syntax()}} method instead.}
+without compiling it or for a model that is already compiled the
+\code{\link[=model-method-check_syntax]{$check_syntax()}} method can be used instead.}
 
 \item{include_paths}{(character vector) Paths to directories where Stan
 should look for files specified in \verb{#include} directives in the Stan


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Closes #556. Instead of adding the compile arguments explicitly to `cmdstan_model` this PR improves the documentation of the `...` argument to make it more clear what options are available (e.g., specifying the directory to store the executable).  

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
