### PR TITLE
Wes/grepquotes

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmdstanr
 Title: R Interface to 'CmdStan'
-Version: 0.5.2
+Version: 0.5.2.1
 Date: 2022-04-24
 Authors@R: 
     c(person(given = "Jonah", family = "Gabry", role = c("aut", "cre"),

--- a/R/csv.R
+++ b/R/csv.R
@@ -236,9 +236,9 @@ read_cmdstan_csv <- function(files,
       grep_path_quotes <- paste0('"', grep_path_repaired, '"')
       fread_cmd <- paste0(
         grep_path_quotes,
-        " -v '^#' --color=never '",
+        " -v \"^#\" --color=never \"",
         output_file,
-        "'"
+        "\""
       )
     } else {
       fread_cmd <- paste0("grep -v '^#' --color=never '", output_file, "'")
@@ -578,9 +578,9 @@ read_csv_metadata <- function(csv_file) {
     grep_path_quotes <- paste0('"', grep_path_repaired, '"')
     fread_cmd <- paste0(
       grep_path_quotes,
-      " '^[#a-zA-Z]' --color=never '",
+      " \"^[#a-zA-Z]\" --color=never \"",
       csv_file,
-      "'"
+      "\""
     )
   } else {
     fread_cmd <- paste0("grep '^[#a-zA-Z]' --color=never '", csv_file, "'")


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

(Unable to run unit tests fully locally - but the fix in this PR is very minor and all within strings)

#### Summary

Using grep on windows, the filename and match string need to be provided (as I see it) with double-quotes, not single-quotes. Without that, I am seeing grep failures pulling out the metadata. See comments on https://github.com/stan-dev/cmdstanr/pull/660 which is also working in that section of code, where Sys.which() is used to determine where grep.exe is.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Imperial College London


By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
