### PR TITLE
Windows fix: Normalize paths before comparing them

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -685,7 +685,7 @@ is_toolchain_installed <- function(app, path) {
         ),
         repair_path(dirname(Sys.which(app)))
       )
-      if (app_path != rtools4x_toolchain_path()) {
+      if (normalizePath(app_path) != normalizePath(rtools4x_toolchain_path())) {
         return(FALSE)
       }
       return(TRUE)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes the toolchain check by normalizing paths before comparing them, avoiding comparing long and short paths, which leads to false positives.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting 
(this will be you or your assignee, such as a university or company): 
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to 
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)    
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
