### PR TITLE
Add version check when exposing external functions

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -582,6 +582,7 @@ compile <- function(quiet = TRUE,
   }
   stancflags_standalone <- c("--standalone-functions", stancflags_val, stancflags_combined)
   self$functions$hpp_code <- get_standalone_hpp(temp_stan_file, stancflags_standalone)
+  self$functions$external <- !is.null(user_header)
   if (compile_standalone) {
     expose_functions(self$functions, !quiet)
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -878,6 +878,10 @@ expose_functions <- function(function_env, global = FALSE, verbose = FALSE) {
           "WSL CmdStan and will not be compiled",
           call. = FALSE)
   }
+  if (function_env$external && cmdstan_version() < "2.32") {
+    stop("Exporting standalone functions with external C++ is not available before CmdStan 2.32",
+         call. = FALSE)
+  }
   require_suggested_package("Rcpp")
   require_suggested_package("RcppEigen")
   require_suggested_package("decor")

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -147,3 +147,25 @@ test_that("Overloaded functions give meaningful errors", {
   expect_error(funmod$expose_functions(),
                "Overloaded functions are currently not able to be exposed to R! The following overloaded functions were found: fun1, fun3")
 })
+
+test_that("Exposing external functions errors before v2.32", {
+  tmpfile <- tempfile(fileext = ".hpp")
+  hpp <-
+  "
+  #include <ostream>
+  namespace standalone_external_model_namespace {
+    int rtn_int(int x, std::ostream *pstream__) { return x; }
+  }"
+  cat(hpp, file = tmpfile, sep = "\n")
+  stanfile <- file.path(tempdir(), "standalone_external.stan")
+  cat("functions { int rtn_int(int x); }\n", file = stanfile)
+  expect_error({
+    cmdstan_model(
+      stan_file = stanfile,
+      user_header = tmpfile,
+      compile_standalone = TRUE
+    )
+  },
+  "Exporting standalone functions with external C++ is not available before CmdStan 2.32",
+  fixed = TRUE)
+})

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -149,6 +149,16 @@ test_that("Overloaded functions give meaningful errors", {
 })
 
 test_that("Exposing external functions errors before v2.32", {
+  if (getRversion() < '3.5.0') {
+    dir <- tempdir()
+  } else {
+    dir <- tempdir(check = TRUE)
+  }
+  install_cmdstan(dir = dir, cores = 2, quiet = FALSE,
+                  overwrite = TRUE, version = "2.31.0",
+                  wsl = os_is_wsl())
+  set_cmdstan_path(dir)
+
   tmpfile <- tempfile(fileext = ".hpp")
   hpp <-
   "

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -157,7 +157,6 @@ test_that("Exposing external functions errors before v2.32", {
   install_cmdstan(dir = dir, cores = 2, quiet = FALSE,
                   overwrite = TRUE, version = "2.31.0",
                   wsl = os_is_wsl())
-  set_cmdstan_path(dir)
 
   tmpfile <- tempfile(fileext = ".hpp")
   hpp <-

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -149,6 +149,8 @@ test_that("Overloaded functions give meaningful errors", {
 })
 
 test_that("Exposing external functions errors before v2.32", {
+  skip_if(os_is_wsl())
+
   if (getRversion() < '3.5.0') {
     dir <- tempdir()
   } else {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This PR closes #713. Currently `expose_functions()` fails with an uninformative error message if external c++ is used. This is due to a bug in `stanc3`, and after [this PR](https://github.com/stan-dev/stanc3/pull/1298) the generated code will be compatible.

This PR adds a simple version check when exposing external functions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
