### PR TITLE
r-markdown.Rmd: use verbatim chunks again

### DIFF
--- a/docs/articles/r-markdown.html
+++ b/docs/articles/r-markdown.html
@@ -141,15 +141,13 @@
     
 <p>R Markdown supports a variety of languages through the use of knitr language engines. One such engine is the <code>stan</code> engine, which allows users to write Stan programs directly in their R Markdown documents by setting the language of the chunk to <code>stan</code>.</p>
 <p>Behind the scenes, the engine relies on RStan to compile the model code into an in-memory <code>stanmodel</code>, which is assigned to a variable with the name given by the <code>output.var</code> chunk option. For example:</p>
-<!-- trick for using verbatim chunks taken from  -->
-<!-- https://support.rstudio.com/hc/en-us/articles/360018181633-Including-verbatim-R-code-chunks-inside-R-Markdown -->
-<div class="sourceCode" id="cb1"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a><span class="in">```{stan, output.var="model"}</span></span>
-<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a><span class="in">// Stan model code</span></span>
-<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span>
+<div class="sourceCode" id="cb1"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb1-1"><a href="#cb1-1" aria-hidden="true" tabindex="-1"></a>```{stan, output.var="model"}</span>
+<span id="cb1-2"><a href="#cb1-2" aria-hidden="true" tabindex="-1"></a>// Stan model code</span>
+<span id="cb1-3"><a href="#cb1-3" aria-hidden="true" tabindex="-1"></a>```</span>
 <span id="cb1-4"><a href="#cb1-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a><span class="in">```{r}</span></span>
-<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a><span class="in">rstan::sampling(model)</span></span>
-<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span></code></pre></div>
+<span id="cb1-5"><a href="#cb1-5" aria-hidden="true" tabindex="-1"></a>```{r}</span>
+<span id="cb1-6"><a href="#cb1-6" aria-hidden="true" tabindex="-1"></a>rstan::sampling(model)</span>
+<span id="cb1-7"><a href="#cb1-7" aria-hidden="true" tabindex="-1"></a>```</span></code></pre></div>
 <p>CmdStanR provides a replacement engine, which can be registered as follows:</p>
 <div class="sourceCode" id="cb2"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="kw"><a href="https://rdrr.io/r/base/library.html">library</a></span><span class="op">(</span><span class="va"><a href="https://mc-stan.org/cmdstanr/">cmdstanr</a></span><span class="op">)</span>
@@ -157,18 +155,17 @@
 
 <span class="fu"><a href="../reference/register_knitr_engine.html">register_knitr_engine</a></span><span class="op">(</span><span class="op">)</span></code></pre></div>
 <p>By default, this overrides knitr’s built-in <code>stan</code> engine so that all <code>stan</code> chunks are processed with CmdStanR, not RStan. Of course, this also means that the variable specified by <code>output.var</code> will no longer be a <code>stanmodel</code> object, but instead a <code>CmdStanModel</code> object, so the code above would look like this:</p>
-<div class="sourceCode" id="cb3"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a><span class="in">```{stan, output.var="model"}</span></span>
-<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a><span class="in">// Stan model code</span></span>
-<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span>
+<div class="sourceCode" id="cb3"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb3-1"><a href="#cb3-1" aria-hidden="true" tabindex="-1"></a>```{stan, output.var="model"}</span>
+<span id="cb3-2"><a href="#cb3-2" aria-hidden="true" tabindex="-1"></a>// Stan model code</span>
+<span id="cb3-3"><a href="#cb3-3" aria-hidden="true" tabindex="-1"></a>```</span>
 <span id="cb3-4"><a href="#cb3-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a><span class="in">```{r}</span></span>
-<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a><span class="in">model$sample()</span></span>
-<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span></code></pre></div>
+<span id="cb3-5"><a href="#cb3-5" aria-hidden="true" tabindex="-1"></a>```{r}</span>
+<span id="cb3-6"><a href="#cb3-6" aria-hidden="true" tabindex="-1"></a>model$sample()</span>
+<span id="cb3-7"><a href="#cb3-7" aria-hidden="true" tabindex="-1"></a>```</span></code></pre></div>
 <div id="example" class="section level2">
 <h2 class="hasAnchor">
 <a href="#example" class="anchor"></a>Example</h2>
