### PR TITLE
Fix for M1

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -495,9 +495,6 @@ compile <- function(quiet = TRUE,
     self$exe_file(exe)
     return(invisible(self))
   } else {
-    if (file.exists(exe)) {
-      file.remove(exe)
-    }
     if (interactive()) {
       message("Compiling Stan program...")
     }
@@ -590,7 +587,9 @@ compile <- function(quiet = TRUE,
     stop("An error occured during compilation! See the message above for more information.",
          call. = FALSE)
   }
-
+  if (file.exists(exe)) {
+    file.remove(exe)
+  }
   file.copy(tmp_exe, exe, overwrite = TRUE)
   private$exe_file_ <- exe
   private$cpp_options_ <- cpp_options

--- a/R/model.R
+++ b/R/model.R
@@ -495,6 +495,9 @@ compile <- function(quiet = TRUE,
     self$exe_file(exe)
     return(invisible(self))
   } else {
+    if (file.exists(self$exe_file())) {
+      file.remove(self$exe_file())
+    }
     if (interactive()) {
       message("Compiling Stan program...")
     }

--- a/R/model.R
+++ b/R/model.R
@@ -495,8 +495,8 @@ compile <- function(quiet = TRUE,
     self$exe_file(exe)
     return(invisible(self))
   } else {
-    if (file.exists(self$exe_file())) {
-      file.remove(self$exe_file())
+    if (file.exists(exe)) {
+      file.remove(exe)
     }
     if (interactive()) {
       message("Compiling Stan program...")


### PR DESCRIPTION
#### Summary

Adds a fix for an M1 macOS issue reported by @spinkney. See https://discourse.mc-stan.org/t/m1-mac-issues/25453/6 for more.

The fix is essentially deleting the executable before we copy it over. For some reason (I will admit I am not exactly sure why this helps) just overwriting it causes issues. But an extra delete before an overwrite seems fine to me, so I am fine with adding this even though I am not 100% why it helps :)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
