### PR TITLE
Fix incorrect format of inv_metric when only 1 parameter in model

### DIFF
--- a/R/args.R
+++ b/R/args.R
@@ -254,6 +254,9 @@ SampleArgs <- R6::R6Class(
             fileext = ".json"
           )
         for (i in seq_along(inv_metric_paths)) {
+          if (length(inv_metric[[i]] == 1) && metric == "diag_e") {
+            inv_metric[[i]] <- array(inv_metric[[i]], dim = c(1))
+          }
           write_stan_json(list(inv_metric = inv_metric[[i]]), inv_metric_paths[i])
         }
 

--- a/R/args.R
+++ b/R/args.R
@@ -254,7 +254,7 @@ SampleArgs <- R6::R6Class(
             fileext = ".json"
           )
         for (i in seq_along(inv_metric_paths)) {
-          if (length(inv_metric[[i]] == 1) && metric == "diag_e") {
+          if (length(inv_metric[[i]]) == 1 && metric == "diag_e") {
             inv_metric[[i]] <- array(inv_metric[[i]], dim = c(1))
           }
           write_stan_json(list(inv_metric = inv_metric[[i]]), inv_metric_paths[i])

--- a/R/fit.R
+++ b/R/fit.R
@@ -1743,6 +1743,9 @@ inv_metric <- function(matrix = TRUE) {
   if (matrix && !is.matrix(out[[1]])) {
     # convert each vector to a diagonal matrix
     out <- lapply(out, diag)
+  } else if (length(out[[1]]) == 1) {
+    # convert each scalar to a 1x1 matrix
+    out <- lapply(out, array, dim = c(1))
   }
   out
 }

--- a/R/fit.R
+++ b/R/fit.R
@@ -1742,9 +1742,9 @@ inv_metric <- function(matrix = TRUE) {
   out <- private$inv_metric_
   if (matrix && !is.matrix(out[[1]])) {
     # convert each vector to a diagonal matrix
-    out <- lapply(out, diag)
+    out <- lapply(out, function(x) diag(x, nrow = length(x)))
   } else if (length(out[[1]]) == 1) {
-    # convert each scalar to a 1x1 matrix
+    # convert each scalar to an array with dimension 1
     out <- lapply(out, array, dim = c(1))
   }
   out

--- a/tests/testthat/test-model-sample-metric.R
+++ b/tests/testthat/test-model-sample-metric.R
@@ -4,6 +4,9 @@ set_cmdstan_path()
 mod <- testing_model("bernoulli")
 data_list <- testing_data("bernoulli")
 
+mod2 <- testing_model("logistic")
+data_list2 <- testing_data("logistic")
+
 
 test_that("sample() method works with provided inv_metrics", {
   inv_metric_vector <- array(1, dim = c(1))
@@ -54,7 +57,7 @@ test_that("sample() method works with provided inv_metrics", {
 })
 
 
-test_that("sample() method works with inv_metrics extracted from previous fit", {
+test_that("sample() method works with inv_metrics extracted from previous fit with 1 parameter", {
   expect_sample_output(fit_r <- mod$sample(data = data_list,
                                            chains = 2,
                                            seed = 123))
@@ -87,6 +90,41 @@ test_that("sample() method works with inv_metrics extracted from previous fit", 
                                            metric = "dense_e",
                                            inv_metric = inv_metric_matrix,
                                            seed = 123)))
+})
+
+test_that("sample() method works with inv_metrics extracted from previous fit with > 1 parameter", {
+  expect_sample_output(fit_r <- mod2$sample(data = data_list2,
+                                            chains = 2,
+                                            seed = 123))
+  inv_metric_vector <- fit_r$inv_metric(matrix = FALSE)
+  inv_metric_matrix <- fit_r$inv_metric()
+
+  expect_equal(length(inv_metric_vector[[1]]), 4)
+  expect_equal(dim(inv_metric_matrix[[1]]), c(4, 4))
+
+  expect_silent(expect_sample_output(fit_r <- mod2$sample(data = data_list2,
+                                                         chains = 1,
+                                                         metric = "diag_e",
+                                                         inv_metric = inv_metric_vector[[1]],
+                                                         seed = 123)))
+
+  expect_silent(expect_sample_output(fit_r <- mod2$sample(data = data_list2,
+                                                         chains = 1,
+                                                         metric = "dense_e",
+                                                         inv_metric = inv_metric_matrix[[1]],
+                                                         seed = 123)))
+
+  expect_silent(expect_sample_output(fit_r <- mod2$sample(data = data_list2,
+                                                         chains = 2,
+                                                         metric = "diag_e",
+                                                         inv_metric = inv_metric_vector,
+                                                         seed = 123)))
+
+  expect_silent(expect_sample_output(fit_r <- mod2$sample(data = data_list2,
+                                                         chains = 2,
+                                                         metric = "dense_e",
+                                                         inv_metric = inv_metric_matrix,
+                                                         seed = 123)))
 })
 
 

--- a/tests/testthat/test-model-sample-metric.R
+++ b/tests/testthat/test-model-sample-metric.R
@@ -54,6 +54,42 @@ test_that("sample() method works with provided inv_metrics", {
 })
 
 
+test_that("sample() method works with inv_metrics extracted from previous fit", {
+  expect_sample_output(fit_r <- mod$sample(data = data_list,
+                                           chains = 2,
+                                           seed = 123))
+  inv_metric_vector <- fit_r$inv_metric(matrix = FALSE)
+  inv_metric_matrix <- fit_r$inv_metric()
+
+  expect_equal(dim(inv_metric_vector[[1]]), 1)
+  expect_equal(dim(inv_metric_matrix[[1]]), c(1, 1))
+
+  expect_silent(expect_sample_output(fit_r <- mod$sample(data = data_list,
+                                           chains = 1,
+                                           metric = "diag_e",
+                                           inv_metric = inv_metric_vector[[1]],
+                                           seed = 123)))
+
+  expect_silent(expect_sample_output(fit_r <- mod$sample(data = data_list,
+                                           chains = 1,
+                                           metric = "dense_e",
+                                           inv_metric = inv_metric_matrix[[1]],
+                                           seed = 123)))
+
+  expect_silent(expect_sample_output(fit_r <- mod$sample(data = data_list,
+                                           chains = 2,
+                                           metric = "diag_e",
+                                           inv_metric = inv_metric_vector,
+                                           seed = 123)))
+
+  expect_silent(expect_sample_output(fit_r <- mod$sample(data = data_list,
+                                           chains = 2,
+                                           metric = "dense_e",
+                                           inv_metric = inv_metric_matrix,
+                                           seed = 123)))
+})
+
+
 test_that("sample() method works with lists of inv_metrics", {
   inv_metric_vector <- array(1, dim = c(1))
   inv_metric_vector_json <- test_path("resources", "metric", "bernoulli.inv_metric.diag_e.json")


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests
- [X] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #934. Now it checks in inv_matrix() function whether the input is a scalar for each chain, and if so, makes it an array with dimension 1. It also corrects the behavior of diag() when matrix=TRUE, which previously produced an empty matrix with a scalar inv_metric.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Vencislav Popov**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
