### PR TITLE
Bugfix - Deep copy method/function environments

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -13,8 +13,14 @@ CmdStanFit <- R6::R6Class(
     initialize = function(runset) {
       checkmate::assert_r6(runset, classes = "CmdStanRun")
       self$runset <- runset
-      private$model_methods_env_ <- runset$model_methods_env()
-      self$functions <- runset$standalone_env()
+      private$model_methods_env_ <- new.env()
+      for (n in ls(runset$model_methods_env(), all.names = TRUE)) {
+        assign(n, get(n, runset$model_methods_env()), private$model_methods_env_)
+      }
+      self$functions <- new.env()
+      for (n in ls(runset$standalone_env(), all.names = TRUE)) {
+        assign(n, get(n, runset$standalone_env()), self$functions)
+      }
 
       if (!is.null(private$model_methods_env_$model_ptr)) {
         initialize_model_pointer(private$model_methods_env_, self$data_file(), 0)

--- a/R/fit.R
+++ b/R/fit.R
@@ -13,13 +13,19 @@ CmdStanFit <- R6::R6Class(
     initialize = function(runset) {
       checkmate::assert_r6(runset, classes = "CmdStanRun")
       self$runset <- runset
+
       private$model_methods_env_ <- new.env()
-      for (n in ls(runset$model_methods_env(), all.names = TRUE)) {
-        assign(n, get(n, runset$model_methods_env()), private$model_methods_env_)
+      if (!is.null(runset$model_methods_env())) {
+        for (n in ls(runset$model_methods_env(), all.names = TRUE)) {
+          assign(n, get(n, runset$model_methods_env()), private$model_methods_env_)
+        }
       }
+
       self$functions <- new.env()
-      for (n in ls(runset$standalone_env(), all.names = TRUE)) {
-        assign(n, get(n, runset$standalone_env()), self$functions)
+      if (!is.null(runset$standalone_env())) {
+        for (n in ls(runset$standalone_env(), all.names = TRUE)) {
+          assign(n, get(n, runset$standalone_env()), self$functions)
+        }
       }
 
       if (!is.null(private$model_methods_env_$model_ptr)) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -870,10 +870,8 @@ expose_functions <- function(function_env, global = FALSE, verbose = FALSE) {
     } else {
       message("Functions already compiled, copying to global environment")
       # Create reference to global environment, avoids NOTE about assigning to global
-      pos <- 1
-      envir = as.environment(pos)
       lapply(function_env$fun_names, function(fun_name) {
-        assign(fun_name, get(fun_name, function_env), envir)
+        assign(fun_name, get(fun_name, function_env), as.environment(1))
       })
     }
   } else {

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -18,7 +18,7 @@ test_that("Functions can be exposed in model object", {
   mod$expose_functions(verbose = TRUE)
 
   expect_equal(
-    fit$functions$retvec(c(1,2,3,4)),
+    mod$functions$retvec(c(1,2,3,4)),
     c(1,2,3,4)
   )
 

--- a/tests/testthat/test-model-methods.R
+++ b/tests/testthat/test-model-methods.R
@@ -81,6 +81,16 @@ test_that("Methods return correct values", {
   expect_equal(upars, c(0.1))
 })
 
+test_that("Model methods environments are independent", {
+  data_list_2 <- data_list
+  data_list_2$N <- 20
+  data_list_2$y <- c(data_list$y, data_list$y)
+  fit_2 <- mod$sample(data = data_list_2, chains = 1)
+  fit_2$init_model_methods()
+
+  expect_equal(fit$log_prob(upars=c(0.1)), -8.6327599208828509347)
+  expect_equal(fit_2$log_prob(upars=c(0.1)), -15.87672652161856135)
+})
 
 test_that("methods error for incorrect inputs", {
   skip_if(os_is_wsl())


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

There was a bug with the model methods and exposed functions wherein running `init_model_methods()` on a `CmdStanFit` object would overwrite the model methods from all `CmdStanFit` objects that came from the same `CmdStanModel`.

This was because the environment was being passed by reference from the `CmdStanModel` object when initialising each `CmdStanFit`, so every fit object was pointing to the same environment.

This PR updates the initialisation to create a new environment and copy the contents, as well as adding a test to check for this in the future

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
