### PR TITLE
in cmdstan_default_path() ignore other directories in .cmdstan

### DIFF
--- a/R/path.R
+++ b/R/path.R
@@ -145,6 +145,7 @@ cmdstan_default_path <- function(old = FALSE, dir = NULL) {
       cmdstan_installs <- list.dirs(path = installs_path, recursive = FALSE, full.names = FALSE)
     }
     if (length(cmdstan_installs) > 0) {
+      cmdstan_installs <- grep("^cmdstan-", cmdstan_installs, value = TRUE)
       latest_cmdstan <- sort(cmdstan_installs, decreasing = TRUE)[1]
       if (is_release_candidate(latest_cmdstan)) {
         non_rc_path <- strsplit(latest_cmdstan, "-rc")[[1]][1]


### PR DESCRIPTION
fixes #650

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

In `cmdstan_default_path()` ignore directories inside `.cmdstan` that don't start with `"cmdstan-"`.  

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
**Columbia University**

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
