### PR TITLE
Correct path for Rtools >=4.2 toolchain

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmdstanr
 Title: R Interface to 'CmdStan'
-Version: 0.8.0
+Version: 0.8.0.1000
 Date: 2024-05-18
 Authors@R:
     c(person(given = "Jonah", family = "Gabry", role = "aut",

--- a/R/install.R
+++ b/R/install.R
@@ -843,8 +843,9 @@ toolchain_PATH_env_var <- function() {
   path
 }
 
-rtools4x_toolchain_path <- function() {
-  c_runtime <- ifelse(is_ucrt_toolchain(), "ucrt64", "mingw64")
+rtools4x_toolchain_path <- function(version) {
+  c_runtime <- ifelse(is_ucrt_toolchain(),
+                      "x86_64-w64-mingw32.static.posix", "mingw64")
   repair_path(file.path(rtools4x_home_path(), c_runtime, "bin"))
 }
 


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

install.R : rtools4x_toolchain_path has the wrong path for RTools 4.2 or later,
so never finds the existing toolchain, and always calls pacman to install its own.
This has various consequences for other use of the RTools installation. This PR
corrects the path, so g++ and make are found, and pacman does not need
calling.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):

Imperial College London

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
