### PR TITLE
Fix model$format and model$check_syntax for compiled models with include-paths

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -784,8 +784,8 @@ check_syntax <- function(pedantic = FALSE,
   if (length(stanc_options) == 0 && !is.null(private$precompile_stanc_options_)) {
     stanc_options <- private$precompile_stanc_options_
   }
-  if (is.null(include_paths) && !is.null(private$precompile_include_paths_)) {
-    include_paths <- private$precompile_include_paths_
+  if (is.null(include_paths) && !is.null(self$include_paths())) {
+    include_paths <- self$include_paths()
   }
 
   temp_hpp_file <- tempfile(pattern = "model-", fileext = ".hpp")
@@ -922,7 +922,7 @@ format <- function(overwrite_file = FALSE,
     lower = 1, len = 1, null.ok = TRUE
   )
   stanc_options <- private$precompile_stanc_options_
-  stancflags_val <- include_paths_stanc3_args(private$precompile_include_paths_)
+  stancflags_val <- include_paths_stanc3_args(self$include_paths())
   stanc_options["auto-format"] <- TRUE
   if (!is.null(max_line_length)) {
     stanc_options["max-line-length"] <- max_line_length

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -406,6 +406,15 @@ test_that("check_syntax() works with include_paths", {
 
 })
 
+test_that("check_syntax() works with include_paths on compiled model", {
+  stan_program_w_include <- testing_stan_file("bernoulli_include")
+
+  mod_w_include <- cmdstan_model(stan_file = stan_program_w_include, compile=TRUE,
+                                 include_paths = test_path("resources", "stan"))
+  expect_true(mod_w_include$check_syntax())
+
+})
+
 test_that("check_syntax() works with pedantic=TRUE", {
   model_code <- "
   transformed data {
@@ -735,6 +744,28 @@ test_that("format() works with include_paths", {
     fixed = TRUE
   )
     expect_output(
+    mod_w_include$format(canonicalize = list('includes')),
+    "real divide_real_by_two",
+    fixed = TRUE
+  )
+})
+
+test_that("format() works with include_paths on compiled model", {
+  stan_program_w_include <- testing_stan_file("bernoulli_include")
+
+  mod_w_include <- cmdstan_model(stan_file = stan_program_w_include, compile=TRUE,
+                                 include_paths = test_path("resources", "stan"))
+  expect_output(
+    mod_w_include$format(),
+    "#include ",
+    fixed = TRUE
+  )
+  expect_output(
+    mod_w_include$format(canonicalize = list('deprecations', 'parentheses', 'braces')),
+    "#include ",
+    fixed = TRUE
+  )
+  expect_output(
     mod_w_include$format(canonicalize = list('includes')),
     "real divide_real_by_two",
     fixed = TRUE


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This PR fixes #774 by using `self$include_paths() ` instead of `private$precompile_include_paths_` in the methods `check_syntax` and `format`. This is because the latter only holds the `include_paths` if the model has not been compiled yet. As a result, it is now possible to call these methods on compiled models with include statements without getting a syntax error from `stanc`. For `format`, this has currently not been possible at all, for `check_syntax`, you always had to use the `include_paths` argument of the function even if the same, default `include_paths` were used.

The PR also adds tests for include_paths in `check_syntax` and `format` on compiled models, but I am not sure if these are desired as they require compilation of the example model during testing.

This is my first PR for `cmdstanr`, so apologies in case I violated any conventions.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Adrian Lison

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
