### PR TITLE
Global option for turning off warning for partial initial values

### DIFF
--- a/R/args.R
+++ b/R/args.R
@@ -1054,7 +1054,7 @@ process_init_list <- function(init, num_procs, model_variables = NULL,
     }
     if (length(missing_parameter_values) > 0 && isTRUE(warn_partial)) {
       warning_message <- c(
-        "Init values were only set for a subset of parameters. ","\nMissing init values for the following parameters:\n"
+        "Init values were only set for a subset of parameters. \nMissing init values for the following parameters:\n"
       )
       for (i in seq_along(missing_parameter_values)) {
         if (length(init) > 1) {

--- a/R/args.R
+++ b/R/args.R
@@ -1021,8 +1021,12 @@ validate_exe_file <- function(exe_file) {
 #' @param num_procs Number of CmdStan processes.
 #' @param model_variables  A list of all parameters with their types and
 #'   number of dimensions. Typically the output of model$variables().
+#' @param warn_partial Should a warning be thrown if inits are only specified
+#'   for a subset of parameters? Can be controlled by global option
+#'   `cmdstanr_warn_inits`.
 #' @return A character vector of file paths.
-process_init_list <- function(init, num_procs, model_variables = NULL) {
+process_init_list <- function(init, num_procs, model_variables = NULL,
+                              warn_partial = getOption("cmdstanr_warn_inits", TRUE)) {
   if (!all(sapply(init, function(x) is.list(x) && !is.data.frame(x)))) {
     stop("If 'init' is a list it must be a list of lists.", call. = FALSE)
   }
@@ -1048,9 +1052,9 @@ process_init_list <- function(init, num_procs, model_variables = NULL) {
         }
       }
     }
-    if (length(missing_parameter_values) > 0) {
+    if (length(missing_parameter_values) > 0 && isTRUE(warn_partial)) {
       warning_message <- c(
-        "Init values were only set for a subset of parameters. \nMissing init values for the following parameters:\n"
+        "Init values were only set for a subset of parameters. ","\nMissing init values for the following parameters:\n"
       )
       for (i in seq_along(missing_parameter_values)) {
         if (length(init) > 1) {
@@ -1062,6 +1066,7 @@ process_init_list <- function(init, num_procs, model_variables = NULL) {
           warning_message <- c(warning_message, paste0(line_text, paste0(missing_parameter_values[[i]], collapse = ", "), "\n"))
         }
       }
+      warning_message <- c(warning_message, "\nTo disable this message use options(cmdstanr_warn_inits = FALSE).\n")
       message(warning_message)
     }
   }

--- a/tests/testthat/test-model-init.R
+++ b/tests/testthat/test-model-init.R
@@ -240,6 +240,7 @@ test_that("error if init function specified incorrectly", {
 })
 
 test_that("print message if not all parameters are initialized", {
+  options(cmdstanr_warn_inits = NULL) # should default to TRUE
   init_list <- list(
     list(
       alpha = 1
@@ -269,6 +270,23 @@ test_that("print message if not all parameters are initialized", {
     "- chain 2: alpha, beta",
     fixed = TRUE
   )
+})
+
+test_that("No message printed if options(cmdstanr_warn_inits=FALSE)", {
+  options(cmdstanr_warn_inits = FALSE)
+  expect_message(
+    utils::capture.output(mod_logistic$optimize(data = data_list_logistic, init = list(list(a = 0)), seed = 123)),
+    regexp = NA
+  )
+  expect_message(
+    utils::capture.output(mod_logistic$optimize(data = data_list_logistic, init = list(list(alpha = 1)), seed = 123)),
+    regexp = NA
+  )
+  expect_message(
+    utils::capture.output(mod_logistic$sample(data = data_list_logistic, init = list(list(alpha = 1),list(alpha = 1)), chains = 2, seed = 123)),
+    regexp = NA
+  )
+  options(cmdstanr_warn_inits = TRUE)
 })
 
 test_that("Initial values for single-element containers treated correctly", {


### PR DESCRIPTION
closes #912

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Adds a global option to turn off warning about partial initial value specification. When `options(cmdstanr_warn_inits=TRUE)` (the default) the warning message now looks like this, with a new line about disabling the warning: 

```
Init values were only set for a subset of parameters. 
Missing init values for the following parameters:
alpha, beta

To disable this message use options(cmdstanr_warn_inits = FALSE).
```

When `options(cmdstanr_warn_inits=FALSE)` there is now no message at all. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
