### PR TITLE
Fix handling of single-length inits for containers

### DIFF
--- a/R/args.R
+++ b/R/args.R
@@ -829,7 +829,7 @@ process_init_list <- function(init, num_procs, model_variables = NULL) {
       for (par_name in parameter_names[is_parameter_value_supplied]) {
         # Make sure that initial values for single-element containers don't get
         # unboxed when writing to JSON
-        if (model_variables$parameters[[par_name]]$dimensions == 1 && is.null(attr(init[[i]][[par_name]], "dim"))) {
+        if (model_variables$parameters[[par_name]]$dimensions == 1 && length(init[[i]][[par_name]]) == 1) {
           init[[i]][[par_name]] <- array(init[[i]][[par_name]], dim = 1)
         }
       }

--- a/R/args.R
+++ b/R/args.R
@@ -826,6 +826,13 @@ process_init_list <- function(init, num_procs, model_variables = NULL) {
       if (!all(is_parameter_value_supplied)) {
         missing_parameter_values[[i]] <- parameter_names[!is_parameter_value_supplied]
       }
+      for (par_name in parameter_names[is_parameter_value_supplied]) {
+        # Make sure that initial values for single-element containers don't get
+        # unboxed when writing to JSON
+        if (model_variables$parameters[[par_name]]$dimensions == 1 && is.null(attr(init[[i]][[par_name]], "dim"))) {
+          init[[i]][[par_name]] <- array(init[[i]][[par_name]], dim = 1)
+        }
+      }
     }
     if (length(missing_parameter_values) > 0) {
       warning_message <- c(

--- a/tests/testthat/test-model-init.R
+++ b/tests/testthat/test-model-init.R
@@ -262,3 +262,25 @@ test_that("print message if not all parameters are initialized", {
     fixed = TRUE
   )
 })
+
+test_that("Initial values for single-element containers treated correctly", {
+  modcode <- "
+  data {
+    real y_mean;
+  }
+  parameters {
+    vector[1] y;
+  }
+  model {
+    y_mean ~ normal(y[1], 1);
+  }
+  "
+  mod <- cmdstan_model(write_stan_file(modcode), force_recompile = TRUE)
+  expect_no_error(
+    fit <- mod$sample(
+      data = list(y_mean = 0),
+      init = list(list(y = c(0))),
+      chains = 1
+    )
+  )
+})


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Resolves the bug report in #855, which identified a more general issue that passing initial values for single-element containers would fail due to the `auto_unbox` setting in `jsonlite` treating them as scalars, resulting in `cmdstan` throwing a dimension-mismatch error.

This PR updates the processing of init-lists to check whether the initial value is for a single dimension-container and then format the value appropriately

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
