### PR TITLE
Allow exposing functions without sampling

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -64,6 +64,10 @@ CmdStanFit <- R6::R6Class(
             "rows (change via 'max_rows' argument or 'cmdstanr_max_rows' option)\n")
       }
       invisible(self)
+    },
+    expose_functions = function(global = FALSE, verbose = FALSE) {
+      expose_functions(self$functions, global, verbose)
+      invisible(NULL)
     }
   ),
   private = list(
@@ -279,30 +283,6 @@ init <- function() {
   private$init_
 }
 CmdStanFit$set("public", name = "init", value = init)
-
-expose_functions <- function(global = FALSE, verbose = FALSE) {
-  require_suggested_package("Rcpp")
-  require_suggested_package("RcppEigen")
-  require_suggested_package("decor")
-  if (self$functions$compiled) {
-    if (!global) {
-      message("Functions already compiled, nothing to do!")
-    } else {
-      message("Functions already compiled, copying to global environment")
-      # Create reference to global environment, avoids NOTE about assigning to global
-      pos <- 1
-      envir = as.environment(pos)
-      lapply(self$functions$fun_names, function(fun_name) {
-        assign(fun_name, get(fun_name, self$functions), envir)
-      })
-    }
-  } else {
-    message("Compiling standalone functions...")
-    expose_functions(self$functions, verbose, global)
-  }
-  invisible(NULL)
-}
-CmdStanFit$set("public", name = "expose_functions", value = expose_functions)
 
 #' Compile additional methods for accessing the model log-probability function
 #' and parameter constraining and unconstraining. This requires the `Rcpp` package.

--- a/R/utils.R
+++ b/R/utils.R
@@ -675,7 +675,7 @@ prep_fun_cpp <- function(fun_body, model_lines) {
   gsub(pattern = ",\\s*)", replacement = ")", fun_body)
 }
 
-expose_functions <- function(env, verbose = FALSE, global = FALSE) {
+compile_functions <- function(env, verbose = FALSE, global = FALSE) {
   funs <- grep("// [[stan::function]]", env$hpp_code, fixed = TRUE)
   funs <- c(funs, length(env$hpp_code))
 
@@ -700,5 +700,28 @@ expose_functions <- function(env, verbose = FALSE, global = FALSE) {
     rcpp_source_stan(mod_stan_funs, env, verbose)
   }
   env$compiled <- TRUE
+  invisible(NULL)
+}
+
+expose_functions <- function(function_env, global = FALSE, verbose = FALSE) {
+  require_suggested_package("Rcpp")
+  require_suggested_package("RcppEigen")
+  require_suggested_package("decor")
+  if (function_env$compiled) {
+    if (!global) {
+      message("Functions already compiled, nothing to do!")
+    } else {
+      message("Functions already compiled, copying to global environment")
+      # Create reference to global environment, avoids NOTE about assigning to global
+      pos <- 1
+      envir = as.environment(pos)
+      lapply(function_env$fun_names, function(fun_name) {
+        assign(fun_name, get(fun_name, function_env), envir)
+      })
+    }
+  } else {
+    message("Compiling standalone functions...")
+    compile_functions(function_env, verbose, global)
+  }
   invisible(NULL)
 }

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -12,6 +12,23 @@ data_list <- testing_data("bernoulli")
 mod <- cmdstan_model(model, force_recompile = TRUE)
 fit <- mod$sample(data = data_list)
 
+
+test_that("Functions can be exposed in model object", {
+  mod$expose_functions(verbose = TRUE)
+
+  expect_equal(
+    fit$functions$retvec(c(1,2,3,4)),
+    c(1,2,3,4)
+  )
+
+  mod$expose_functions(global = TRUE, verbose = TRUE)
+
+  expect_equal(
+    retvec(c(1,2,3,4)),
+    c(1,2,3,4)
+  )
+})
+
 test_that("Functions can be exposed in fit object", {
   fit$expose_functions(verbose = TRUE)
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This PR adds the `expose_functions()` method to the `CmdStanModel` class so that functions can be exposed to R without fitting any models first

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
