### PR TITLE
Add option for including jacobian adjustments in hessian method

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -403,6 +403,8 @@ CmdStanFit$set("public", name = "grad_log_prob", value = grad_log_prob)
 #'
 #' @param upars (numeric) A vector of unconstrained parameters to be passed
 #' to `hessian`
+#' @param jacobian_adjustment (bool) Whether to include the log-density adjustments from
+#' un/constraining variables
 #'
 #' @examples
 #' \dontrun{
@@ -410,7 +412,7 @@ CmdStanFit$set("public", name = "grad_log_prob", value = grad_log_prob)
 #' fit_mcmc$hessian(upars = c(0.5, 1.2, 1.1, 2.2, 1.1))
 #' }
 #'
-hessian <- function(upars) {
+hessian <- function(upars, jacobian_adjustment = TRUE) {
   if (is.null(private$model_methods_env_$model_ptr)) {
     stop("The method has not been compiled, please call `init_model_methods()` first",
         call. = FALSE)
@@ -419,7 +421,7 @@ hessian <- function(upars) {
     stop("Model has ", private$model_methods_env_$num_upars_, " unconstrained parameter(s), but ",
           length(upars), " were provided!", call. = FALSE)
   }
-  private$model_methods_env_$hessian(private$model_methods_env_$model_ptr_, upars)
+  private$model_methods_env_$hessian(private$model_methods_env_$model_ptr_, upars, jacobian_adjustment)
 }
 CmdStanFit$set("public", name = "hessian", value = hessian)
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -870,8 +870,10 @@ expose_functions <- function(function_env, global = FALSE, verbose = FALSE) {
     } else {
       message("Functions already compiled, copying to global environment")
       # Create reference to global environment, avoids NOTE about assigning to global
+      pos <- 1
+      envir <- as.environment(pos)
       lapply(function_env$fun_names, function(fun_name) {
-        assign(fun_name, get(fun_name, function_env), as.environment(1))
+        assign(fun_name, get(fun_name, function_env), envir)
       })
     }
   } else {

--- a/inst/include/hessian.cpp
+++ b/inst/include/hessian.cpp
@@ -1,17 +1,28 @@
 #include <RcppEigen.h>
-#include <stan/model/hessian.hpp>
+#include <stan/math/mix/functor/hessian.hpp>
 
 // [[Rcpp::depends(RcppEigen)]]
 
 // [[Rcpp::export]]
-Rcpp::List hessian(SEXP ext_model_ptr, Eigen::VectorXd& upars) {
+Rcpp::List hessian(SEXP ext_model_ptr, Eigen::VectorXd& upars,
+                   bool jac_adjust) {
   Rcpp::XPtr<stan_model> ptr(ext_model_ptr);
+
+  auto log_prob_fun = [](const bool adjust, Rcpp::XPtr<stan_model> model_ptr) {
+    return [=](auto& pars) {
+      if (adjust) {
+        return model_ptr.get()->log_prob<true, true>(pars, &Rcpp::Rcout);
+      } else {
+        return model_ptr.get()->log_prob<true, false>(pars, &Rcpp::Rcout);
+      }
+    };
+  };
 
   double log_prob;
   Eigen::VectorXd grad;
   Eigen::MatrixXd hessian;
 
-  stan::model::hessian(*ptr.get(), upars, log_prob, grad, hessian);
+  stan::math::hessian(log_prob_fun(jac_adjust, ptr), upars, log_prob, grad, hessian);
 
   return Rcpp::List::create(
     Rcpp::Named("log_prob") = log_prob,

--- a/inst/include/hessian.cpp
+++ b/inst/include/hessian.cpp
@@ -1,28 +1,40 @@
 #include <RcppEigen.h>
-#include <stan/math/mix/functor/hessian.hpp>
+#include <stan/model/hessian.hpp>
 
 // [[Rcpp::depends(RcppEigen)]]
 
-// [[Rcpp::export]]
-Rcpp::List hessian(SEXP ext_model_ptr, Eigen::VectorXd& upars,
-                   bool jac_adjust) {
-  Rcpp::XPtr<stan_model> ptr(ext_model_ptr);
+template <class M>
+struct hessian_wrapper {
+  const M& model;
+  bool jac_adjust;
+  std::ostream* o;
 
-  auto log_prob_fun = [](const bool adjust, Rcpp::XPtr<stan_model> model_ptr) {
-    return [=](auto& pars) {
-      if (adjust) {
-        return model_ptr.get()->log_prob<true, true>(pars, &Rcpp::Rcout);
-      } else {
-        return model_ptr.get()->log_prob<true, false>(pars, &Rcpp::Rcout);
-      }
-    };
-  };
+  hessian_wrapper(const M& m, bool adj, std::ostream* out) : model(m), jac_adjust(adj), o(out) {}
+
+  template <typename T>
+  T operator()(const Eigen::Matrix<T, Eigen::Dynamic, 1>& x) const {
+    if (jac_adjust) {
+      // log_prob() requires non-const but doesn't modify its argument
+      return model.template log_prob<true, true, T>(
+          const_cast<Eigen::Matrix<T, -1, 1>&>(x), o);
+    } else {
+      // log_prob() requires non-const but doesn't modify its argument
+      return model.template log_prob<true, false, T>(
+          const_cast<Eigen::Matrix<T, -1, 1>&>(x), o);
+    }
+  }
+};
+
+// [[Rcpp::export]]
+Rcpp::List hessian(SEXP ext_model_ptr, Eigen::VectorXd& upars, bool jac_adjust) {
+  Rcpp::XPtr<stan_model> ptr(ext_model_ptr);
 
   double log_prob;
   Eigen::VectorXd grad;
   Eigen::MatrixXd hessian;
 
-  stan::math::hessian(log_prob_fun(jac_adjust, ptr), upars, log_prob, grad, hessian);
+  stan::math::hessian(hessian_wrapper<decltype(*ptr.get())>(*ptr.get(), jac_adjust, 0),
+                      upars, log_prob, grad, hessian);
 
   return Rcpp::List::create(
     Rcpp::Named("log_prob") = log_prob,

--- a/man/cmdstanr-package.Rd
+++ b/man/cmdstanr-package.Rd
@@ -33,8 +33,8 @@ algorithms, and writing results to output files.
 
 \subsection{Advantages of RStan}{
 \itemize{
-\item Advanced features. We are working on making these available outside
-of RStan but currently they are only available to R users via RStan:
+\item Advanced features. We are working on making these available outside of
+RStan but currently they are only available to R users via RStan:
 \itemize{
 \item \code{rstan::log_prob()}
 \item \code{rstan::grad_log_prob()}
@@ -47,14 +47,13 @@ Stan programs (like \strong{rstanarm}) on CRAN.
 
 \subsection{Advantages of CmdStanR}{
 \itemize{
-\item Compatible with latest versions of Stan. Keeping up with Stan
-releases is complicated for RStan, often requiring non-trivial
-changes to the \strong{rstan} package and new CRAN releases of both
-\strong{rstan} and \strong{StanHeaders}. With CmdStanR the latest improvements
-in Stan will be available from R immediately after updating CmdStan
-using \code{cmdstanr::install_cmdstan()}.
-\item Fewer installation issues (e.g., no need to mess with Makevars
-files).
+\item Compatible with latest versions of Stan. Keeping up with Stan releases
+is complicated for RStan, often requiring non-trivial changes to the
+\strong{rstan} package and new CRAN releases of both \strong{rstan} and
+\strong{StanHeaders}. With CmdStanR the latest improvements in Stan will be
+available from R immediately after updating CmdStan using
+\code{cmdstanr::install_cmdstan()}.
+\item Fewer installation issues (e.g., no need to mess with Makevars files).
 \item Running Stan via external processes results in fewer unexpected
 crashes, especially in RStudio.
 \item Less memory overhead.

--- a/man/fit-method-hessian.Rd
+++ b/man/fit-method-hessian.Rd
@@ -6,11 +6,14 @@
 \title{Calculate the log-probability , the gradient w.r.t. each input, and the hessian
 for a given vector of unconstrained parameters}
 \usage{
-hessian(upars)
+hessian(upars, jacobian_adjustment = TRUE)
 }
 \arguments{
 \item{upars}{(numeric) A vector of unconstrained parameters to be passed
 to \code{hessian}}
+
+\item{jacobian_adjustment}{(bool) Whether to include the log-density adjustments from
+un/constraining variables}
 }
 \description{
 The \verb{$hessian()} method provides access to the

--- a/tests/testthat/test-model-methods.R
+++ b/tests/testthat/test-model-methods.R
@@ -59,6 +59,15 @@ test_that("Methods return correct values", {
   )
   expect_equal(fit$hessian(upars=c(0.1)), hessian)
 
+  hessian_noadj <- list(
+    log_prob = -7.2439666007357095268,
+    grad_log_prob = -3.2497918747894001257,
+    hessian = as.matrix(-2.4937604019289194568, nrow=1, ncol=1)
+  )
+
+  expect_equal(fit$hessian(upars=c(0.1), jacobian_adjustment = FALSE),
+               hessian_noadj)
+
   cpars <- fit$constrain_pars(c(0.1))
   cpars_true <- list(
     theta = 0.52497918747894001257,


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This PR updates the `hessian()` method with an additional argument for whether to include jacobian adjustments from parameter constraints - this makes the method now consistent with the `log_prob` and `grad_log_prob` methods.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
