### PR TITLE
Fix windows output message test

### DIFF
--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -72,7 +72,7 @@ test_that("cmdstan_summary works if bin/stansummary deleted file", {
     file.remove(file.path(cmdstan_path(), "bin", cmdstan_ext("stansummary")))
     fit_mcmc$cmdstan_summary()
   }
-  expect_output(delete_and_run(), "Inference for Stan model: logistic_model\\n2 chains: each with iter")
+  expect_output(delete_and_run(), "Inference for Stan model: logistic_model")
 })
 
 test_that("cmdstan_diagnose works if bin/diagnose deleted file", {


### PR DESCRIPTION
#### Summary

Fixes a brittle test that relied on "\n" in the output. It failed if the output had "\r\n".

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
