### PR TITLE
Document a CmdStan-focused way to pre-compile Stan models in R packages

### DIFF
--- a/vignettes/cmdstanr-internals.Rmd
+++ b/vignettes/cmdstanr-internals.Rmd
@@ -474,16 +474,18 @@ through CmdStan.
 
 You may compile a Stan model at runtime (e.g. just before sampling),
 or you may compile all the models inside the package file system in advance at installation time.
-The latter avoids repeated compilations at runtime.
+The latter avoids compilations at runtime, which matters in centrally managed R installations
+where users should not compile their own software.
+
 To pre-compile all the models in a package,
 you may create top-level scripts `configure` and `configure.win`
 which run `cmdstan_model()` with `compile = TRUE` and save the compiled executables
 somewhere inside the `inst/` folder of the package source.
-The [`instantiate`](https://wlandau.github.io/instantiate/) package helps follow
-this configuration pattern and documents other topics like CRAN submission and
-administering CmdStan in centralized R enviroinments.
-Kevin Ushey's [`configure`](https://github.com/kevinushey/configure) package helps write
-configuration files more generally.
+The [`instantiate`](https://wlandau.github.io/instantiate/) package helps developers
+configure packages this way,
+and it documents other topics such as submitting to CRAN and administering CmdStan.
+Kevin Ushey's [`configure`](https://github.com/kevinushey/configure) package helps
+create and manage package configuration files in general.
 
 
 ### Troubleshooting and debugging

--- a/vignettes/cmdstanr-internals.Rmd
+++ b/vignettes/cmdstanr-internals.Rmd
@@ -470,6 +470,22 @@ CmdStanR can of course be used for developing other packages that require compil
 and running Stan models as well as using new or custom Stan features available
 through CmdStan.
 
+### Pre-compiled Stan models in R packages
+
+You may compile a Stan model at runtime (e.g. just before sampling),
+or you may compile all the models inside the package file system in advance at installation time.
+The latter avoids repeated compilations at runtime.
+To pre-compile all the models in a package,
+you may create top-level scripts `configure` and `configure.win`
+which run `cmdstan_model()` with `compile = TRUE` and save the compiled executables
+somewhere inside the `inst/` folder of the package source.
+The [`instantiate`](https://wlandau.github.io/instantiate/) package helps follow
+this configuration pattern and documents other topics like CRAN submission and
+administering CmdStan in centralized R enviroinments.
+Kevin Ushey's [`configure`](https://github.com/kevinushey/configure) package helps write
+configuration files more generally.
+
+
 ### Troubleshooting and debugging
 
 When developing or testing new features it might be useful to have more


### PR DESCRIPTION
#### Submission Checklist

- [n/a] Run unit tests (this PR only modifies a vignette)
- [x] Declare copyright holder and agree to license (see below)

#### Summary

As proposed by @jgabry at https://github.com/stan-dev/cmdstanr/issues/738#issuecomment-1660632765, this PR documents one way to pre-compile Stan models in a CmdStanR-powered R package. [`instantiate`](https://github.com/wlandau/instantiate) is still in its early days, and I am not sure how to deal with the compiler issues we will inevitably face going forward (c.f. https://github.com/stan-dev/cmdstanr/issues/787, https://github.com/wlandau/instantiate/issues/1). But there are good reasons to pre-compile Stan models in an R package, and this is a start using the modern CmdStan-based tooling.

#### Copyright and Licensing

> Please list the copyright holder for the work you are submitting
> (this will be you or your assignee, such as a university or company):

Eli Lilly and Company


> By submitting this pull request, the copyright holder is agreeing to
> license the submitted work under the following licenses:
>
> - Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
> - Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
