### PR TITLE
Fix finding grep.exe path on Windows

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -237,7 +237,7 @@ read_cmdstan_csv <- function(files,
       fread_cmd <- paste0(
         grep_path_quotes,
         " '^[#a-zA-Z]' --color=never '",
-        csv_file,
+        output_file,
         "'"
       )
     } else {

--- a/R/csv.R
+++ b/R/csv.R
@@ -236,7 +236,7 @@ read_cmdstan_csv <- function(files,
       grep_path_quotes <- paste0('"', grep_path_repaired, '"')
       fread_cmd <- paste0(
         grep_path_quotes,
-        " '^[#a-zA-Z]' --color=never '",
+        " -v '^#' --color=never '",
         output_file,
         "'"
       )

--- a/R/csv.R
+++ b/R/csv.R
@@ -227,8 +227,19 @@ read_cmdstan_csv <- function(files,
   num_post_warmup_draws <- ceiling(metadata$iter_sampling / metadata$thin)
   for (output_file in files) {
     if (os_is_windows()) {
-      grep_path <- paste0('"', repair_path(Sys.which("grep.exe")), '"')
-      fread_cmd <- paste0(grep_path, " -v '^#' --color=never '", output_file, "'")
+      grep_path_repaired <- withr::with_path(
+        c(
+          toolchain_PATH_env_var()
+        ),
+        repair_path(Sys.which("grep.exe"))
+      )
+      grep_path_quotes <- paste0('"', grep_path_repaired, '"')
+      fread_cmd <- paste0(
+        grep_path_quotes,
+        " '^[#a-zA-Z]' --color=never '",
+        csv_file,
+        "'"
+      )
     } else {
       fread_cmd <- paste0("grep -v '^#' --color=never '", output_file, "'")
     }
@@ -558,8 +569,19 @@ read_csv_metadata <- function(csv_file) {
   sampling_time <- 0
   total_time <- 0
   if (os_is_windows()) {
-    grep_path <- paste0('"', repair_path(Sys.which("grep.exe")), '"')
-    fread_cmd <- paste0(grep_path, " '^[#a-zA-Z]' --color=never '", csv_file, "'")
+    grep_path_repaired <- withr::with_path(
+      c(
+        toolchain_PATH_env_var()
+      ),
+      repair_path(Sys.which("grep.exe"))
+    )
+    grep_path_quotes <- paste0('"', grep_path_repaired, '"')
+    fread_cmd <- paste0(
+      grep_path_quotes,
+      " '^[#a-zA-Z]' --color=never '",
+      csv_file,
+      "'"
+    )
   } else {
     fread_cmd <- paste0("grep '^[#a-zA-Z]' --color=never '", csv_file, "'")
   }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

In the edge case where the users do not have `grep.exe` in their system path, we need to wrap the `Sys.which()` call in the with_path call just like we do the rest of the system calls.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
