### PR TITLE
change duplicate stdout_file to stderr_file

### DIFF
--- a/R/run.R
+++ b/R/run.R
@@ -560,8 +560,8 @@ CmdStanRun$set("private", name = "run_variational_", value = .run_other)
     if (file.exists(stdout_file)) {
       cat(readLines(stdout_file), sep = "\n")
     }
-    if (file.exists(stdout_file)) {
-      cat(readLines(stdout_file), sep = "\n")
+    if (file.exists(stderr_file)) {
+      cat(readLines(stderr_file), sep = "\n")
     }
     stop(
       "Diagnose failed with the status code ", ret$status, "!\n",


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

closes #826

In `.run_diagnose` we were printing stdout twice instead of stdout one and stderr once. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
