### PR TITLE
Make constrain_pars behaviour consistent with rstan

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -459,17 +459,14 @@ unconstrain_pars <- function(pars) {
   model_par_names <- names(self$runset$args$model_variables$parameters)
   prov_par_names <- names(pars)
 
-  prov_pars_not_in_model <- which(!(prov_par_names %in% model_par_names))
-  if (length(prov_pars_not_in_model) > 0) {
-    stop("Provided parameter(s): ", paste(prov_par_names[prov_pars_not_in_model], collapse = ","),
-         " not present in model!", call. = FALSE)
-  }
-
   model_pars_not_prov <- which(!(model_par_names %in% prov_par_names))
   if (length(model_pars_not_prov) > 0) {
     stop("Model parameter(s): ", paste(model_par_names[model_pars_not_prov], collapse = ","),
          " not provided!", call. = FALSE)
   }
+
+  # Ignore extraneous parameters
+  model_pars_only <- pars[model_par_names]
 
   stan_pars <- process_init_list(list(pars), num_procs = 1, self$runset$args$model_variables)
   private$model_methods_env_$unconstrain_pars(private$model_methods_env_$model_ptr_, stan_pars)
@@ -484,6 +481,10 @@ CmdStanFit$set("public", name = "unconstrain_pars", value = unconstrain_pars)
 #' the constrained scale
 #'
 #' @param upars (numeric) A vector of unconstrained parameters to constrain
+#' @param transformed_parameters (boolean) Whether to return transformed parameters
+#'  implied by newly-constrained parameters (defaults to TRUE)
+#' @param generated_quantities (boolean) Whether to return generated quantities
+#'  implied by newly-constrained parameters (defaults to TRUE)
 #'
 #' @examples
 #' \dontrun{
@@ -491,7 +492,7 @@ CmdStanFit$set("public", name = "unconstrain_pars", value = unconstrain_pars)
 #' fit_mcmc$constrain_pars(upars = c(0.5, 1.2, 1.1, 2.2, 1.1))
 #' }
 #'
-constrain_pars <- function(upars) {
+constrain_pars <- function(upars, transformed_parameters = TRUE, generated_quantities = TRUE) {
   if (is.null(private$model_methods_env_$model_ptr)) {
     stop("The method has not been compiled, please call `init_model_methods()` first",
         call. = FALSE)
@@ -500,8 +501,15 @@ constrain_pars <- function(upars) {
     stop("Model has ", private$model_methods_env_$num_upars_, " unconstrained parameter(s), but ",
           length(upars), " were provided!", call. = FALSE)
   }
-  cpars <- private$model_methods_env_$constrain_pars(private$model_methods_env_$model_ptr_, private$model_methods_env_$model_rng_, upars)
-  skeleton <- create_skeleton(self$runset$args$model_variables)
+  cpars <- private$model_methods_env_$constrain_pars(
+    private$model_methods_env_$model_ptr_,
+    private$model_methods_env_$model_rng_,
+    upars, transformed_parameters, generated_quantities)
+
+  skeleton <- create_skeleton(private$model_methods_env_$param_metadata_,
+                              self$runset$args$model_variables,
+                              transformed_parameters,
+                              generated_quantities)
   utils::relist(cpars, skeleton)
 }
 CmdStanFit$set("public", name = "constrain_pars", value = constrain_pars)

--- a/R/fit.R
+++ b/R/fit.R
@@ -332,8 +332,7 @@ init_model_methods <- function(seed = 0, verbose = FALSE, hessian = FALSE) {
   if (hessian) {
     message("The hessian method relies on higher-order autodiff ",
             "which is still experimental. Please report any compilation ",
-            "errors that you encounter",
-            call. = FALSE)
+            "errors that you encounter")
   }
   message("Compiling additional model methods...")
   if (is.null(private$model_methods_env_$model_ptr)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -602,17 +602,24 @@ initialize_model_pointer <- function(env, data, seed = 0) {
   env$model_ptr_ <- ptr_and_rng$model_ptr
   env$model_rng_ <- ptr_and_rng$base_rng
   env$num_upars_ <- env$get_num_upars(env$model_ptr_)
+  env$param_metadata_ <- env$get_param_metadata(env$model_ptr_)
   invisible(NULL)
 }
 
-create_skeleton <- function(model_variables) {
-  model_pars <- model_variables$parameters
-  skeleton <- lapply(model_pars, function(par) {
-    dims <- par$dimensions
-    dims <- ifelse(dims == 0, 1, dims)
-    array(0, dim = dims)
+create_skeleton <- function(param_metadata, model_variables,
+                            transformed_parameters, generated_quantities) {
+  target_params <- names(model_variables$parameters)
+  if (transformed_parameters) {
+    target_params <- c(target_params,
+                       names(model_variables$transformed_parameters))
+  }
+  if (generated_quantities) {
+    target_params <- c(target_params,
+                       names(model_variables$generated_quantities))
+  }
+  lapply(param_metadata[target_params], function(par_dims) {
+    array(0, dim = ifelse(length(par_dims) == 0, 1, par_dims))
   })
-  stats::setNames(skeleton, names(model_pars))
 }
 
 get_standalone_hpp <- function(stan_file, stancflags) {

--- a/inst/include/model_methods.cpp
+++ b/inst/include/model_methods.cpp
@@ -70,6 +70,24 @@ size_t get_num_upars(SEXP ext_model_ptr) {
 }
 
 // [[Rcpp::export]]
+Rcpp::List get_param_metadata(SEXP ext_model_ptr) {
+  Rcpp::XPtr<stan::model::model_base> ptr(ext_model_ptr);
+  std::vector<std::string> param_names;
+  std::vector<std::vector<size_t> > param_dims;
+  ptr->get_param_names(param_names);
+  ptr->get_dims(param_dims);
+
+  Rcpp::List param_metadata = Rcpp::List::create(
+    Rcpp::Named(param_names[0]) = param_dims[0]
+  );
+  for (size_t i = 1; i < param_names.size(); i++) {
+    param_metadata.push_back(param_dims[i], param_names[i]);
+  }
+
+  return param_metadata;
+}
+
+// [[Rcpp::export]]
 std::vector<double> unconstrain_pars(SEXP ext_model_ptr, std::string init_path) {
   Rcpp::XPtr<stan::model::model_base> ptr(ext_model_ptr);
   std::vector<int> params_i;
@@ -79,12 +97,15 @@ std::vector<double> unconstrain_pars(SEXP ext_model_ptr, std::string init_path) 
 }
 
 // [[Rcpp::export]]
-std::vector<double> constrain_pars(SEXP ext_model_ptr, SEXP base_rng, std::vector<double> upars) {
+std::vector<double> constrain_pars(SEXP ext_model_ptr, SEXP base_rng,
+                                    std::vector<double> upars,
+                                    bool return_trans_pars,
+                                    bool return_gen_quants) {
   Rcpp::XPtr<stan::model::model_base> ptr(ext_model_ptr);
   Rcpp::XPtr<boost::ecuyer1988> rng(base_rng);
   std::vector<int> params_i;
   std::vector<double> vars;
 
-  ptr->write_array(*rng.get(), upars, params_i, vars, false, false);
+  ptr->write_array(*rng.get(), upars, params_i, vars, return_trans_pars, return_gen_quants);
   return vars;
 }

--- a/man/fit-method-constrain_pars.Rd
+++ b/man/fit-method-constrain_pars.Rd
@@ -5,10 +5,20 @@
 \alias{constrain_pars}
 \title{Transform a set of unconstrained parameter values to the constrained scale}
 \usage{
-constrain_pars(upars)
+constrain_pars(
+  upars,
+  transformed_parameters = TRUE,
+  generated_quantities = TRUE
+)
 }
 \arguments{
 \item{upars}{(numeric) A vector of unconstrained parameters to constrain}
+
+\item{transformed_parameters}{(boolean) Whether to return transformed parameters
+implied by newly-constrained parameters (defaults to TRUE)}
+
+\item{generated_quantities}{(boolean) Whether to return generated quantities
+implied by newly-constrained parameters (defaults to TRUE)}
 }
 \description{
 The \verb{$constrain_pars()} method transforms input parameters to


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The `constrain_pars` method in RStan also returns the transformed parameters and generated quantities implied by the provided unconstrained parameters. This PR adds two boolean arguments to the `cmdstanr` `constrain_pars` for whether to return the transformed parameters and/or generated quantities (defaulting to `TRUE` for consistency with `rstan`):

``` r
fit$constrain_pars(c(0.1))
#> $theta
#> [1] 0.5249792
#> 
#> $log_lik
#>  [1] -7.243967 -7.243967 -7.243967 -7.243967 -7.243967 -7.243967 -7.243967
#>  [8] -7.243967 -7.243967 -7.243967

fit$constrain_pars(c(0.1), generated_quantities = FALSE)
#> $theta
#> [1] 0.5249792
```

<sup>Created on 2022-10-16 with [reprex v2.0.2](https://reprex.tidyverse.org)</sup>

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
