### PR TITLE
Fix variable_skeleton() with containers

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -780,7 +780,11 @@ create_skeleton <- function(param_metadata, model_variables,
                        names(model_variables$generated_quantities))
   }
   lapply(param_metadata[target_params], function(par_dims) {
-    array(0, dim = ifelse(length(par_dims) == 0, 1, par_dims))
+    if ((length(par_dims) == 0)) {
+      array(0, dim = 1)
+    } else {
+      array(0, dim = par_dims)
+    }
   })
 }
 

--- a/tests/testthat/test-model-methods.R
+++ b/tests/testthat/test-model-methods.R
@@ -297,14 +297,16 @@ test_that("Variable skeleton returns correct dimensions for matrices", {
   }")
   mod <- cmdstan_model(stan_file, compile_model_methods = TRUE,
                       force_recompile = TRUE)
-  fit <- mod$sample(data = list(N = 4, K = 3), chains = 1,
+  N <- 4
+  K <- 3
+  fit <- mod$sample(data = list(N = N, K = K), chains = 1,
                     iter_warmup = 1, iter_sampling = 1)
 
   target_skeleton <- list(
     x_real = array(0, dim = 1),
-    x_mat = array(0, dim = c(4, 3)),
-    x_vec = array(0, dim = c(3)),
-    x_rowvec = array(0, dim = c(3))
+    x_mat = array(0, dim = c(N, K)),
+    x_vec = array(0, dim = K),
+    x_rowvec = array(0, dim = K)
   )
 
   expect_equal(fit$variable_skeleton(),


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Resolves #821 by fixing the handling of container dimensions in `variable_skeleton()`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
