### PR TITLE
Update handling of show_messages, add show_exceptions

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -1054,7 +1054,7 @@ sample <- function(data = NULL,
                    window = NULL,
                    fixed_param = FALSE,
                    show_messages = TRUE,
-                   show_errors = TRUE,
+                   show_exceptions = TRUE,
                    diagnostics = c("divergences", "treedepth", "ebfmi"),
                    # deprecated
                    cores = NULL,
@@ -1124,7 +1124,7 @@ sample <- function(data = NULL,
     num_procs = checkmate::assert_integerish(chains, lower = 1, len = 1),
     parallel_procs = checkmate::assert_integerish(parallel_chains, lower = 1, null.ok = TRUE),
     threads_per_proc = assert_valid_threads(threads_per_chain, self$cpp_options(), multiple_chains = TRUE),
-    show_stderr_messages = show_errors,
+    show_stderr_messages = show_exceptions,
     show_stdout_messages = show_messages
   )
   model_variables <- NULL
@@ -1262,7 +1262,7 @@ sample_mpi <- function(data = NULL,
                        fixed_param = FALSE,
                        sig_figs = NULL,
                        show_messages = TRUE,
-                       show_errors = TRUE,
+                       show_exceptions = TRUE,
                        diagnostics = c("divergences", "treedepth", "ebfmi"),
                        # deprecated
                        validate_csv = TRUE) {
@@ -1285,7 +1285,7 @@ sample_mpi <- function(data = NULL,
   procs <- CmdStanMCMCProcs$new(
     num_procs = checkmate::assert_integerish(chains, lower = 1, len = 1),
     parallel_procs = 1,
-    show_stderr_messages = show_errors,
+    show_stderr_messages = show_exceptions,
     show_stdout_messages = show_messages
   )
   model_variables <- NULL

--- a/R/model.R
+++ b/R/model.R
@@ -1054,6 +1054,7 @@ sample <- function(data = NULL,
                    window = NULL,
                    fixed_param = FALSE,
                    show_messages = TRUE,
+                   show_errors = TRUE,
                    diagnostics = c("divergences", "treedepth", "ebfmi"),
                    # deprecated
                    cores = NULL,
@@ -1123,7 +1124,8 @@ sample <- function(data = NULL,
     num_procs = checkmate::assert_integerish(chains, lower = 1, len = 1),
     parallel_procs = checkmate::assert_integerish(parallel_chains, lower = 1, null.ok = TRUE),
     threads_per_proc = assert_valid_threads(threads_per_chain, self$cpp_options(), multiple_chains = TRUE),
-    show_stderr_messages = show_messages
+    show_stderr_messages = show_errors,
+    show_stdout_messages = show_messages
   )
   model_variables <- NULL
   if (is_variables_method_supported(self)) {
@@ -1260,6 +1262,7 @@ sample_mpi <- function(data = NULL,
                        fixed_param = FALSE,
                        sig_figs = NULL,
                        show_messages = TRUE,
+                       show_errors = TRUE,
                        diagnostics = c("divergences", "treedepth", "ebfmi"),
                        # deprecated
                        validate_csv = TRUE) {
@@ -1282,7 +1285,8 @@ sample_mpi <- function(data = NULL,
   procs <- CmdStanMCMCProcs$new(
     num_procs = checkmate::assert_integerish(chains, lower = 1, len = 1),
     parallel_procs = 1,
-    show_stderr_messages = show_messages
+    show_stderr_messages = show_errors,
+    show_stdout_messages = show_messages
   )
   model_variables <- NULL
   if (is_variables_method_supported(self)) {

--- a/R/run.R
+++ b/R/run.R
@@ -361,16 +361,18 @@ check_target_exe <- function(exe) {
       start_msg <- paste0("Running MCMC with ", procs$num_procs(), " chains, at most ", procs$parallel_procs(), " in parallel")
     }
   }
-  if (procs$show_stdout_messages()) {
-    if (is.null(procs$threads_per_proc())) {
+  if (is.null(procs$threads_per_proc())) {
+    if (procs$show_stdout_messages()) {
       cat(paste0(start_msg, "...\n\n"))
-    } else {
+    }
+  } else {
+    if (procs$show_stdout_messages()) {
       cat(paste0(start_msg, ", with ", procs$threads_per_proc(), " thread(s) per chain...\n\n"))
-      Sys.setenv("STAN_NUM_THREADS" = as.integer(procs$threads_per_proc()))
-      # Windows environment variables have to be explicitly exported to WSL
-      if (os_is_wsl()) {
-        Sys.setenv("WSLENV"="STAN_NUM_THREADS/u")
-      }
+    }
+    Sys.setenv("STAN_NUM_THREADS" = as.integer(procs$threads_per_proc()))
+    # Windows environment variables have to be explicitly exported to WSL
+    if (os_is_wsl()) {
+      Sys.setenv("WSLENV"="STAN_NUM_THREADS/u")
     }
   }
   start_time <- Sys.time()
@@ -426,16 +428,18 @@ CmdStanRun$set("private", name = "run_sample_", value = .run_sample)
       start_msg <- paste0("Running standalone generated quantities after ", procs$num_procs(), " MCMC chains, ", procs$parallel_procs(), " chains at a time ")
     }
   }
-  if (procs$show_stdout_messages()) {
-    if (is.null(procs$threads_per_proc())) {
+  if (is.null(procs$threads_per_proc())) {
+    if (procs$show_stdout_messages()) {
       cat(paste0(start_msg, "...\n\n"))
-    } else {
+    }
+  } else {
+    if (procs$show_stdout_messages()) {
       cat(paste0(start_msg, ", with ", procs$threads_per_proc(), " thread(s) per chain...\n\n"))
-      Sys.setenv("STAN_NUM_THREADS" = as.integer(procs$threads_per_proc()))
-      # Windows environment variables have to be explicitly exported to WSL
-      if (os_is_wsl()) {
-        Sys.setenv("WSLENV"="STAN_NUM_THREADS/u")
-      }
+    }
+    Sys.setenv("STAN_NUM_THREADS" = as.integer(procs$threads_per_proc()))
+    # Windows environment variables have to be explicitly exported to WSL
+    if (os_is_wsl()) {
+      Sys.setenv("WSLENV"="STAN_NUM_THREADS/u")
     }
   }
   start_time <- Sys.time()

--- a/man-roxygen/model-sample-args.R
+++ b/man-roxygen/model-sample-args.R
@@ -75,6 +75,10 @@
 #'   `fixed_param=TRUE` is mandatory. When `fixed_param=TRUE` the `chains` and
 #'   `parallel_chains` arguments will be set to `1`.
 #' @param show_messages (logical) When `TRUE` (the default), prints all
+#'   output during the sampling process, such as iteration numbers and elapsed times.
+#'   If the output is silenced then the [`$output()`][fit-method-output] method of
+#'   the resulting fit object can be used to display the silenced messages.
+#' @param show_exceptions (logical) When `TRUE` (the default), prints all
 #'   informational messages, for example rejection of the current proposal.
 #'   Disable if you wish to silence these messages, but this is not usually
 #'   recommended unless you are very confident that the model is correct up to

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -35,7 +35,7 @@ sample(
   window = NULL,
   fixed_param = FALSE,
   show_messages = TRUE,
-  show_errors = TRUE,
+  show_exceptions = TRUE,
   diagnostics = c("divergences", "treedepth", "ebfmi"),
   cores = NULL,
   num_cores = NULL,

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -35,6 +35,7 @@ sample(
   window = NULL,
   fixed_param = FALSE,
   show_messages = TRUE,
+  show_errors = TRUE,
   diagnostics = c("divergences", "treedepth", "ebfmi"),
   cores = NULL,
   num_cores = NULL,

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -237,6 +237,11 @@ quantities block. If the parameters block is empty then using
 \code{parallel_chains} arguments will be set to \code{1}.}
 
 \item{show_messages}{(logical) When \code{TRUE} (the default), prints all
+output during the sampling process, such as iteration numbers and elapsed times.
+If the output is silenced then the \code{\link[=fit-method-output]{$output()}} method of
+the resulting fit object can be used to display the silenced messages.}
+
+\item{show_exceptions}{(logical) When \code{TRUE} (the default), prints all
 informational messages, for example rejection of the current proposal.
 Disable if you wish to silence these messages, but this is not usually
 recommended unless you are very confident that the model is correct up to

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -215,6 +215,11 @@ Increasing this value will result in larger output CSV files and thus an
 increased usage of disk space.}
 
 \item{show_messages}{(logical) When \code{TRUE} (the default), prints all
+output during the sampling process, such as iteration numbers and elapsed times.
+If the output is silenced then the \code{\link[=fit-method-output]{$output()}} method of
+the resulting fit object can be used to display the silenced messages.}
+
+\item{show_exceptions}{(logical) When \code{TRUE} (the default), prints all
 informational messages, for example rejection of the current proposal.
 Disable if you wish to silence these messages, but this is not usually
 recommended unless you are very confident that the model is correct up to

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -34,6 +34,7 @@ sample_mpi(
   fixed_param = FALSE,
   sig_figs = NULL,
   show_messages = TRUE,
+  show_errors = TRUE,
   diagnostics = c("divergences", "treedepth", "ebfmi"),
   validate_csv = TRUE
 )

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -34,7 +34,7 @@ sample_mpi(
   fixed_param = FALSE,
   sig_figs = NULL,
   show_messages = TRUE,
-  show_errors = TRUE,
+  show_exceptions = TRUE,
   diagnostics = c("divergences", "treedepth", "ebfmi"),
   validate_csv = TRUE
 )

--- a/tests/testthat/test-model-sample.R
+++ b/tests/testthat/test-model-sample.R
@@ -118,7 +118,7 @@ test_that("sample() method runs when the stan file is removed", {
   )
 })
 
-test_that("sample() prints informational messages depening on show_messages", {
+test_that("sample() prints informational messages depening on show_exceptions", {
   mod_info_msg <- testing_model("info_message")
   expect_sample_output(
     expect_message(
@@ -127,7 +127,7 @@ test_that("sample() prints informational messages depening on show_messages", {
     )
   )
   expect_sample_output(
-    expect_message(mod_info_msg$sample(show_messages = FALSE), regexp = NA)
+    expect_message(mod_info_msg$sample(show_exceptions = FALSE), regexp = NA)
   )
 })
 
@@ -322,7 +322,7 @@ test_that("sig_figs warning if version less than 2.25", {
   reset_cmdstan_version()
 })
 
-test_that("Errors are suppressed with show_errors", {
+test_that("Errors are suppressed with show_exceptions", {
   errmodcode <- "
   data {
     real y_mean;
@@ -347,7 +347,7 @@ test_that("Errors are suppressed with show_errors", {
   )
 
   expect_no_message(
-    suppressWarnings(errmod$sample(data = list(y_mean = 1), chains = 1, show_errors = FALSE))
+    suppressWarnings(errmod$sample(data = list(y_mean = 1), chains = 1, show_exceptions = FALSE))
   )
 })
 

--- a/tests/testthat/test-model-sample.R
+++ b/tests/testthat/test-model-sample.R
@@ -355,6 +355,7 @@ test_that("All output can be suppressed by show_messages", {
   stan_program <- testing_stan_file("bernoulli")
   data_list <- testing_data("bernoulli")
   mod <- cmdstan_model(stan_program, force_recompile = TRUE)
+  options("cmdstanr_verbose" = FALSE)
   output <- capture.output(
     fit <- mod$sample(data = data_list, show_messages = FALSE)
   )


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This PR addresses #718 and #646 by adding a `show_exceptions` argument to the `sample()` and `sample_mpi()` methods, and also expands the use of `show_messages=FALSE` to completely suppress all printing of non-errors.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
