### PR TITLE
Add option for installing from release archive

### DIFF
--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -15,6 +15,7 @@ install_cmdstan(
   timeout = 1200,
   version = NULL,
   release_url = NULL,
+  release_file = NULL,
   cpp_options = list(),
   check_toolchain = TRUE,
   wsl = FALSE
@@ -65,6 +66,11 @@ release candidate to install. See \url{https://github.com/stan-dev/cmdstan/relea
 The URL should point to the tarball (\code{.tar.gz.} file) itself, e.g.,
 \code{release_url="https://github.com/stan-dev/cmdstan/releases/download/v2.25.0/cmdstan-2.25.0.tar.gz"}.
 If both \code{version} and \code{release_url} are specified then \code{version} will be used.}
+
+\item{release_file}{(string) A file path to a CmdStan release tar.gz file
+downloaded from the releases page: \url{https://github.com/stan-dev/cmdstan/releases}.
+For example: \verb{release_file=""./cmdstan-2.33.1.tar.gz"}. If \code{release_file} is
+specified then both \code{release_url} and \code{version} will be ignored.}
 
 \item{cpp_options}{(list) Any makefile flags/variables to be written to
 the \code{make/local} file. For example, \code{list("CXX" = "clang++")} will force

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -247,3 +247,28 @@ test_that("Download failures return error message", {
     "GitHub download of release list failed with error: cannot open URL 'https://api.github.com/repos/stan-dev/cmdstan/releases/latest'")
 })
 
+test_that("Install from release file works", {
+  if (getRversion() < '3.5.0') {
+    dir <- tempdir()
+  } else {
+    dir <- tempdir(check = TRUE)
+  }
+
+  destfile = file.path(dir, "cmdstan-2.33.1.tar.gz")
+
+  download_with_retries(
+    "https://github.com/stan-dev/cmdstan/releases/download/v2.33.1/cmdstan-2.33.1.tar.gz",
+    destfile)
+
+  expect_message(
+    expect_output(
+      install_cmdstan(dir = dir, cores = 2, quiet = FALSE, overwrite = TRUE,
+                      release_file = destfile,
+                      wsl = os_is_wsl()),
+      "Compiling, linking C++ code",
+      fixed = TRUE
+    ),
+    "CmdStan path set",
+    fixed = TRUE
+  )
+})


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary
Closes #865 by adding the option to install cmdstan from a downloaded release archive:
```r
install_cmdstan(release_file = "./cmdstan-2.33.1.tar.gz")
```

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
