### PR TITLE
`mod$variables` works w includes in precompile state (fix #680)

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -265,7 +265,11 @@ CmdStanModel <- R6::R6Class(
       invisible(self)
     },
     include_paths = function() {
-      private$include_paths_
+      if (length(self$exe_file()) > 0 && file.exists(self$exe_file())) {
+        return(private$include_paths_)
+      } else {
+        return(private$precompile_include_paths_)
+      }
     },
     code = function() {
       if (length(private$stan_code_) == 0) {
@@ -655,13 +659,7 @@ variables <- function() {
   if (is.null(private$variables_) && file.exists(self$stan_file())) {
     private$variables_ <- model_variables(
       stan_file = self$stan_file(),
-      include_paths = {
-        if (length(self$exe_file()) > 0 && file.exists(self$exe_file())) {
-          self$include_paths()
-        } else {
-          private$precompile_include_paths_
-        }
-      },
+      include_paths = self$include_paths(),
       allow_undefined = private$using_user_header_
     )
   }

--- a/R/model.R
+++ b/R/model.R
@@ -653,7 +653,17 @@ variables <- function() {
   }
   assert_stan_file_exists(self$stan_file())
   if (is.null(private$variables_) && file.exists(self$stan_file())) {
-    private$variables_ <- model_variables(self$stan_file(), self$include_paths(), allow_undefined = private$using_user_header_)
+    private$variables_ <- model_variables(
+      stan_file = self$stan_file(),
+      include_paths = {
+        if (length(self$exe_file()) > 0 && file.exists(self$exe_file())) {
+          self$include_paths()
+        } else {
+          private$precompile_include_paths_
+        }
+      },
+      allow_undefined = private$using_user_header_
+    )
   }
   private$variables_
 }


### PR DESCRIPTION
Naive attempt to tackle #680.

## Description

**Approach**
Adapt the `CmdStanModel$variables()` query method in such a way that it returns either `private$include_paths_` or `private$precompile_include_paths_`. 


**Alternative that was considered:**
During call to `model_variables()`, make the value passed to the  `include_paths` argument dependent on the state of the model. I.e., if no executable is present, insert `private$precompile_include_paths_`, and otherwise `self$include_paths()`.


Concerns: it seems somewhat not optimal to query the state of the model (compiled / not compiled) via the existence of the executable, but I saw this approach also elsewhere in the code.

***

#### Submission Checklist

- [X] Run unit tests
- [X] Add unit tests for added / fixed behavior.
- [X] Declare copyright holder and agree to license (see below)

#### Summary

Please describe the purpose of the pull request.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**INSERT COPYRIGHT HOLDER HERE**

Malte Kyhos

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
