### PR TITLE
Fix `user_header` handling

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -66,7 +66,7 @@
 #'
 #' cpp_options <- list(
 #'   "CXX" = "clang++",
-#'   "CXXFLAGS+= -march-native",
+#'   "CXXFLAGS+= -march=native",
 #'   PRECOMPILED_HEADERS = TRUE
 #' )
 #' # cmdstan_make_local(cpp_options = cpp_options)

--- a/R/model.R
+++ b/R/model.R
@@ -233,7 +233,8 @@ CmdStanModel <- R6::R6Class(
         private$model_name_ <- sub(" ", "_", strip_ext(basename(private$stan_file_)))
         private$precompile_cpp_options_ <- args$cpp_options %||% list()
         private$precompile_stanc_options_ <- assert_valid_stanc_options(args$stanc_options) %||% list()
-        if (!is.null(args$user_header)) {
+        if (!is.null(args$user_header) || !is.null(args$cpp_options[["USER_HEADER"]]) ||
+            !is.null(args$cpp_options[["user_header"]])) {
           private$using_user_header_ <- TRUE
         }
         private$precompile_include_paths_ <- args$include_paths

--- a/docs/reference/install_cmdstan.html
+++ b/docs/reference/install_cmdstan.html
@@ -320,7 +320,7 @@ the updated contents are returned.</p>
 
 <span class='no'>cpp_options</span> <span class='kw'>&lt;-</span> <span class='fu'><a href='https://rdrr.io/r/base/list.html'>list</a></span>(
   <span class='st'>"CXX"</span> <span class='kw'>=</span> <span class='st'>"clang++"</span>,
-  <span class='st'>"CXXFLAGS+= -march-native"</span>,
+  <span class='st'>"CXXFLAGS+= -march=native"</span>,
   <span class='kw'>PRECOMPILED_HEADERS</span> <span class='kw'>=</span> <span class='fl'>TRUE</span>
 )
 <span class='co'># cmdstan_make_local(cpp_options = cpp_options)</span>

--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -118,7 +118,7 @@ check_cmdstan_toolchain()
 
 cpp_options <- list(
   "CXX" = "clang++",
-  "CXXFLAGS+= -march-native",
+  "CXXFLAGS+= -march=native",
   PRECOMPILED_HEADERS = TRUE
 )
 # cmdstan_make_local(cpp_options = cpp_options)

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -602,6 +602,13 @@ test_that("cmdstan_model works with user_header", {
     user_header = tmpfile
   )
   expect_true(file.exists(mod$exe_file()))
+  file.remove(mod$exe_file())
+  mod_2 <- cmdstan_model(
+    stan_file = testing_stan_file("bernoulli_external"),
+    cpp_options=list(USER_HEADER=tmpfile),
+    stanc_options = list("allow-undefined")
+  )
+  expect_true(file.exists(mod_2$exe_file()))
 })
 
 test_that("cmdstan_model cpp_options dont captialize cxxflags ", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -111,7 +111,7 @@ test_that("cmdstan_make_local() works", {
   expect_equal(cmdstan_make_local(), NULL)
   cpp_options = list(
    "CXX" = "clang++",
-   "CXXFLAGS+=  -march=native",
+   "CXXFLAGS+= -march=native",
    TEST1 = TRUE,
    "TEST2" = FALSE
   )

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -111,21 +111,21 @@ test_that("cmdstan_make_local() works", {
   expect_equal(cmdstan_make_local(), NULL)
   cpp_options = list(
    "CXX" = "clang++",
-   "CXXFLAGS+= -march-native",
+   "CXXFLAGS+=  -march=native",
    TEST1 = TRUE,
    "TEST2" = FALSE
   )
   expect_equal(cmdstan_make_local(cpp_options = cpp_options),
                c(
                  "CXX=clang++",
-                 "CXXFLAGS+= -march-native",
+                 "CXXFLAGS+= -march=native",
                  "TEST1=true",
                  "TEST2=false"
                  ))
   expect_equal(cmdstan_make_local(cpp_options = list("TEST3" = TRUE)),
                c(
                  "CXX=clang++",
-                 "CXXFLAGS+= -march-native",
+                 "CXXFLAGS+= -march=native",
                  "TEST1=true",
                  "TEST2=false",
                  "TEST3=true"


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes handling of user_header when it is supplied as part of cpp_options.

Fixes #612 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
