### PR TITLE
Allow latest version check to take retries arg

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -398,10 +398,10 @@ github_download_url <- function(version_number) {
 }
 
 # get version number of latest release
-latest_released_version <- function(quiet=TRUE) {
+latest_released_version <- function(quiet=TRUE, ...) {
   dest_file <- tempfile(pattern = "releases-", fileext = ".json")
   download_url <- "https://api.github.com/repos/stan-dev/cmdstan/releases/latest"
-  release_list_downloaded <- download_with_retries(download_url, dest_file, quiet = quiet)
+  release_list_downloaded <- download_with_retries(download_url, dest_file, quiet = quiet, ...)
   if (inherits(release_list_downloaded, "try-error")) {
     stop("GitHub download of release list failed with error: ",
         attr(release_list_downloaded, "condition")$message,

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -14,7 +14,7 @@ startup_messages <- function() {
     default = identical(tolower(Sys.getenv("CMDSTANR_NO_VER_CHECK")), "true")
   ))
   if (!skip_version_check) {
-    latest_version <- try(suppressWarnings(latest_released_version()), silent = TRUE)
+    latest_version <- try(suppressWarnings(latest_released_version(retries = 0)), silent = TRUE)
     current_version <- try(cmdstan_version(), silent = TRUE)
     if (!inherits(latest_version, "try-error")
         && !inherits(current_version, "try-error")


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Addresses #889

Allows the `latest_released_version()` function to pass-through arguments to the `download_with_retries()` function. This is to avoid the latest version check from retrying 5 times on package load when the user does not have internet access (or a similar firewall issue)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
