### PR TITLE
Fix exposing functions under 2.33+

### DIFF
--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -192,7 +192,8 @@ test_that("Exposing functions with precompiled model gives meaningful error", {
     parameters { real x; }
     model { x ~ std_normal(); }
   ")
-  mod1 <- cmdstan_model(stan_file, compile_standalone = TRUE)
+  mod1 <- cmdstan_model(stan_file, compile_standalone = TRUE,
+                        force_recompile = TRUE)
   expect_equal(7.5, mod1$functions$a_plus_b(5, 2.5))
 
   mod2 <- cmdstan_model(stan_file)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Exposing functions fails under 2.33+ since `cmdstanr` no longer needs to replace the `auto` return type with a plain type (this is done by `stanc3` instead). 

This PR fixes the handling of this between CmdStan versions

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
