### PR TITLE
Fix init_model_methods for models with no data

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -759,7 +759,8 @@ expose_model_methods <- function(env, verbose = FALSE, hessian = FALSE) {
 }
 
 initialize_model_pointer <- function(env, data, seed = 0) {
-  ptr_and_rng <- env$model_ptr(data, seed)
+  datafile_path <- ifelse(is.null(data), "", data)
+  ptr_and_rng <- env$model_ptr(datafile_path, seed)
   env$model_ptr_ <- ptr_and_rng$model_ptr
   env$model_rng_ <- ptr_and_rng$base_rng
   env$num_upars_ <- env$get_num_upars(env$model_ptr_)

--- a/inst/include/model_methods.cpp
+++ b/inst/include/model_methods.cpp
@@ -6,9 +6,15 @@
 #include <cmdstan/io/json/json_data.hpp>
 #else
 #include <stan/io/json/json_data.hpp>
+#include <stan/io/empty_var_context.hpp>
 #endif
 
 std::shared_ptr<stan::io::var_context> var_context(std::string file_path) {
+  if (file_path == "") {
+    stan::io::empty_var_context empty_context;
+    return std::make_shared<stan::io::empty_var_context>(empty_context);
+  }
+
   std::fstream stream(file_path.c_str(), std::fstream::in);
 #ifdef CMDSTAN_JSON
 using json_data_t = cmdstan::json::json_data;

--- a/tests/testthat/test-model-methods.R
+++ b/tests/testthat/test-model-methods.R
@@ -270,6 +270,8 @@ test_that("unconstrain_draws returns correct values", {
 })
 
 test_that("Model methods can be initialised for models with no data", {
+  skip_if(os_is_wsl())
+
   stan_file <- write_stan_file("parameters { real x; } model { x ~ std_normal(); }")
   mod <- cmdstan_model(stan_file, compile_model_methods = TRUE, force_recompile = TRUE)
   expect_no_error(fit <- mod$sample())

--- a/tests/testthat/test-model-methods.R
+++ b/tests/testthat/test-model-methods.R
@@ -268,3 +268,10 @@ test_that("unconstrain_draws returns correct values", {
   unconstrained_draws <- fit$unconstrain_draws(draws = fit$draws())[[1]]
   expect_equal(as.numeric(x_draws), exp(as.numeric(unconstrained_draws)))
 })
+
+test_that("Model methods can be initialised for models with no data", {
+  stan_file <- write_stan_file("parameters { real x; } model { x ~ std_normal(); }")
+  mod <- cmdstan_model(stan_file, compile_model_methods = TRUE, force_recompile = TRUE)
+  expect_no_error(fit <- mod$sample())
+  expect_equal(fit$log_prob(5), -12.5)
+})


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #793 by allowing the model methods to be initialised for models with no input data

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
