### PR TITLE
Rename `jacobian_adjustment` argument to `jacobian`

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -362,12 +362,13 @@ CmdStanFit$set("public", name = "init_model_methods", value = init_model_methods
 #'
 #' @name fit-method-log_prob
 #' @aliases log_prob
-#' @description The `$log_prob()` method provides access to the Stan model's `log_prob` function
+#' @description The `$log_prob()` method provides access to the Stan model's
+#'   `log_prob` function.
 #'
-#' @param unconstrained_variables (numeric) A vector of unconstrained parameters
-#'   to be passed to `log_prob`.
-#' @param jacobian_adjustment (logical) Whether to include the log-density
-#'   adjustments from un/constraining variables.
+#' @param unconstrained_variables (numeric) A vector of unconstrained parameters.
+#' @param jacobian (logical) Whether to include the log-density adjustments from
+#'   un/constraining variables.
+#' @param jacobian_adjustment Deprecated. Please use `jacobian` instead.
 #'
 #' @examples
 #' \dontrun{
@@ -380,7 +381,11 @@ CmdStanFit$set("public", name = "init_model_methods", value = init_model_methods
 #'   [unconstrain_variables()], [unconstrain_draws()], [variable_skeleton()],
 #'   [hessian()]
 #'
-log_prob <- function(unconstrained_variables, jacobian_adjustment = TRUE) {
+log_prob <- function(unconstrained_variables, jacobian = TRUE, jacobian_adjustment = NULL) {
+  if (!is.null(jacobian_adjustment)) {
+    warning("'jacobian_adjustment' is deprecated. Please use 'jacobian' instead.", call. = FALSE)
+    jacobian <- jacobian_adjustment
+  }
   if (is.null(private$model_methods_env_$model_ptr)) {
     stop("The method has not been compiled, please call `init_model_methods()` first",
         call. = FALSE)
@@ -390,7 +395,7 @@ log_prob <- function(unconstrained_variables, jacobian_adjustment = TRUE) {
           length(unconstrained_variables), " were provided!", call. = FALSE)
   }
   private$model_methods_env_$log_prob(private$model_methods_env_$model_ptr_,
-                                      unconstrained_variables, jacobian_adjustment)
+                                      unconstrained_variables, jacobian)
 }
 CmdStanFit$set("public", name = "log_prob", value = log_prob)
 
@@ -401,11 +406,7 @@ CmdStanFit$set("public", name = "log_prob", value = log_prob)
 #' @aliases grad_log_prob
 #' @description The `$grad_log_prob()` method provides access to the Stan
 #'   model's `log_prob` function and its derivative.
-#'
-#' @param unconstrained_variables (numeric) A vector of unconstrained parameters
-#'   to be passed to `grad_log_prob`.
-#' @param jacobian_adjustment (logical) Whether to include the log-density
-#'   adjustments from un/constraining variables.
+#' @inheritParams fit-method-log_prob
 #'
 #' @examples
 #' \dontrun{
@@ -418,7 +419,11 @@ CmdStanFit$set("public", name = "log_prob", value = log_prob)
 #'   [unconstrain_variables()], [unconstrain_draws()], [variable_skeleton()],
 #'   [hessian()]
 #'
-grad_log_prob <- function(unconstrained_variables, jacobian_adjustment = TRUE) {
+grad_log_prob <- function(unconstrained_variables, jacobian = TRUE, jacobian_adjustment = NULL) {
+  if (!is.null(jacobian_adjustment)) {
+    warning("'jacobian_adjustment' is deprecated. Please use 'jacobian' instead.", call. = FALSE)
+    jacobian <- jacobian_adjustment
+  }
   if (is.null(private$model_methods_env_$model_ptr)) {
     stop("The method has not been compiled, please call `init_model_methods()` first",
         call. = FALSE)
@@ -428,7 +433,7 @@ grad_log_prob <- function(unconstrained_variables, jacobian_adjustment = TRUE) {
           length(unconstrained_variables), " were provided!", call. = FALSE)
   }
   private$model_methods_env_$grad_log_prob(private$model_methods_env_$model_ptr_,
-                                            unconstrained_variables, jacobian_adjustment)
+                                            unconstrained_variables, jacobian)
 }
 CmdStanFit$set("public", name = "grad_log_prob", value = grad_log_prob)
 
@@ -439,11 +444,7 @@ CmdStanFit$set("public", name = "grad_log_prob", value = grad_log_prob)
 #' @aliases hessian
 #' @description The `$hessian()` method provides access to the Stan model's
 #'   `log_prob`, its derivative, and its hessian.
-#'
-#' @param unconstrained_variables (numeric) A vector of unconstrained parameters
-#'   to be passed to `hessian`.
-#' @param jacobian_adjustment (logical) Whether to include the log-density
-#'   adjustments from un/constraining variables.
+#' @inheritParams fit-method-log_prob
 #'
 #' @examples
 #' \dontrun{
@@ -456,7 +457,11 @@ CmdStanFit$set("public", name = "grad_log_prob", value = grad_log_prob)
 #'   [unconstrain_variables()], [unconstrain_draws()], [variable_skeleton()],
 #'   [hessian()]
 #'
-hessian <- function(unconstrained_variables, jacobian_adjustment = TRUE) {
+hessian <- function(unconstrained_variables, jacobian = TRUE, jacobian_adjustment = TRUE) {
+  if (!is.null(jacobian_adjustment)) {
+    warning("'jacobian_adjustment' is deprecated. Please use 'jacobian' instead.", call. = FALSE)
+    jacobian <- jacobian_adjustment
+  }
   if (is.null(private$model_methods_env_$model_ptr)) {
     stop("The method has not been compiled, please call `init_model_methods()` first",
         call. = FALSE)
@@ -466,7 +471,7 @@ hessian <- function(unconstrained_variables, jacobian_adjustment = TRUE) {
           length(unconstrained_variables), " were provided!", call. = FALSE)
   }
   private$model_methods_env_$hessian(private$model_methods_env_$model_ptr_,
-                                      unconstrained_variables, jacobian_adjustment)
+                                      unconstrained_variables, jacobian)
 }
 CmdStanFit$set("public", name = "hessian", value = hessian)
 

--- a/man/fit-method-grad_log_prob.Rd
+++ b/man/fit-method-grad_log_prob.Rd
@@ -6,14 +6,19 @@
 \title{Calculate the log-probability and the gradient w.r.t. each input for a
 given vector of unconstrained parameters}
 \usage{
-grad_log_prob(unconstrained_variables, jacobian_adjustment = TRUE)
+grad_log_prob(
+  unconstrained_variables,
+  jacobian = TRUE,
+  jacobian_adjustment = NULL
+)
 }
 \arguments{
-\item{unconstrained_variables}{(numeric) A vector of unconstrained parameters
-to be passed to \code{grad_log_prob}.}
+\item{unconstrained_variables}{(numeric) A vector of unconstrained parameters.}
 
-\item{jacobian_adjustment}{(logical) Whether to include the log-density
-adjustments from un/constraining variables.}
+\item{jacobian}{(logical) Whether to include the log-density adjustments from
+un/constraining variables.}
+
+\item{jacobian_adjustment}{Deprecated. Please use \code{jacobian} instead.}
 }
 \description{
 The \verb{$grad_log_prob()} method provides access to the Stan

--- a/man/fit-method-hessian.Rd
+++ b/man/fit-method-hessian.Rd
@@ -6,14 +6,15 @@
 \title{Calculate the log-probability , the gradient w.r.t. each input, and the hessian
 for a given vector of unconstrained parameters}
 \usage{
-hessian(unconstrained_variables, jacobian_adjustment = TRUE)
+hessian(unconstrained_variables, jacobian = TRUE, jacobian_adjustment = TRUE)
 }
 \arguments{
-\item{unconstrained_variables}{(numeric) A vector of unconstrained parameters
-to be passed to \code{hessian}.}
+\item{unconstrained_variables}{(numeric) A vector of unconstrained parameters.}
 
-\item{jacobian_adjustment}{(logical) Whether to include the log-density
-adjustments from un/constraining variables.}
+\item{jacobian}{(logical) Whether to include the log-density adjustments from
+un/constraining variables.}
+
+\item{jacobian_adjustment}{Deprecated. Please use \code{jacobian} instead.}
 }
 \description{
 The \verb{$hessian()} method provides access to the Stan model's

--- a/man/fit-method-log_prob.Rd
+++ b/man/fit-method-log_prob.Rd
@@ -5,17 +5,19 @@
 \alias{log_prob}
 \title{Calculate the log-probability given a provided vector of unconstrained parameters.}
 \usage{
-log_prob(unconstrained_variables, jacobian_adjustment = TRUE)
+log_prob(unconstrained_variables, jacobian = TRUE, jacobian_adjustment = NULL)
 }
 \arguments{
-\item{unconstrained_variables}{(numeric) A vector of unconstrained parameters
-to be passed to \code{log_prob}.}
+\item{unconstrained_variables}{(numeric) A vector of unconstrained parameters.}
 
-\item{jacobian_adjustment}{(logical) Whether to include the log-density
-adjustments from un/constraining variables.}
+\item{jacobian}{(logical) Whether to include the log-density adjustments from
+un/constraining variables.}
+
+\item{jacobian_adjustment}{Deprecated. Please use \code{jacobian} instead.}
 }
 \description{
-The \verb{$log_prob()} method provides access to the Stan model's \code{log_prob} function
+The \verb{$log_prob()} method provides access to the Stan model's
+\code{log_prob} function.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-model-methods.R
+++ b/tests/testthat/test-model-methods.R
@@ -65,7 +65,7 @@ test_that("Methods return correct values", {
     hessian = as.matrix(-2.4937604019289194568, nrow=1, ncol=1)
   )
 
-  expect_equal(fit$hessian(unconstrained_variables=c(0.1), jacobian_adjustment = FALSE),
+  expect_equal(fit$hessian(unconstrained_variables=c(0.1), jacobian = FALSE),
                hessian_noadj)
 
   cpars <- fit$constrain_variables(c(0.1))


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Closes #877 

Deprecates argument `jacobian_adjustment` in favor of `jacobian` to be consistent with `optimize` and `laplace`. Based on feedback from @avehtari. This affects `log_prob`, `grad_log_prob` and `hessian`. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
