### PR TITLE
Fix ebfmi calculation to handle NaN

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -308,9 +308,17 @@ ebfmi <- function(post_warmup_sampler_diagnostics) {
 
 check_ebfmi <- function(post_warmup_sampler_diagnostics, threshold = 0.2) {
   efbmi_per_chain <- ebfmi(post_warmup_sampler_diagnostics)
-  if (any(efbmi_per_chain < threshold)) {
+  nan_efbmi_count <- sum(is.nan(efbmi_per_chain))
+  efbmi_below_threshold <- sum(efbmi_per_chain < threshold)
+  if (nan_efbmi_count > 0) {
     message(
-      "Warning: ", sum(efbmi_per_chain < threshold), " of ", length(efbmi_per_chain),
+      "Warning: ", nan_efbmi_count, " of ", length(efbmi_per_chain),
+      " chains have a NaN E-BFMI.\n",
+      "See https://mc-stan.org/misc/warnings for details.\n"
+    )
+  } else if (efbmi_below_threshold > 0) {
+    message(
+      "Warning: ", efbmi_below_threshold, " of ", length(efbmi_per_chain),
       " chains had an E-BFMI less than ", threshold, ".\n",
       "See https://mc-stan.org/misc/warnings for details.\n"
     )


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

If the calculate ebfmi was NaN, the post-processing failed. This should fix that and thus should fix #657 and fix #652 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
