### PR TITLE
Expand the use of CMDSTAN variable 

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -85,7 +85,6 @@ cmdstan_version <- function(error_on_NA = TRUE) {
 # number, and path to temp dir
 .cmdstanr <- new.env(parent = emptyenv())
 .cmdstanr$PATH <- NULL
-.cmdstanr$INSTALL_FOLDER <- NULL
 .cmdstanr$VERSION <- NULL
 .cmdstanr$TEMP_DIR <- NULL
 
@@ -110,14 +109,10 @@ stop_no_path <- function() {
 #' @return The installation path.
 #' @export
 cmdstan_default_install_path <- function(old = FALSE) {
-  if (!is.null(.cmdstanr$INSTALL_FOLDER)) {
-    .cmdstanr$INSTALL_FOLDER
+  if (old) {
+    file.path(Sys.getenv("HOME"), ".cmdstanr")
   } else {
-    if (old) {
-      file.path(Sys.getenv("HOME"), ".cmdstanr")
-    } else {
-      file.path(Sys.getenv("HOME"), ".cmdstan")
-    }
+    file.path(Sys.getenv("HOME"), ".cmdstan")
   }
 }
 
@@ -129,11 +124,16 @@ cmdstan_default_install_path <- function(old = FALSE) {
 #' @export
 #' @keywords internal
 #' @param old See [cmdstan_default_install_path()].
+#' @param dir Path to a custom install folder with CmdStan installations.
 #' @return Path to the CmdStan installation with the most recent release
 #'   version, or `NULL` if no installation found.
 #'
-cmdstan_default_path <- function(old = FALSE) {
-  installs_path <- cmdstan_default_install_path(old)
+cmdstan_default_path <- function(old = FALSE, dir = NULL) {
+  if (!is.null(dir)) {
+    installs_path <- dir
+  } else {
+    installs_path <- cmdstan_default_install_path(old)
+  }
   if (dir.exists(installs_path)) {
     cmdstan_installs <- list.dirs(path = installs_path, recursive = FALSE, full.names = FALSE)
     # if installed in cmdstan folder with no version move to cmdstan-version folder

--- a/R/path.R
+++ b/R/path.R
@@ -21,7 +21,11 @@
 #'
 #' * If the [environment variable][Sys.setenv()] `"CMDSTAN"` exists at load time
 #' then its value will be automatically set as the default path to CmdStan for
-#' the \R session.
+#' the \R session. If the environment variable `"CMDSTAN"` is set, but a valid
+#' CmdStan is not found in the supplied path, the path is treated as a top
+#' folder that contains CmdStan installations. In that case, the CmdStan
+#' installation with the largest version number will be set as the path to
+#' CmdStan for the \R session.
 #' * If no environment variable is found when loaded but any directory in the
 #' form `".cmdstan/cmdstan-[version]"` (e.g., `".cmdstan/cmdstan-2.23.0"`),
 #' exists in the user's home directory (`Sys.getenv("HOME")`, *not* the current
@@ -81,6 +85,7 @@ cmdstan_version <- function(error_on_NA = TRUE) {
 # number, and path to temp dir
 .cmdstanr <- new.env(parent = emptyenv())
 .cmdstanr$PATH <- NULL
+.cmdstanr$INSTALL_FOLDER <- NULL
 .cmdstanr$VERSION <- NULL
 .cmdstanr$TEMP_DIR <- NULL
 
@@ -105,10 +110,14 @@ stop_no_path <- function() {
 #' @return The installation path.
 #' @export
 cmdstan_default_install_path <- function(old = FALSE) {
-  if (old) {
-    file.path(Sys.getenv("HOME"), ".cmdstanr")
+  if (!is.null(.cmdstanr$INSTALL_FOLDER)) {
+    .cmdstanr$INSTALL_FOLDER
   } else {
-    file.path(Sys.getenv("HOME"), ".cmdstan")
+    if (old) {
+      file.path(Sys.getenv("HOME"), ".cmdstanr")
+    } else {
+      file.path(Sys.getenv("HOME"), ".cmdstan")
+    }
   }
 }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -34,10 +34,19 @@ cmdstanr_initialize <- function() {
   if (isTRUE(nzchar(path))) { # CMDSTAN environment variable found
     if (dir.exists(path)) {
       path <- absolute_path(path)
-      suppressMessages(set_cmdstan_path(path))
+      suppressWarnings(suppressMessages(set_cmdstan_path(path)))
       if (is.null(cmdstan_version(error_on_NA = FALSE))) {
-        .cmdstanr$INSTALL_FOLDER <- path
-        set_cmdstan_path()
+        path <- cmdstan_default_path(dir = path)
+        if (is.null(path)) {
+          warning(
+            "No CmdStan installation found in the path specified ",
+            "by the environment variable 'CMDSTAN'.",
+            call. = FALSE
+          )
+          .cmdstanr$PATH <- NULL
+        } else {
+          set_cmdstan_path(path)
+        }
       }
     } else {
       warning(

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -35,6 +35,10 @@ cmdstanr_initialize <- function() {
     if (dir.exists(path)) {
       path <- absolute_path(path)
       suppressMessages(set_cmdstan_path(path))
+      if (is.null(cmdstan_version(error_on_NA = FALSE))) {
+        .cmdstanr$INSTALL_FOLDER <- path
+        set_cmdstan_path()
+      }
     } else {
       warning(
         "Can't find directory specified by environment variable 'CMDSTAN'. ",

--- a/man/cmdstan_default_path.Rd
+++ b/man/cmdstan_default_path.Rd
@@ -4,10 +4,12 @@
 \alias{cmdstan_default_path}
 \title{cmdstan_default_path}
 \usage{
-cmdstan_default_path(old = FALSE)
+cmdstan_default_path(old = FALSE, dir = NULL)
 }
 \arguments{
 \item{old}{See \code{\link[=cmdstan_default_install_path]{cmdstan_default_install_path()}}.}
+
+\item{dir}{Path to a custom install folder with CmdStan installations.}
 }
 \value{
 Path to the CmdStan installation with the most recent release

--- a/man/cmdstan_model.Rd
+++ b/man/cmdstan_model.Rd
@@ -31,7 +31,7 @@ more. See \code{\link[=model-method-compile]{$compile()}} for details.}
 A \code{\link{CmdStanModel}} object.
 }
 \description{
-\if{html}{\figure{logo.png}{options: width="25"}}
+\if{html}{\figure{logo.png}{options: width="25px"}}
 Create a new \code{\link{CmdStanModel}} object from a file containing a Stan program
 or from an existing Stan executable. The \code{\link{CmdStanModel}} object stores the
 path to a Stan program and compiled executable (once created), and provides

--- a/man/set_cmdstan_path.Rd
+++ b/man/set_cmdstan_path.Rd
@@ -42,7 +42,11 @@ this to avoid having to manually set the path every session:
 \itemize{
 \item If the \link[=Sys.setenv]{environment variable} \code{"CMDSTAN"} exists at load time
 then its value will be automatically set as the default path to CmdStan for
-the \R session.
+the \R session. If the environment variable \code{"CMDSTAN"} is set, but a valid
+CmdStan is not found in the supplied path, the path is treated as a top
+folder that contains CmdStan installations. In that case, the CmdStan
+installation with the largest version number will be set as the path to
+CmdStan for the \R session.
 \item If no environment variable is found when loaded but any directory in the
 form \code{".cmdstan/cmdstan-[version]"} (e.g., \code{".cmdstan/cmdstan-2.23.0"}),
 exists in the user's home directory (\code{Sys.getenv("HOME")}, \emph{not} the current


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #638 

Expands the use of the `CMDSTAN` environment variable so that if a valid CmdStan installation is not found in the `CMDSTAN` path, it is used as the top level installation folder (cmdstan installations are a level below).

To test run:

```r
Sys.setenv("CMDSTAN" = "/top/level/folder/of/cmdstan/installs")

library(cmdstanr)
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
