### PR TITLE
Align ebfmi threshold with cmdstan

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -321,7 +321,7 @@ ebfmi <- function(post_warmup_sampler_diagnostics) {
   efbmi_per_chain
 }
 
-check_ebfmi <- function(post_warmup_sampler_diagnostics, threshold = 0.2) {
+check_ebfmi <- function(post_warmup_sampler_diagnostics, threshold = 0.3) {
   efbmi_per_chain <- ebfmi(post_warmup_sampler_diagnostics)
   nan_efbmi_count <- sum(is.nan(efbmi_per_chain))
   efbmi_below_threshold <- sum(efbmi_per_chain < threshold)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The `cmdstanr` diagnostic threshold for low E-BFMI is 0.2, while the [cmdstan threshold is 0.3](https://github.com/stan-dev/cmdstan/blob/430e382e776f5043efdc869fefccef3179ba778e/src/cmdstan/diagnose.cpp#L153)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
