### PR TITLE
Add newline to check syntax output

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -774,21 +774,19 @@ check_syntax <- function(pedantic = FALSE,
       echo = is_verbose_mode(),
       echo_cmd = is_verbose_mode(),
       spinner = quiet && interactive(),
-      stdout_line_callback = function(x, p) {
-        if (!quiet) cat(x)
-      },
       stderr_callback = function(x, p) {
         message(x)
       },
       error_on_status = FALSE
     )
   )
+  cat(run_log$stdout)
   if (is.na(run_log$status) || run_log$status != 0) {
     stop("Syntax error found! See the message above for more information.",
          call. = FALSE)
   }
   if (!quiet) {
-    message("Stan program is syntactically correct");
+    message("Stan program is syntactically correct")
   }
   invisible(TRUE)
 }


### PR DESCRIPTION

#### Summary

Running the following script:
```
library(cmdstanr)

file <- system.file("logistic.stan", package = "cmdstanr")

model <- cmdstan_model(stan_file=file, compile=FALSE)
model$check_syntax(stanc_options = list("debug-mem-patterns"))
```

produced the following output:

```
vector[K] beta: AoSStan program is syntactically correct
```
which is missing a newline. This PR fixes this issue. This was reported by @avehtari.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Rok Češnovar

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
