### PR TITLE
temporarily disable rvars

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: cmdstanr
 Title: R Interface to 'CmdStan'
-Version: 0.5.0
-Date: 2022-03-17
+Version: 0.5.1
+Date: 2022-04-06
 Authors@R: 
     c(person(given = "Jonah", family = "Gabry", role = c("aut", "cre"),
            email = "jsg2201@columbia.edu"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# cmdstanr 0.5.1
+
+* Temporarily disable `format="draws_rvars"` in the `$draws()` method due to a
+bug. Until this is fixed users can make use of `posterior::as_draws_rvars()` to
+convert draws from CmdStanR to the `draws_rvars` format. (#640)
+
 # cmdstanr 0.5.0
 
 ### Bug fixes

--- a/R/fit.R
+++ b/R/fit.R
@@ -823,6 +823,7 @@ CmdStanFit$set("public", name = "code", value = code)
 #'
 #'  |**Method**|**Description**|
 #'  |:----------|:---------------|
+#'  [`$print()`][fit-method-print] |  Run [`posterior::summarise_draws()`][posterior::draws_summary]. |
 #'  [`$summary()`][fit-method-summary] |  Run [`posterior::summarise_draws()`][posterior::draws_summary]. |
 #'  [`$diagnostic_summary()`][fit-method-diagnostic_summary] |  Get summaries of sampler diagnostics and warning messages. |
 #'  [`$cmdstan_summary()`][fit-method-cmdstan_summary] |  Run and print CmdStan's `bin/stansummary`. |

--- a/R/utils.R
+++ b/R/utils.R
@@ -356,18 +356,19 @@ as_draws_format_fun <- function(draws_format) {
 }
 
 assert_valid_draws_format <- function(format) {
-  if (!is.null(format) &&
-      !format %in% valid_draws_formats()) {
-    stop(
-      "The supplied draws format is not valid. ",
-      call. = FALSE
-    )
-  }
-  if (format %in% c("rvars", "draws_rvars")) {
-    stop(
-      "\nWe are fixing a bug in fit$draws(format = 'draws_rvars').",
-      "\nFor now please use posterior::as_draws_rvars(fit$draws()) instead."
-    )
+  if (!is.null(format)) {
+    if (!format %in% valid_draws_formats()) {
+      stop(
+        "The supplied draws format is not valid. ",
+        call. = FALSE
+      )
+    }
+    if (format %in% c("rvars", "draws_rvars")) {
+      stop(
+        "\nWe are fixing a bug in fit$draws(format = 'draws_rvars').",
+        "\nFor now please use posterior::as_draws_rvars(fit$draws()) instead."
+      )
+    }
   }
   invisible(format)
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -363,6 +363,12 @@ assert_valid_draws_format <- function(format) {
       call. = FALSE
     )
   }
+  if (format %in% c("rvars", "draws_rvars")) {
+    stop(
+      "\nWe are fixing a bug in fit$draws(format = 'draws_rvars').",
+      "\nFor now please use posterior::as_draws_rvars(fit$draws()) instead."
+    )
+  }
   invisible(format)
 }
 

--- a/man/CmdStanMCMC.Rd
+++ b/man/CmdStanMCMC.Rd
@@ -28,6 +28,7 @@ methods, all of which have their own (linked) documentation pages.
 
 \subsection{Summarize inferences and diagnostics}{\tabular{ll}{
    \strong{Method} \tab \strong{Description} \cr
+   \code{\link[=fit-method-print]{$print()}} \tab Run \code{\link[posterior:draws_summary]{posterior::summarise_draws()}}. \cr
    \code{\link[=fit-method-summary]{$summary()}} \tab Run \code{\link[posterior:draws_summary]{posterior::summarise_draws()}}. \cr
    \code{\link[=fit-method-diagnostic_summary]{$diagnostic_summary()}} \tab Get summaries of sampler diagnostics and warning messages. \cr
    \code{\link[=fit-method-cmdstan_summary]{$cmdstan_summary()}} \tab Run and print CmdStan's \code{bin/stansummary}. \cr

--- a/vignettes/profiling.Rmd
+++ b/vignettes/profiling.Rmd
@@ -46,7 +46,7 @@ data {
   int<lower=1> k;
   int<lower=0> n;
   matrix[n, k] X;
-  int y[n];
+  array[n] int y;
 }
 parameters {
   vector[k] beta;
@@ -84,7 +84,7 @@ data {
   int<lower=1> k;
   int<lower=0> n;
   matrix[n, k] X;
-  int y[n];
+  array[n] int y;
 }
 parameters {
   vector[k] beta;
@@ -157,7 +157,7 @@ data {
   int<lower=1> k;
   int<lower=0> n;
   matrix[n, k] X;
-  int y[n];
+  array[n] int y;
 }
 parameters {
   vector[k] beta;


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

I was thinking that while we decide what to do about #582 we should probably error when the `draws_rvars` format is used instead of returning the wrong thing. What do you think @rok-cesnovar? The error message I added suggests using `posterior::as_draws_rvars` for now. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
