### PR TITLE
Fix use of tilde with cmdstanr_write_stan_file_dir

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,18 @@
+# cmdstanr 0.4.0.9000
+
+### Bug fixes
+
+* In `cmdstan_default_path()` we now ignore directories inside `.cmdstan` that don't start 
+with `"cmdstan-"`. (#651)
+
+* Fixed Windows issue related to not locating `grep.exe` or when it is located in a path
+with spaces. (@weshinsley, #661, #663)
+
+* Fixed a bug with diagnostic checks when ebfmi is NaN.
+
+* Fixed a bug that caused issues when using `~` or `.` in paths supplied to the 
+`cmdstanr_write_stan_file_dir` global option.
+
 # cmdstanr 0.5.2
 
 * Refactored toolchain installation and checks for R 4.x on Windows and added support

--- a/R/example.R
+++ b/R/example.R
@@ -148,6 +148,7 @@ write_stan_file <- function(code,
                             basename = NULL,
                             force_overwrite = FALSE,
                             hash_salt = "") {
+  dir <- absolute_path(dir)
   if (!dir.exists(dir)) {
     dir.create(dir, recursive = TRUE)
   }

--- a/tests/testthat/test-example.R
+++ b/tests/testthat/test-example.R
@@ -48,13 +48,14 @@ test_that("write_stan_file writes Stan file correctly", {
 
 test_that("write_stan_file writes to specified directory and filename", {
   dir <- file.path(test_path(), "answers")
-  expect_equal(dirname(f1 <- write_stan_file(stan_program, dir = dir, basename = "pasta")), dir)
+  expect_equal(dirname(f1 <- write_stan_file(stan_program, dir = dir, basename = "pasta")),
+               absolute_path(dir))
   expect_equal(f2 <- write_stan_file(stan_program, dir = dir, basename = "fruit.stan"),
-               file.path(dir, "fruit.stan"))
+               absolute_path(file.path(dir, "fruit.stan")))
   expect_equal(f3 <- write_stan_file(stan_program, dir = dir, basename = "vegetable"),
-               file.path(dir, "vegetable.stan")) # should add .stan extension if missing
+               absolute_path(file.path(dir, "vegetable.stan"))) # should add .stan extension if missing
   expect_equal(f4 <- write_stan_file(stan_program, dir = tempdir(), basename = "test"),
-               file.path(tempdir(), "test.stan"))
+               absolute_path(file.path(tempdir(), "test.stan")))
 
   try(file.remove(f1, f2, f3, f4), silent = TRUE)
 })

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -590,7 +590,8 @@ test_that("cmdstan_model works with user_header", {
 
   namespace bernoulli_external_model_namespace
   {
-      template <typename T0__, stan::require_stan_scalar_t<T0__>* = nullptr>
+      template <typename T0__,
+            stan::require_all_t<stan::is_stan_scalar<T0__>>* = nullptr>
       inline typename boost::math::tools::promote_args<T0__>::type make_odds(const T0__ &
                                                                                  theta,
                                                                              std::ostream *pstream__)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

See https://discourse.mc-stan.org/t/problem-using-cmdstanr-write-stan-file-dir-with-brms/28117 for reasons
Essentially using  ~ with the cmdstanr_write_stan_file_dir option did not work. This fixes that.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
