### PR TITLE
Don't test on R 3.6 anymore

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -31,7 +31,6 @@ jobs:
           - {os: ubuntu-20.04, r: 'devel', rtools: ''}
           - {os: ubuntu-20.04, r: 'release', rtools: ''}
           - {os: ubuntu-20.04, r: 'oldrel', rtools: ''}
-          - {os: ubuntu-20.04, r: '3.6', rtools: ''}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}

--- a/tests/testthat/test-fit-mle.R
+++ b/tests/testthat/test-fit-mle.R
@@ -52,7 +52,10 @@ test_that("time is reported after optimization", {
 })
 
 test_that("no error when checking estimates after failure", {
-  fit <- cmdstanr_example("schools", method = "optimize", seed = 123) # optim ålways fails for this
+  expect_warning(
+    fit <- cmdstanr_example("schools", method = "optimize", seed = 123), # optim ålways fails for this
+    "Fitting finished unexpectedly"
+  )
   expect_error(fit$summary(), "Fitting failed. Unable to retrieve the draws.")
 })
 

--- a/tests/testthat/test-fit-shared.R
+++ b/tests/testthat/test-fit-shared.R
@@ -216,7 +216,10 @@ test_that("return_codes method works properly", {
   expect_equal(fits[["generate_quantities"]]$return_codes(), c(0,0,0,0))
 
   # non-zero
-  non_zero <- testing_fit("schools", method = "optimize", seed = 123)
+  expect_warning(
+    non_zero <- testing_fit("schools", method = "optimize", seed = 123),
+    "Fitting finished unexpectedly"
+  )
   expect_gt(non_zero$return_codes(), 0)
 })
 

--- a/tests/testthat/test-model-laplace.R
+++ b/tests/testthat/test-model-laplace.R
@@ -54,7 +54,7 @@ test_that("laplace() runs when all arguments specified validly", {
   expect_equal(fit1$metadata()$draws, as.integer(ok_arg_values$draws))
   expect_equal(fit1$mode()$metadata()$jacobian, as.integer(ok_arg_values$jacobian))
   expect_equal(fit1$mode()$metadata()$init_alpha, ok_arg_values$opt_args$init_alpha)
-  
+
   expect_equal(fit1$mode()$metadata()$tol_obj, ok_arg_values$opt_args$tol_obj, tolerance = 0)
 
   # leaving all at default (except 'data')
@@ -121,11 +121,13 @@ test_that("laplace() errors with bad combinations of arguments", {
 test_that("laplace() errors if optimize() fails", {
   mod_schools <- testing_model("schools")
   expect_error(
-    expect_message(
-      mod_schools$laplace(data = testing_data("schools"), refresh = 0),
-      "Line search failed to achieve a sufficient decrease"
+    expect_warning(
+      expect_message(
+        mod_schools$laplace(data = testing_data("schools"), refresh = 0),
+        "Line search failed to achieve a sufficient decrease"
+      ),
+      "Fitting finished unexpectedly"
     ),
     "Optimization failed"
   )
-
 })

--- a/tests/testthat/test-model-methods.R
+++ b/tests/testthat/test-model-methods.R
@@ -300,7 +300,7 @@ test_that("Variable skeleton returns correct dimensions for matrices", {
   N <- 4
   K <- 3
   fit <- mod$sample(data = list(N = N, K = K), chains = 1,
-                    iter_warmup = 1, iter_sampling = 1)
+                    iter_warmup = 1, iter_sampling = 5)
 
   target_skeleton <- list(
     x_real = array(0, dim = 1),

--- a/tests/testthat/test-model-sample.R
+++ b/tests/testthat/test-model-sample.R
@@ -246,7 +246,7 @@ test_that("print statements in transformed data work", {
   }'
   ))
 
-  out <- capture.output(fit <- mod$sample(iter_warmup = 1, iter_sampling = 1, chains = 1))
+  out <- capture.output(fit <- mod$sample(iter_warmup = 1, iter_sampling = 5, chains = 1))
   expect_true(any(grepl("*N = 2*", out)))
 })
 
@@ -276,7 +276,7 @@ test_that("seed works for multi chain sampling", {
   f <- write_stan_file(m, basename = "rngs.stan")
   mod <- cmdstan_model(f)
   utils::capture.output(
-    fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100, seed = 2)
+    fit_sample <- mod$sample(chains = 2, iter_sampling = 5, iter_warmup = 100, seed = 2)
   )
   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)
   chain_tdata_2 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 2)
@@ -286,7 +286,7 @@ test_that("seed works for multi chain sampling", {
   expect_false(all(chain_tdata_1 == chain_tdata_2))
 
   utils::capture.output(
-    fit_sample <- mod$sample(chains = 2, iter_sampling = 1, iter_warmup = 100,
+    fit_sample <- mod$sample(chains = 2, iter_sampling = 5, iter_warmup = 100,
                              seed = c(1, 2))
   )
   chain_tdata_1 <- posterior::subset_draws(fit_sample$draws("tdata"), chain = 1)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Removes R version 3.6 from Github Actions checks since we will now require at least R 4.0 with future versions of CmdStanR. 

I also updated few tests to get rid of some warnings in the testthat output. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