-<pre class="stan"><code>// This stan chunk results in a CmdStanModel object called "ex1" (by setting output.var="ex1")
-
+<pre class="stan"><code>// This stan chunk results in a CmdStanModel object called "ex1"
 parameters {
   array[2] real y;
 }
@@ -178,8 +175,7 @@ model {
 }</code></pre>
 <div class="sourceCode" id="cb5"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="va">ex1</span><span class="op">$</span><span class="fu">print</span><span class="op">(</span><span class="op">)</span>
-<span class="co">#&gt; // This stan chunk results in a CmdStanModel object called "ex1" (by setting output.var="ex1")</span>
-<span class="co">#&gt; </span>
+<span class="co">#&gt; // This stan chunk results in a CmdStanModel object called "ex1"</span>
 <span class="co">#&gt; parameters {</span>
 <span class="co">#&gt;   array[2] real y;</span>
 <span class="co">#&gt; }</span>
@@ -222,20 +218,21 @@ model {
 <div class="sourceCode" id="cb7"><pre class="downlit sourceCode r">
 <code class="sourceCode R"><span class="fu"><a href="../reference/register_knitr_engine.html">register_knitr_engine</a></span><span class="op">(</span>override <span class="op">=</span> <span class="cn">FALSE</span><span class="op">)</span></code></pre></div>
 <p>This will cause <code>stan</code> chunks to be processed by knitr’s built-in, RStan-based engine and only use CmdStanR’s knitr engine for <code>cmdstan</code> chunks:</p>
-<div class="sourceCode" id="cb8"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a><span class="in">```{stan, output.var="model_obj1"}</span></span>
-<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a><span class="in">// Results in a stanmodel object from RStan</span></span>
-<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span>
+<div class="sourceCode" id="cb8"><pre class="sourceCode default"><code class="sourceCode default"><span id="cb8-1"><a href="#cb8-1" aria-hidden="true" tabindex="-1"></a>```{stan, output.var="model_obj1"}</span>
+<span id="cb8-2"><a href="#cb8-2" aria-hidden="true" tabindex="-1"></a>// Results in a stanmodel object from RStan</span>
+<span id="cb8-3"><a href="#cb8-3" aria-hidden="true" tabindex="-1"></a>```</span>
 <span id="cb8-4"><a href="#cb8-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a><span class="in">```{r}</span></span>
-<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a><span class="in">rstan::sampling(model_obj1)</span></span>
-<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span></code></pre></div>
-<div class="sourceCode" id="cb9"><pre class="sourceCode markdown"><code class="sourceCode markdown"><span id="cb9-1"><a href="#cb9-1" aria-hidden="true" tabindex="-1"></a><span class="in">```{cmdstan, output.var="model_obj2"}</span></span>
-<span id="cb9-2"><a href="#cb9-2" aria-hidden="true" tabindex="-1"></a><span class="in">// Results in a CmdStanModel object from CmdStanR</span></span>
-<span id="cb9-3"><a href="#cb9-3" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span>
-<span id="cb9-4"><a href="#cb9-4" aria-hidden="true" tabindex="-1"></a></span>
-<span id="cb9-5"><a href="#cb9-5" aria-hidden="true" tabindex="-1"></a><span class="in">```{r}</span></span>
-<span id="cb9-6"><a href="#cb9-6" aria-hidden="true" tabindex="-1"></a><span class="in">model_obj2$sample()</span></span>
-<span id="cb9-7"><a href="#cb9-7" aria-hidden="true" tabindex="-1"></a><span class="in">```</span></span></code></pre></div>
+<span id="cb8-5"><a href="#cb8-5" aria-hidden="true" tabindex="-1"></a>```{r}</span>
+<span id="cb8-6"><a href="#cb8-6" aria-hidden="true" tabindex="-1"></a>rstan::sampling(model_obj1)</span>
+<span id="cb8-7"><a href="#cb8-7" aria-hidden="true" tabindex="-1"></a>```</span>
+<span id="cb8-8"><a href="#cb8-8" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-9"><a href="#cb8-9" aria-hidden="true" tabindex="-1"></a>```{cmdstan, output.var="model_obj2"}</span>
+<span id="cb8-10"><a href="#cb8-10" aria-hidden="true" tabindex="-1"></a>// Results in a CmdStanModel object from CmdStanR</span>
+<span id="cb8-11"><a href="#cb8-11" aria-hidden="true" tabindex="-1"></a>```</span>
+<span id="cb8-12"><a href="#cb8-12" aria-hidden="true" tabindex="-1"></a></span>
+<span id="cb8-13"><a href="#cb8-13" aria-hidden="true" tabindex="-1"></a>```{r}</span>
+<span id="cb8-14"><a href="#cb8-14" aria-hidden="true" tabindex="-1"></a>model_obj2$sample()</span>
+<span id="cb8-15"><a href="#cb8-15" aria-hidden="true" tabindex="-1"></a>```</span></code></pre></div>
 </div>
 <div id="running-interactively" class="section level2">
 <h2 class="hasAnchor">

--- a/vignettes/r-markdown.Rmd
+++ b/vignettes/r-markdown.Rmd
@@ -12,7 +12,7 @@ vignette: >
   %\VignetteEncoding{UTF-8}
 ---
 
-```{r, include = FALSE}
+```{r settings-knitr, include = FALSE}
 knitr::opts_chunk$set(
   collapse = TRUE,
   comment = "#>",
@@ -29,22 +29,19 @@ Behind the scenes, the engine relies on RStan to compile the model code into an
 in-memory `stanmodel`, which is assigned to a variable with the name given by
 the `output.var` chunk option. For example:
 
-<!-- trick for using verbatim chunks taken from  -->
-<!-- https://support.rstudio.com/hc/en-us/articles/360018181633-Including-verbatim-R-code-chunks-inside-R-Markdown -->
-
-````markdown
-`r ''````{stan, output.var="model"}
+````{verbatim}
+```{stan, output.var="model"}
 // Stan model code
 ```
 
-`r ''````{r}
+```{r}
 rstan::sampling(model)
 ```
 ````
 
 CmdStanR provides a replacement engine, which can be registered as follows:
 
-```{r setup, message=FALSE}
+```{r register-engine, message=FALSE}
 library(cmdstanr)
 check_cmdstan_toolchain(fix = TRUE, quiet = TRUE)
 
@@ -56,12 +53,12 @@ chunks are processed with CmdStanR, not RStan. Of course, this also means that
 the variable specified by `output.var` will no longer be a `stanmodel` object,
 but instead a `CmdStanModel` object, so the code above would look like this:
 
-````markdown
-`r ''````{stan, output.var="model"}
+````{verbatim}
+```{stan, output.var="model"}
 // Stan model code
 ```
 
-`r ''````{r}
+```{r}
 model$sample()
 ```
 ````
@@ -69,8 +66,7 @@ model$sample()
 ## Example
 
 ```{stan ex1, output.var="ex1"}
-// This stan chunk results in a CmdStanModel object called "ex1" (by setting output.var="ex1")
-
+// This stan chunk results in a CmdStanModel object called "ex1"
 parameters {
   array[2] real y;
 }
@@ -80,11 +76,11 @@ model {
 }
 ```
 
-```{r}
+```{r print-ex1}
 ex1$print()
 ```
 
-```{r fit}
+```{r fit-ex1}
 fit <- ex1$sample(
   refresh = 0,
   seed = 42L
@@ -109,29 +105,27 @@ same document or project, the option to use both exists. When registering
 CmdStanR's knitr engine, set `override = FALSE` to register the engine as a
 `cmdstan` engine:
 
-```r
+```{r register-engine-no-override}
 register_knitr_engine(override = FALSE)
 ```
 
 This will cause `stan` chunks to be processed by knitr's built-in, RStan-based
 engine and only use CmdStanR's knitr engine for `cmdstan` chunks:
 
-````markdown
-`r ''````{stan, output.var="model_obj1"}
+````{verbatim}
+```{stan, output.var="model_obj1"}
 // Results in a stanmodel object from RStan
 ```
 
-`r ''````{r}
+```{r}
 rstan::sampling(model_obj1)
 ```
-````
 
-````markdown
-`r ''````{cmdstan, output.var="model_obj2"}
+```{cmdstan, output.var="model_obj2"}
 // Results in a CmdStanModel object from CmdStanR
 ```
 
-`r ''````{r}
+```{r}
 model_obj2$sample()
 ```
 ````


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

I got the verbatim chunks working again. Actually I think they never stopped working, I just had an old version of knitr installed. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
