### PR TITLE
FreeBSD support

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -54,6 +54,10 @@ os_is_linux <- function() {
   isTRUE(Sys.info()[["sysname"]] == "Linux")
 }
 
+os_is_freebsd <- function() {
+  isTRUE(Sys.info()[["sysname"]] == "FreeBSD")
+}
+
 is_rtools43_toolchain <- function() {
   os_is_windows() && R.version$major == "4" && R.version$minor >= "3.0"
 }
@@ -87,6 +91,8 @@ is_rosetta2 <- function() {
 make_cmd <- function() {
   if (os_is_windows() && !os_is_wsl()) {
     "mingw32-make.exe"
+  } else if (os_is_freebsd()) {
+    "gmake"
   } else {
     "make"
   }
@@ -677,7 +683,7 @@ assert_file_exists <- checkmate::makeAssertionFunction(check_file_exists)
 get_cmdstan_flags <- function(flag_name) {
   cmdstan_path <- cmdstanr::cmdstan_path()
   flags <- wsl_compatible_run(
-    command = "make",
+    command = make_cmd(),
     args = c("-s", paste0("print-", flag_name)),
     wd = cmdstan_path
   )$stdout


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [X] Declare copyright holder and agree to license (see below)

#### Summary

The make command on FreeBSD is BSD make.
`gmake` should be called instead of `make`.

* Add a function to detect FreeBSD.
* Modify `make_cmd()` to return `gmake` on FreeBSD.
* replace hard coded `make` to `make_cmd()`.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Takeshi Enomoto


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
