### PR TITLE
Make exported RNG functions respect changes to R's seed

### DIFF
--- a/inst/include/stan_rng.hpp
+++ b/inst/include/stan_rng.hpp
@@ -15,13 +15,4 @@ namespace stan {
 }
 #endif
 
-// To ensure that exported RNG functions respect changes to R's RNG state,
-// we need to deterministically set the seed of the RNG used by the exported
-// functions.
-int get_seed() {
-  Rcpp::Environment pkg = Rcpp::Environment::namespace_env("cmdstanr");
-  Rcpp::Function f = pkg["get_seed"];
-  return Rcpp::as<int>(f());
-}
-
 #endif

--- a/inst/include/stan_rng.hpp
+++ b/inst/include/stan_rng.hpp
@@ -3,7 +3,6 @@
 
 #include <boost/random/additive_combine.hpp>
 #include <stan/version.hpp>
-#include <Rcpp.h>
 
 // A consistent rng_t is defined from 2.35 onwards
 // so add a fallback for older versions

--- a/inst/include/stan_rng.hpp
+++ b/inst/include/stan_rng.hpp
@@ -3,6 +3,7 @@
 
 #include <boost/random/additive_combine.hpp>
 #include <stan/version.hpp>
+#include <Rcpp.h>
 
 // A consistent rng_t is defined from 2.35 onwards
 // so add a fallback for older versions
@@ -13,5 +14,14 @@ namespace stan {
   using rng_t = boost::ecuyer1988;
 }
 #endif
+
+// To ensure that exported RNG functions respect changes to R's RNG state,
+// we need to deterministically set the seed of the RNG used by the exported
+// functions.
+int get_seed() {
+  Rcpp::Environment pkg = Rcpp::Environment::namespace_env("cmdstanr");
+  Rcpp::Function f = pkg["get_seed"];
+  return Rcpp::as<int>(f());
+}
 
 #endif

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -348,35 +348,14 @@ test_that("rng functions can be exposed", {
 
   fit$expose_functions(verbose = TRUE)
   set.seed(10)
-  res <- fit$functions$wrap_normal_rng(5,10)
-
-  expect_equal(
-    res,
-    # Stan RNG changed in 2.35
-    ifelse(cmdstan_version() < "2.35.0", 1.217251562, 20.49842178)
-  )
-  res <- fit$functions$wrap_normal_rng(5,10)
-
-  expect_equal(
-    res,
-    ifelse(cmdstan_version() < "2.35.0", -0.1426366567, 12.93498553)
-  )
-
-  # Test that the RNG function respects set.seed
+  res1_1 <- fit$functions$wrap_normal_rng(5,10)
+  res2_1 <- fit$functions$wrap_normal_rng(5,10)
   set.seed(10)
-  res <- fit$functions$wrap_normal_rng(5,10)
+  res1_2 <- fit$functions$wrap_normal_rng(5,10)
+  res2_2 <- fit$functions$wrap_normal_rng(5,10)
 
-  expect_equal(
-    res,
-    # Stan RNG changed in 2.35
-    ifelse(cmdstan_version() < "2.35.0", 1.217251562, 20.49842178)
-  )
-  res <- fit$functions$wrap_normal_rng(5,10)
-
-  expect_equal(
-    res,
-    ifelse(cmdstan_version() < "2.35.0", -0.1426366567, 12.93498553)
-  )
+  expect_equal(res1_1, res1_2)
+  expect_equal(res2_1, res2_2)
 })
 
 test_that("Overloaded functions give meaningful errors", {

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -352,12 +352,12 @@ test_that("rng functions can be exposed", {
   expect_equal(
     fit$functions$wrap_normal_rng(5,10),
     # Stan RNG changed in 2.35
-    ifelse(cmdstan_version() < "2.35.0",-4.529876423, 0.02974925)
+    ifelse(cmdstan_version() < "2.35.0", 1.217251562, 20.49842178)
   )
 
   expect_equal(
     fit$functions$wrap_normal_rng(5,10),
-    ifelse(cmdstan_version() < "2.35.0", 8.12959026, 10.3881349)
+    ifelse(cmdstan_version() < "2.35.0", -0.1426366567, 12.93498553)
   )
 })
 

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -346,17 +346,35 @@ test_that("rng functions can be exposed", {
   mod <- cmdstan_model(model, force_recompile = TRUE)
   fit <- mod$sample(data = data_list)
 
-  set.seed(10)
   fit$expose_functions(verbose = TRUE)
+  set.seed(10)
+  res <- fit$functions$wrap_normal_rng(5,10)
 
   expect_equal(
-    fit$functions$wrap_normal_rng(5,10),
+    res,
     # Stan RNG changed in 2.35
     ifelse(cmdstan_version() < "2.35.0", 1.217251562, 20.49842178)
   )
+  res <- fit$functions$wrap_normal_rng(5,10)
 
   expect_equal(
-    fit$functions$wrap_normal_rng(5,10),
+    res,
+    ifelse(cmdstan_version() < "2.35.0", -0.1426366567, 12.93498553)
+  )
+
+  # Test that the RNG function respects set.seed
+  set.seed(10)
+  res <- fit$functions$wrap_normal_rng(5,10)
+
+  expect_equal(
+    res,
+    # Stan RNG changed in 2.35
+    ifelse(cmdstan_version() < "2.35.0", 1.217251562, 20.49842178)
+  )
+  res <- fit$functions$wrap_normal_rng(5,10)
+
+  expect_equal(
+    res,
     ifelse(cmdstan_version() < "2.35.0", -0.1426366567, 12.93498553)
   )
 })


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Exported RNG functions currently manage their state separately from R, so a user calling `set.seed()` has no effect on the result of the RNG.

This PR updates the exporting of RNG functions to additionally update their seed deterministically from the current seed in R

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
