### PR TITLE
Use quotes with path to grep.exe on Windows

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -227,7 +227,7 @@ read_cmdstan_csv <- function(files,
   num_post_warmup_draws <- ceiling(metadata$iter_sampling / metadata$thin)
   for (output_file in files) {
     if (os_is_windows()) {
-      grep_path <- paste0('"', repair_path(Sys.which("grep.exe"), '"')
+      grep_path <- paste0('"', repair_path(Sys.which("grep.exe"), '"'))
       fread_cmd <- paste0(grep_path, " -v '^#' --color=never '", output_file, "'")
     } else {
       fread_cmd <- paste0("grep -v '^#' --color=never '", output_file, "'")

--- a/R/csv.R
+++ b/R/csv.R
@@ -556,7 +556,7 @@ read_csv_metadata <- function(csv_file) {
   sampling_time <- 0
   total_time <- 0
   if (os_is_windows()) {
-    grep_path <- paste0('"', repair_path(Sys.which("grep.exe"), '"')
+    grep_path <- paste0('"', repair_path(Sys.which("grep.exe")), '"')
     fread_cmd <- paste0(grep_path, " '^[#a-zA-Z]' --color=never '", csv_file, "'")
   } else {
     fread_cmd <- paste0("grep '^[#a-zA-Z]' --color=never '", csv_file, "'")

--- a/R/csv.R
+++ b/R/csv.R
@@ -227,7 +227,7 @@ read_cmdstan_csv <- function(files,
   num_post_warmup_draws <- ceiling(metadata$iter_sampling / metadata$thin)
   for (output_file in files) {
     if (os_is_windows()) {
-      grep_path <- repair_path(Sys.which("grep.exe"))
+      grep_path <- paste0('"', repair_path(Sys.which("grep.exe"), '"')
       fread_cmd <- paste0(grep_path, " -v '^#' --color=never '", output_file, "'")
     } else {
       fread_cmd <- paste0("grep -v '^#' --color=never '", output_file, "'")
@@ -556,7 +556,7 @@ read_csv_metadata <- function(csv_file) {
   sampling_time <- 0
   total_time <- 0
   if (os_is_windows()) {
-    grep_path <- repair_path(Sys.which("grep.exe"))
+    grep_path <- paste0('"', repair_path(Sys.which("grep.exe"), '"')
     fread_cmd <- paste0(grep_path, " '^[#a-zA-Z]' --color=never '", csv_file, "'")
   } else {
     fread_cmd <- paste0("grep '^[#a-zA-Z]' --color=never '", csv_file, "'")

--- a/R/csv.R
+++ b/R/csv.R
@@ -227,7 +227,7 @@ read_cmdstan_csv <- function(files,
   num_post_warmup_draws <- ceiling(metadata$iter_sampling / metadata$thin)
   for (output_file in files) {
     if (os_is_windows()) {
-      grep_path <- paste0('"', repair_path(Sys.which("grep.exe"), '"'))
+      grep_path <- paste0('"', repair_path(Sys.which("grep.exe")), '"')
       fread_cmd <- paste0(grep_path, " -v '^#' --color=never '", output_file, "'")
     } else {
       fread_cmd <- paste0("grep -v '^#' --color=never '", output_file, "'")


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #562 

We cant really add tests for this. I did try this script out on Windows Github Actions instances: 

```r
fit <- cmdstanr::cmdstanr_example()
a <- Sys.which("grep.exe")
dir.create("~/test test")
b <- cmdstanr:::repair_path("~/test test")
file.copy(a, b)
grep_path <- paste0('"', file.path(b, "grep.exe"), '"')
fread_cmd <- paste0(grep_path, " -v '^#' --color=never '", fit$output_files()[1], "'")
t <- data.table::fread(
  cmd = fread_cmd,
  data.table = FALSE
)
```
and it works fine with this fix and doesn't without it.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
