### PR TITLE
Drop RcppEigen dependency, implement basic Eigen -> C++ interop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,7 +29,7 @@ URL: https://mc-stan.org/cmdstanr/, https://discourse.mc-stan.org
 BugReports: https://github.com/stan-dev/cmdstanr/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.0
 Roxygen: list(markdown = TRUE, r6 = FALSE)
 SystemRequirements: CmdStan (https://mc-stan.org/users/interfaces/cmdstan)
 Depends:
@@ -50,6 +50,5 @@ Suggests:
     loo (>= 2.0.0),
     rmarkdown,
     testthat (>= 2.1.0),
-    Rcpp,
-    RcppEigen
+    Rcpp
 VignetteBuilder: knitr

--- a/R/fit.R
+++ b/R/fit.R
@@ -312,8 +312,8 @@ CmdStanFit$set("public", name = "init", value = init)
 #' @description The `$init_model_methods()` method compiles and initializes the
 #'   `log_prob`, `grad_log_prob`, `constrain_variables`, `unconstrain_variables`
 #'   and `unconstrain_draws` functions. These are then available as methods of
-#'   the fitted model object. This requires the additional `Rcpp` and
-#'   `RcppEigen` packages, which are not required for fitting models using
+#'   the fitted model object. This requires the additional `Rcpp` package, 
+#'   which are not required for fitting models using
 #'   CmdStanR.
 #'
 #'   Note: there may be many compiler warnings emitted during compilation but
@@ -339,7 +339,6 @@ init_model_methods <- function(seed = 0, verbose = FALSE, hessian = FALSE) {
           call. = FALSE)
   }
   require_suggested_package("Rcpp")
