### PR TITLE
Add stanc M1 make patch, suppress boost warnings

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -209,13 +209,11 @@ install_cmdstan <- function(dir = NULL,
   # Building fails on Apple silicon with < v2.31 due to a makefiles setting
   # for stanc3, so manually implement the patch if needed from:
   # https://github.com/stan-dev/cmdstan/pull/1127
-  if (isTRUE(ver < "2.31") || isTRUE(version < "2.31")) {
-    stanc_makefile <- readLines(file.path(dir_cmdstan, "make", "stanc"))
-    stanc_makefile <- gsub("\\bxattr -d com.apple.quarantine bin/stanc",
-                            "-xattr -d com.apple.quarantine bin/stanc",
-                            stanc_makefile)
-    writeLines(stanc_makefile, con = file.path(dir_cmdstan, "make", "stanc"))
-  }
+  stanc_makefile <- readLines(file.path(dir_cmdstan, "make", "stanc"))
+  stanc_makefile <- gsub("\\bxattr -d com.apple.quarantine bin/stanc",
+                          "-xattr -d com.apple.quarantine bin/stanc",
+                          stanc_makefile)
+  writeLines(stanc_makefile, con = file.path(dir_cmdstan, "make", "stanc"))
 
   if ((is_rtools42_toolchain() || is_rtools43_toolchain()) && !wsl) {
     cmdstan_make_local(

--- a/R/install.R
+++ b/R/install.R
@@ -209,7 +209,7 @@ install_cmdstan <- function(dir = NULL,
   # Building fails on Apple silicon with < v2.31 due to a makefiles setting
   # for stanc3, so manually implement the patch if needed from:
   # https://github.com/stan-dev/cmdstan/pull/1127
-  if (os_is_macos() && R.version$arch == "aarch64") {
+  if (isTRUE(ver < "2.31") || isTRUE(version < "2.31")) {
     stanc_makefile <- readLines(file.path(dir_cmdstan, "make", "stanc"))
     stanc_makefile <- gsub("\\bxattr -d com.apple.quarantine bin/stanc",
                             "-xattr -d com.apple.quarantine bin/stanc",

--- a/R/install.R
+++ b/R/install.R
@@ -205,6 +205,18 @@ install_cmdstan <- function(dir = NULL,
       append = TRUE
     )
   }
+
+  # Building fails on Apple silicon with < v2.31 due to a makefiles setting
+  # for stanc3, so manually implement the patch if needed from:
+  # https://github.com/stan-dev/cmdstan/pull/1127
+  if (os_is_macos() && R.version$arch == "aarch64") {
+    stanc_makefile <- readLines(file.path(dir_cmdstan, "make", "stanc"))
+    stanc_makefile <- gsub("\\bxattr -d com.apple.quarantine bin/stanc",
+                            "-xattr -d com.apple.quarantine bin/stanc",
+                            stanc_makefile)
+    writeLines(stanc_makefile, con = file.path(dir_cmdstan, "make", "stanc"))
+  }
+
   if ((is_rtools42_toolchain() || is_rtools43_toolchain()) && !wsl) {
     cmdstan_make_local(
       dir = dir_cmdstan,
@@ -215,6 +227,15 @@ install_cmdstan <- function(dir = NULL,
       append = TRUE
     )
   }
+
+  # Suppress noisy warnings from Boost
+  cmdstan_make_local(
+    dir = dir_cmdstan,
+    cpp_options = list(
+      "CXXFLAGS += -Wno-deprecated-declarations"
+    ),
+    append = TRUE
+  )
 
   message("* Building CmdStan binaries...")
   build_log <- build_cmdstan(dir_cmdstan, cores, quiet, timeout)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Building cmdstan versions < 2.31 fails on M1/M2 macs due to a makefile setting which has [since been patched](https://github.com/stan-dev/cmdstan/pull/1127). This PR adds the automatic updating of the `stanc` makefile where necessary so that M1/M2 users can install older versions of cmdstan.

I've also added the `-Wno-deprecated-declarations` flag to suppress the warnings [coming from Boost](https://discourse.mc-stan.org/t/running-cmdstan-on-ventura/30948/11)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
