### PR TITLE
Use verbatim engine for embedded code chunks

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -36,7 +36,7 @@ Imports:
     R6 (>= 2.4.0)
 Suggests: 
     bayesplot,
-    knitr,
+    knitr (>= 1.37),
     loo (>= 2.0.0),
     rlang (>= 0.4.7),
     rmarkdown,

--- a/vignettes/r-markdown.Rmd
+++ b/vignettes/r-markdown.Rmd
@@ -29,12 +29,12 @@ Behind the scenes, the engine relies on RStan to compile the model code into an
 in-memory `stanmodel`, which is assigned to a variable with the name given by
 the `output.var` chunk option. For example:
 
-````
-`r ''````{stan, output.var="model"}
+````{verbatim}
+```{stan, output.var="model"}
 // Stan model code
 ```
 
-`r ''````{r}
+```{r}
 rstan::sampling(model)
 ```
 ````
@@ -52,12 +52,12 @@ chunks are processed with CmdStanR, not RStan. Of course, this also means that
 the variable specified by `output.var` will no longer be a `stanmodel` object,
 but instead a `CmdStanModel` object, so the code above would look like this:
 
-````
-`r ''````{stan, output.var="model"}
+````{verbatim}
+```{stan, output.var="model"}
 // Stan model code
 ```
 
-`r ''````{r}
+```{r}
 model$sample()
 ```
 ````
@@ -111,20 +111,20 @@ register_knitr_engine(override = FALSE)
 This will cause `stan` chunks to be processed by knitr's built-in, RStan-based
 engine and only use CmdStanR's knitr engine for `cmdstan` chunks:
 
-````
-`r ''````{stan, output.var="model_obj1"}
+````{verbatim}
+```{stan, output.var="model_obj1"}
 // Results in a stanmodel object
 ```
 
-`r ''````{r}
+```{r}
 rstan::sampling(model_obj1)
 ```
 
-`r ''````{cmdstan, output.var="model_obj2"}
+```{cmdstan, output.var="model_obj2"}
 // Results in a CmdStanModel object
 ```
 
-`r ''````{r}
+```{r}
 model_obj2$sample()
 ```
 ````


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Use the new verbatim engine from [knitr 1.37](https://github.com/yihui/knitr/releases/tag/v1.37) for cleaner embedded code chunks in the source R Markdown document.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Mikhail Popov


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