-  require_suggested_package("RcppEigen")
   if (length(private$model_methods_env_$hpp_code_) == 0) {
     stop("Model methods cannot be used with a pre-compiled Stan executable, ",
           "the model must be compiled again", call. = FALSE)

--- a/R/utils.R
+++ b/R/utils.R
@@ -928,8 +928,7 @@ compile_functions <- function(env, verbose = FALSE, global = FALSE) {
   mod_stan_funs <- paste(c(
     env$hpp_code[1:(funs[1] - 1)],
     "#include <rcpp_tuple_interop.hpp>",
-    "#include <RcppEigen.h>",
-    "// [[Rcpp::depends(RcppEigen)]]",
+    "#include <rcpp_eigen_interop.h>",
     stan_funs),
   collapse = "\n")
   if (global) {
@@ -980,7 +979,6 @@ expose_stan_functions <- function(function_env, global = FALSE, verbose = FALSE)
          call. = FALSE)
   }
   require_suggested_package("Rcpp")
-  require_suggested_package("RcppEigen")
   if (function_env$compiled) {
     if (!global) {
       message("Functions already compiled, nothing to do!")

--- a/R/utils.R
+++ b/R/utils.R
@@ -928,7 +928,7 @@ compile_functions <- function(env, verbose = FALSE, global = FALSE) {
   mod_stan_funs <- paste(c(
     env$hpp_code[1:(funs[1] - 1)],
     "#include <rcpp_tuple_interop.hpp>",
-    "#include <rcpp_eigen_interop.h>",
+    "#include <rcpp_eigen_interop.hpp>",
     stan_funs),
   collapse = "\n")
   if (global) {

--- a/inst/include/hessian.cpp
+++ b/inst/include/hessian.cpp
@@ -1,7 +1,5 @@
-#include <RcppEigen.h>
+#include <rcpp_eigen_interop.hpp>
 #include <stan/model/hessian.hpp>
-
-// [[Rcpp::depends(RcppEigen)]]
 
 template <class M>
 struct hessian_wrapper {

--- a/inst/include/rcpp_eigen_interop.hpp
+++ b/inst/include/rcpp_eigen_interop.hpp
@@ -25,12 +25,12 @@ namespace Rcpp {
           Rcpp::internal::export_indexing<Eigen::Matrix<T, R, 1>, T>(object, result);
           return result;
         } else {
-          Shield<SEXP> dims( ::Rf_getAttrib( object, R_DimSymbol ) );
-          if( Rf_isNull(dims) || Rf_length(dims) != 2 ){
-              throw ::Rcpp::not_a_matrix();
+          Shield<SEXP> dims(Rf_getAttrib(object, R_DimSymbol));
+          if (Rf_isNull(dims) || Rf_length(dims) != 2) {
+            throw Rcpp::not_a_matrix();
           }
           int* dims_ = INTEGER(dims);
-          Eigen::Matrix<T, R, C> result(dims_[0],dims_[1]);
+          Eigen::Matrix<T, R, C> result(dims_[0], dims_[1]);
           T* result_data = result.data();
           Rcpp::internal::export_indexing<T*, T>(object, result_data);
           return result;
@@ -44,7 +44,7 @@ namespace Rcpp {
   namespace RcppEigen {
     template <typename T>
     SEXP eigen_wrap(const T& x) {
-      const static int RTYPE = ::Rcpp::traits::r_sexptype_traits<stan::scalar_type_t<T>>::rtype;
+      const static int RTYPE = Rcpp::traits::r_sexptype_traits<stan::scalar_type_t<T>>::rtype;
       Rcpp::Vector<RTYPE> vec_rtn(Rcpp::wrap(stan::math::to_array_1d(x)));
       if (x.cols() > 1) {
         vec_rtn.attr("dim") = Rcpp::Dimension(x.rows(), x.cols());

--- a/inst/include/rcpp_eigen_interop.hpp
+++ b/inst/include/rcpp_eigen_interop.hpp
@@ -46,7 +46,7 @@ namespace Rcpp {
     SEXP eigen_wrap(const T& x) {
       const static int RTYPE = Rcpp::traits::r_sexptype_traits<stan::scalar_type_t<T>>::rtype;
       Rcpp::Vector<RTYPE> vec_rtn(Rcpp::wrap(stan::math::to_array_1d(x)));
-      if (x.cols() > 1) {
+      if (!stan::is_eigen_col_vector<T>::value) {
         vec_rtn.attr("dim") = Rcpp::Dimension(x.rows(), x.cols());
       }
       return vec_rtn;

--- a/inst/include/rcpp_eigen_interop.hpp
+++ b/inst/include/rcpp_eigen_interop.hpp
@@ -1,0 +1,42 @@
+#ifndef CMDSTANR_RCPP_EIGEN_INTEROP_HPP
+#define CMDSTANR_RCPP_EIGEN_INTEROP_HPP
+
+#include <stan/math/prim/fun/to_array_1d.hpp>
+#include <Rcpp.h>
+
+namespace Rcpp {
+  namespace traits {
+    template <typename T, int R, int C>
+    class Exporter<Eigen::Matrix<T, R, C>> {
+      private:
+        Rcpp::NumericVector vec_x;
+      public:
+        Exporter(SEXP x) : vec_x(x) { }
+        Eigen::Matrix<T, R, C> get() {
+          if (R == 1) {
+            return Eigen::Map<Eigen::RowVectorXd>(vec_x.begin(), vec_x.size());
+          } else if (C == 1) {
+            return Eigen::Map<Eigen::VectorXd>(vec_x.begin(), vec_x.size());
+          } else {
+            Rcpp::Dimension vec_dims(vec_x.attr("dim"));
+            return Eigen::Map<Eigen::Matrix<T, R, C>>(vec_x.begin(), vec_dims[0], vec_dims[1]);
+          }
+        }
+    };
+  } // traits
+
+  // Rcpp is hardcoded to assume that Eigen types will be wrapped using the
+  //   eigen_wrap function in the RcppEigen package
+  namespace RcppEigen {
+    template <typename T>
+    SEXP eigen_wrap(const T& x) {
+      Rcpp::NumericVector vec_rtn(Rcpp::wrap(stan::math::to_array_1d(x)));
+      if (x.cols() > 1) {
+        vec_rtn.attr("dim") = Rcpp::Dimension(x.rows(), x.cols());
+      }
+      return vec_rtn;
+    }
+  } // RcppEigen
+} // Rcpp
+
+#endif

--- a/inst/include/rcpp_eigen_interop.hpp
+++ b/inst/include/rcpp_eigen_interop.hpp
@@ -8,20 +8,33 @@ namespace Rcpp {
   namespace traits {
     template <typename T, int R, int C>
     class Exporter<Eigen::Matrix<T, R, C>> {
-      private:
-        Rcpp::NumericVector vec_x;
-      public:
-        Exporter(SEXP x) : vec_x(x) { }
-        Eigen::Matrix<T, R, C> get() {
-          if (R == 1) {
-            return Eigen::Map<Eigen::RowVectorXd>(vec_x.begin(), vec_x.size());
-          } else if (C == 1) {
-            return Eigen::Map<Eigen::VectorXd>(vec_x.begin(), vec_x.size());
-          } else {
-            Rcpp::Dimension vec_dims(vec_x.attr("dim"));
-            return Eigen::Map<Eigen::Matrix<T, R, C>>(vec_x.begin(), vec_dims[0], vec_dims[1]);
+    private:
+        SEXP object;
+    public:
+      Exporter(SEXP x) : object(x){}
+      ~Exporter(){}
+
+      Eigen::Matrix<T, R, C> get() {
+        if (R == 1) {
+          Eigen::Matrix<T, 1, C> result(::Rf_length(object));
+          ::Rcpp::internal::export_indexing<Eigen::Matrix<T, 1, C>, T>(object, result);
+          return result ;
+        } else if (C == 1) {
+          Eigen::Matrix<T, R, 1> result(::Rf_length(object));
+          ::Rcpp::internal::export_indexing<Eigen::Matrix<T, R, 1>, T>(object, result);
+          return result ;
+        } else {
+          Shield<SEXP> dims( ::Rf_getAttrib( object, R_DimSymbol ) );
+          if( Rf_isNull(dims) || ::Rf_length(dims) != 2 ){
+              throw ::Rcpp::not_a_matrix();
           }
+          int* dims_ = INTEGER(dims);
+          Eigen::Matrix<T, R, C> result(dims_[0],dims_[1]);
+          T* result_data = result.data();
+          ::Rcpp::internal::export_indexing<T*, T>( object, result_data);
+          return result ;
         }
+      }
     };
   } // traits
 
@@ -30,7 +43,8 @@ namespace Rcpp {
   namespace RcppEigen {
     template <typename T>
     SEXP eigen_wrap(const T& x) {
-      Rcpp::NumericVector vec_rtn(Rcpp::wrap(stan::math::to_array_1d(x)));
+      const static int RTYPE = ::Rcpp::traits::r_sexptype_traits<stan::scalar_type_t<T>>::rtype;
+      Rcpp::Vector<RTYPE> vec_rtn(Rcpp::wrap(stan::math::to_array_1d(x)));
       if (x.cols() > 1) {
         vec_rtn.attr("dim") = Rcpp::Dimension(x.rows(), x.cols());
       }

--- a/inst/include/rcpp_eigen_interop.hpp
+++ b/inst/include/rcpp_eigen_interop.hpp
@@ -14,25 +14,26 @@ namespace Rcpp {
       Exporter(SEXP x) : object(x){}
       ~Exporter(){}
 
+      // Adapted from Rcpp/internal/Exporter.h
       Eigen::Matrix<T, R, C> get() {
         if (R == 1) {
-          Eigen::Matrix<T, 1, C> result(::Rf_length(object));
-          ::Rcpp::internal::export_indexing<Eigen::Matrix<T, 1, C>, T>(object, result);
-          return result ;
+          Eigen::Matrix<T, 1, C> result(Rf_length(object));
+          Rcpp::internal::export_indexing<Eigen::Matrix<T, 1, C>, T>(object, result);
+          return result;
         } else if (C == 1) {
-          Eigen::Matrix<T, R, 1> result(::Rf_length(object));
-          ::Rcpp::internal::export_indexing<Eigen::Matrix<T, R, 1>, T>(object, result);
-          return result ;
+          Eigen::Matrix<T, R, 1> result(Rf_length(object));
+          Rcpp::internal::export_indexing<Eigen::Matrix<T, R, 1>, T>(object, result);
+          return result;
         } else {
           Shield<SEXP> dims( ::Rf_getAttrib( object, R_DimSymbol ) );
-          if( Rf_isNull(dims) || ::Rf_length(dims) != 2 ){
+          if( Rf_isNull(dims) || Rf_length(dims) != 2 ){
               throw ::Rcpp::not_a_matrix();
           }
           int* dims_ = INTEGER(dims);
           Eigen::Matrix<T, R, C> result(dims_[0],dims_[1]);
           T* result_data = result.data();
-          ::Rcpp::internal::export_indexing<T*, T>( object, result_data);
-          return result ;
+          Rcpp::internal::export_indexing<T*, T>(object, result_data);
+          return result;
         }
       }
     };

--- a/man/cmdstanr-package.Rd
+++ b/man/cmdstanr-package.Rd
@@ -198,4 +198,34 @@ The Stan and CmdStan documentation:
 \item Stan documentation: \href{https://mc-stan.org/users/documentation/}{mc-stan.org/users/documentation}
 \item CmdStan User’s Guide: \href{https://mc-stan.org/docs/cmdstan-guide/}{mc-stan.org/docs/cmdstan-guide}
 }
+
+Useful links:
+\itemize{
+  \item \url{https://mc-stan.org/cmdstanr/}
+  \item \url{https://discourse.mc-stan.org}
+  \item Report bugs at \url{https://github.com/stan-dev/cmdstanr/issues}
+}
+
+}
+\author{
+\strong{Maintainer}: Jonah Gabry \email{jsg2201@columbia.edu}
+
+Authors:
+\itemize{
+  \item Rok Češnovar \email{rok.cesnovar@fri.uni-lj.si}
+  \item Andrew Johnson (\href{https://orcid.org/0000-0001-7000-8065}{ORCID})
+}
+
+Other contributors:
+\itemize{
+  \item Ben Bales [contributor]
+  \item Mitzi Morris [contributor]
+  \item Mikhail Popov [contributor]
+  \item Mike Lawrence [contributor]
+  \item William Michael Landau \email{will.landau@gmail.com} (\href{https://orcid.org/0000-0003-1878-3253}{ORCID}) [contributor]
+  \item Jacob Socolar [contributor]
+  \item Martin Modrák [contributor]
+  \item Steve Bronder [contributor]
+}
+
 }

--- a/man/fit-method-init_model_methods.Rd
+++ b/man/fit-method-init_model_methods.Rd
@@ -19,8 +19,8 @@ init_model_methods(seed = 0, verbose = FALSE, hessian = FALSE)
 The \verb{$init_model_methods()} method compiles and initializes the
 \code{log_prob}, \code{grad_log_prob}, \code{constrain_variables}, \code{unconstrain_variables}
 and \code{unconstrain_draws} functions. These are then available as methods of
-the fitted model object. This requires the additional \code{Rcpp} and
-\code{RcppEigen} packages, which are not required for fitting models using
+the fitted model object. This requires the additional \code{Rcpp} package,
+which are not required for fitting models using
 CmdStanR.
 
 Note: there may be many compiler warnings emitted during compilation but


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

We currently have `RcppEigen` as a `suggests` for use with the model methods and function exports. However, given that we already have the Eigen headers in the cmdstan install, we only need the methods for converting between R and C++ Eigen types. 

Since only a reduced subset of Eigen types are exposed via Stan (`Eigen::Matrix<>`), this is fairly simple to to handle ourselves.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
