### PR TITLE
Improve efficiency of variable matching

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -852,16 +852,15 @@ remaining_columns_to_read <- function(requested, currently_read, all) {
     unread <- requested[!(requested %in% currently_read)]
   } else {
     all_remaining <- all[!(all %in% currently_read)]
-    unread <- c()
-    for (p in requested) {
-      if (any(all_remaining == p)) {
-        unread <- c(unread, p)
-      }
-      is_unread_element <- startsWith(all_remaining, paste0(p, "["))
-      if (any(is_unread_element)) {
-        unread <- c(unread, all_remaining[is_unread_element])
-      }
+    # identify exact matches
+    matched <- as.list(match(requested, all_remaining))
+    # loop over requests not exactly matched
+    for (id in which(is.na(matched))) {
+      matched[[id]] <-
+        which(startsWith(all_remaining, paste0(requested[id], "[")))
     }
+    # collect all unread variables
+    unread <- all_remaining[unlist(matched)]
   }
   if (length(unread)) {
     unique(unread)

--- a/R/utils.R
+++ b/R/utils.R
@@ -18,22 +18,23 @@ is_verbose_mode <- function() {
 
 # used in both fit.R and csv.R for variable filtering
 matching_variables <- function(variable_filters, variables) {
-  not_found <- c()
-  selected_variables <- c()
-  for (v in variable_filters) {
-    selected <- variables == v | startsWith(variables, paste0(v, "["))
-    selected_variables <- c(selected_variables, variables[selected])
-    variables <- variables[!selected]
-    if (!any(selected)) {
-      not_found <- c(not_found, v)
-    }
+  # identify exact matches
+  matched <- as.list(match(variable_filters, variables))
+  # loop over filters not exactly matched
+  for (id in which(is.na(matched))) {
+    # assign all variable names that match the filter as an array
+    matched[[id]] <-
+      which(startsWith(variables, paste0(variable_filters[id], "[")))
   }
+  # collect all selected variables
+  selected_variables <- variables[unlist(matched)]
+  # collect all filters not found
+  not_found <- variable_filters[vapply(matched, length, 0L) == 0]
   list(
     matching = selected_variables,
     not_found = not_found
   )
 }
-
 
 # checks for OS and hardware ----------------------------------------------
 


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests
- [X] Declare copyright holder and agree to license (see below)

#### Summary

Improve the efficiency of variable matching to fix #735. This is done by first checking for exact matches and removing any matches from the following loop.

As far as I can tell this retains the exact same functionality. The example in #[735](https://github.com/stan-dev/cmdstanr/issues/735#issue-1568907236) runs in under 10s vs. >2mins before. All relevant tests seem to pass.

#### Copyright and Licensing

Sebastian Funk

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
