### PR TITLE
fix: #770, get_cmdstan_flags('STANCFLAGS') in recursive make extraneo…

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -678,7 +678,7 @@ get_cmdstan_flags <- function(flag_name) {
   cmdstan_path <- cmdstanr::cmdstan_path()
   flags <- wsl_compatible_run(
     command = "make",
-    args = c("--no-print-directory", paste0("print-", flag_name)),
+    args = c("-s", paste0("print-", flag_name)),
     wd = cmdstan_path
   )$stdout
 

--- a/R/utils.R
+++ b/R/utils.R
@@ -678,7 +678,7 @@ get_cmdstan_flags <- function(flag_name) {
   cmdstan_path <- cmdstanr::cmdstan_path()
   flags <- wsl_compatible_run(
     command = "make",
-    args = c(paste0("print-", flag_name)),
+    args = c("--no-print-directory", paste0("print-", flag_name)),
     wd = cmdstan_path
   )$stdout
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -250,14 +250,11 @@ test_that("as_mcmc.list() works", {
 })
 
 test_that("get_cmdstan_flags() can be used recursively in `make`", {
-  tmp <- withr::local_tempfile()
-  writeLines(
-    "test:\n\t@Rscript --vanilla -e 'cat(cmdstanr:::get_cmdstan_flags(\"STANCFLAGS\"))'",
-    tmp
-  )
+  mkfile <- normalizePath(test_path("testdata", "Makefile"))
   nonrecursive_flags <- get_cmdstan_flags("STANCFLAGS")
-  recursive_flags <- readLines(textConnection(wsl_compatible_run(
-    command = "make", args = c("-f", tmp), wd = cmdstan_path()
-  )$stdout))
+  stdo <- wsl_compatible_run(
+    command = "make", args = sprintf("--file=%s", mkfile), wd = cmdstan_path()
+  )$stdout
+  recursive_flags <- readLines(textConnection(stdo))
   expect_equal(nonrecursive_flags, recursive_flags)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -257,7 +257,7 @@ test_that("get_cmdstan_flags() can be used recursively in `make`", {
   )
   nonrecursive_flags <- get_cmdstan_flags("STANCFLAGS")
   recursive_flags <- readLines(textConnection(wsl_compatible_run(
-    command = "make", args = c("-f", tmp)
+    command = "make", args = c("-f", tmp), wd = cmdstan_path()
   )$stdout))
   expect_equal(nonrecursive_flags, recursive_flags)
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -248,3 +248,16 @@ test_that("as_mcmc.list() works", {
     "Currently only CmdStanMCMC objects can be converted to mcmc.list"
   )
 })
+
+test_that("get_cmdstan_flags() can be used recursively in `make`", {
+  tmp <- withr::local_tempfile()
+  writeLines(
+    "test:\n\t@Rscript --vanilla -e 'cat(cmdstanr:::get_cmdstan_flags(\"STANCFLAGS\"))'",
+    tmp
+  )
+  nonrecursive_flags <- get_cmdstan_flags("STANCFLAGS")
+  recursive_flags <- readLines(textConnection(wsl_compatible_run(
+    command = "make", args = c("-f", tmp)
+  )$stdout))
+  expect_equal(nonrecursive_flags, recursive_flags)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -252,8 +252,8 @@ test_that("as_mcmc.list() works", {
 test_that("get_cmdstan_flags() can be used recursively in `make`", {
   mkfile <- normalizePath(test_path("testdata", "Makefile"))
   nonrecursive_flags <- get_cmdstan_flags("STANCFLAGS")
-  stdo <- wsl_compatible_run(
-    command = "make", args = sprintf("--file=%s", mkfile), wd = cmdstan_path()
+  stdo <- processx::run(
+    command = "make", args = sprintf("--file=%s", mkfile)
   )$stdout
   recursive_flags <- readLines(textConnection(stdo))
   expect_equal(nonrecursive_flags, recursive_flags)

--- a/tests/testthat/testdata/Makefile
+++ b/tests/testthat/testdata/Makefile
@@ -1,0 +1,3 @@
+
+test:
+	@$(R_HOME)/bin/Rscript --vanilla -e 'cat(cmdstanr:::get_cmdstan_flags("STANCFLAGS"))'


### PR DESCRIPTION
Fix #770 by invoking `make` with `-s` argument.

#### Submission Checklist

- [X] Run unit tests
- [X] Declare copyright holder and agree to license (see below)

#### Summary

This PR addresses issue #770. The problem highlighted in that issue is that recursive calls to `make` can generate messages on stdout. Since `cmdstanr` parses `make`-generated stdout to ascertain certain configuration info (e.g. in `get_cmdstan_flags()`), this poses a problem. Since `make` is also a useful tool for research work generally, recursive calls are a practical consideration.

The change here has `get_cmdstan_flags()` invoke `make` in silent mode (`-s`), which means only the explicitly requested print-information is returned. I initially proposed `--no-print-directory` as the solution, but that is apparently a gnumake-specific flag.

N.b. this is the same fix @bbolker proposed (which I saw when looking for an existing issue after I'd fixed this locally, so ... yeah, should have read first then coded).

~~This should probably come with a unit test, but I'm uncertain on the best formulation of such test.~~

I have added a unit test which:
 - creates a temporary makefile with a target that sends `get_cmdstan_flags()` output to stdout
 - invokes that makefile (using cmdstanr infrastructure) ,
 - captures the output and compares it to the output of invoking `get_cmdstan_flags()` directly.
 
 I confirmed (on Ubuntu 22 only) this fails against 357a07, but passes with this modification.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**London School of Hygiene & Tropical Medicine**

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
