### PR TITLE
Add Depends: R >= 3.5.0

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,7 +28,9 @@ LazyData: true
 RoxygenNote: 7.1.2
 Roxygen: list(markdown = TRUE, r6 = FALSE)
 SystemRequirements: CmdStan (https://mc-stan.org/users/interfaces/cmdstan)
-Imports: 
+Depends:
+    R (>= 3.5.0)
+Imports:
     checkmate,
     data.table,
     jsonlite (>= 1.2.0),


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

When installing, I get the following warning: 
```
     NB: this package now depends on R (>= 3.5.0)
     WARNING: Added dependency on R >= 3.5.0 because serialized objects in
     serialize/load version 3 cannot be read in older versions of R.
     File(s) containing such objects:
       ‘cmdstanr/tests/testthat/answers/model-code-output.rds’
```

So I just added "Depends: R >= 3.5.0". We could go and do something else as opposed to `.rds` file, but R 3.4 is so obsolete, I don't think it's worth it.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
