### PR TITLE
Cache model methods after compilation

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -473,6 +473,7 @@ clean_cmdstan <- function(dir = cmdstan_path(),
       stderr_callback = function(x, p) { if (quiet) message(x) }
     )
   )
+  unlink(file.path(dir, "ModelMethodsCache"), recursive = TRUE)
 }
 
 build_example <- function(dir, cores, quiet, timeout) {

--- a/inst/include/model_methods.cpp
+++ b/inst/include/model_methods.cpp
@@ -1,14 +1,14 @@
 #include <Rcpp.h>
 #include <stan/model/log_prob_grad.hpp>
 #include <stan/model/log_prob_propto.hpp>
-#include <boost/random/additive_combine.hpp>
+#include <stan/model/model_base.hpp>
 #ifdef CMDSTAN_JSON
 #include <cmdstan/io/json/json_data.hpp>
 #else
 #include <stan/io/json/json_data.hpp>
 #endif
 
-std::shared_ptr<stan::io::var_context> var_context(std::string file_path) {
+inline std::shared_ptr<stan::io::var_context> var_context(std::string file_path) {
   std::fstream stream(file_path.c_str(), std::fstream::in);
 #ifdef CMDSTAN_JSON
 using json_data_t = cmdstan::json::json_data;
@@ -17,18 +17,6 @@ using json_data_t = stan::json::json_data;
 #endif
   json_data_t data_context(stream);
   return std::make_shared<json_data_t>(data_context);
-}
-
-// [[Rcpp::export]]
-Rcpp::List model_ptr(std::string data_path, boost::uint32_t seed) {
-  Rcpp::XPtr<stan_model> ptr(
-    new stan_model(*var_context(data_path), seed, &Rcpp::Rcout)
-  );
-  Rcpp::XPtr<boost::ecuyer1988> base_rng(new boost::ecuyer1988(seed));
-  return Rcpp::List::create(
-    Rcpp::Named("model_ptr") = ptr,
-    Rcpp::Named("base_rng") = base_rng
-  );
 }
 
 // [[Rcpp::export]]

--- a/inst/include/model_ptr.cpp
+++ b/inst/include/model_ptr.cpp
@@ -1,0 +1,32 @@
+#include <Rcpp.h>
+#include <stan/model/log_prob_grad.hpp>
+#include <stan/model/log_prob_propto.hpp>
+#include <boost/random/additive_combine.hpp>
+#ifdef CMDSTAN_JSON
+#include <cmdstan/io/json/json_data.hpp>
+#else
+#include <stan/io/json/json_data.hpp>
+#endif
+
+inline std::shared_ptr<stan::io::var_context> var_context(std::string file_path) {
+  std::fstream stream(file_path.c_str(), std::fstream::in);
+#ifdef CMDSTAN_JSON
+using json_data_t = cmdstan::json::json_data;
+#else
+using json_data_t = stan::json::json_data;
+#endif
+  json_data_t data_context(stream);
+  return std::make_shared<json_data_t>(data_context);
+}
+
+// [[Rcpp::export]]
+Rcpp::List model_ptr(std::string data_path, boost::uint32_t seed) {
+  Rcpp::XPtr<stan_model> ptr(
+    new stan_model(*var_context(data_path), seed, &Rcpp::Rcout)
+  );
+  Rcpp::XPtr<boost::ecuyer1988> base_rng(new boost::ecuyer1988(seed));
+  return Rcpp::List::create(
+    Rcpp::Named("model_ptr") = ptr,
+    Rcpp::Named("base_rng") = base_rng
+  );
+}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This PR updates the compilation of the model methods to cache the methods in the `cmdstan_path()` after they're first compiled. These only need to be compiled once, as they can be passed an arbitrary model pointer. This should hopefully reduce compilation/waiting times for users.

Consequently, after the model methods are compiled and cached, the only compilation needed in future calls is the method to instantiate and return a pointer to the current model instance.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
