### PR TITLE
Update linux/wsl detection for install arch

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -50,6 +50,10 @@ os_is_macos <- function() {
   isTRUE(Sys.info()[["sysname"]] == "Darwin")
 }
 
+os_is_linux <- function() {
+  isTRUE(Sys.info()[["sysname"]] == "Linux")
+}
+
 is_rtools43_toolchain <- function() {
   os_is_windows() && R.version$major == "4" && R.version$minor >= "3.0"
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The current install process only downloads the correct release tarball for non-x86_64 if the combination is `Linux+arm64`. This PR updates the detection to correctly handle other architectures on Linux and WSL

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
