### PR TITLE
Temporary fix for vignettes on GHA

### DIFF
--- a/vignettes/cmdstanr-internals.Rmd
+++ b/vignettes/cmdstanr-internals.Rmd
@@ -28,6 +28,7 @@ methods work in a similar way under the hood.
 
 ```{r setup, message=FALSE}
 library(cmdstanr)
+check_cmdstan_toolchain(fix = TRUE, quiet = TRUE)
 ```
 
 ## Compilation

--- a/vignettes/cmdstanr.Rmd
+++ b/vignettes/cmdstanr.Rmd
@@ -38,6 +38,7 @@ later in examples.
 
 ```{r library, message=FALSE}
 library(cmdstanr)
+check_cmdstan_toolchain(fix = TRUE, quiet = TRUE)
 library(posterior)
 library(bayesplot)
 color_scheme_set("brightblue")

--- a/vignettes/profiling.Rmd
+++ b/vignettes/profiling.Rmd
@@ -33,6 +33,7 @@ perspective, see Gelman (2020).
 
 ```{r library, message=FALSE}
 library(cmdstanr)
+check_cmdstan_toolchain(fix = TRUE, quiet = TRUE)
 ```
 
 ## Adding profiling statements to a Stan program

--- a/vignettes/r-markdown.Rmd
+++ b/vignettes/r-markdown.Rmd
@@ -43,6 +43,7 @@ CmdStanR provides a replacement engine, which can be registered as follows:
 
 ```{r setup, message=FALSE}
 library(cmdstanr)
+check_cmdstan_toolchain(fix = TRUE, quiet = TRUE)
 
 register_knitr_engine()
 ```


### PR DESCRIPTION
#### Summary

For some reason, in Github Actions, when running the vignettes, it selects the new Windows UCRT toolchain (the new RTools 4v2 has two available toolchains). I have not been able to find out why exactly this happens and the rest of our tests work fine. 

This just adds a call to fix the toolchain before running the rest of the vignette. I am going to merge this with the tests passing until we find a nicer fix for this probem. This does not affect our Windows users otherwise.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
