### PR TITLE
Add CMDSTANR_USE_RTOOLS envvar to force use of stock RTools

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,6 +42,12 @@ jobs:
           echo "CMDSTAN_PATH=${HOME}/.cmdstan" >> $GITHUB_ENV
         shell: bash
 
+      - name: Use stock RTools for Windows R-Devel
+        if: ${{ matrix.config.os == 'windows-latest' && matrix.config.r == 'devel' }}
+        run: |
+          echo "CMDSTANR_USE_RTOOLS=TRUE" >> $GITHUB_ENV
+        shell: bash
+
       - uses: n1hility/cancel-previous-runs@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -69,6 +69,11 @@ jobs:
       - name: Install cmdstan
         run: |
           cmdstanr::check_cmdstan_toolchain(fix = TRUE)
+          if (Sys.getenv("CMDSTANR_USE_RTOOLS") == "TRUE") {
+            cmdstanr::install_cmdstan(cores = 2, version = "2.35.0-rc2")
+          } else {
+            cmdstanr::install_cmdstan(cores = 2)
+          }
           cmdstanr::install_cmdstan(cores = 2)
         shell: Rscript {0}
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -74,7 +74,6 @@ jobs:
           } else {
             cmdstanr::install_cmdstan(cores = 2)
           }
-          cmdstanr::install_cmdstan(cores = 2)
         shell: Rscript {0}
 
       - name: Session info

--- a/R/install.R
+++ b/R/install.R
@@ -635,6 +635,9 @@ check_rtools4x_windows_toolchain <- function(fix = FALSE, quiet = FALSE) {
       call. = FALSE
     )
   }
+  if (Sys.getenv("CMDSTANR_USE_RTOOLS") != "") {
+    return(invisible(NULL))
+  }
   if (!is_toolchain_installed(app = "g++", path = toolchain_path) ||
       !is_toolchain_installed(app = "mingw32-make", path = toolchain_path)) {
     if (!fix) {
@@ -844,8 +847,11 @@ toolchain_PATH_env_var <- function() {
 }
 
 rtools4x_toolchain_path <- function() {
-  c_runtime <- ifelse(is_ucrt_toolchain(), "ucrt64", "mingw64")
-  repair_path(file.path(rtools4x_home_path(), c_runtime, "bin"))
+  toolchain <- ifelse(is_ucrt_toolchain(), "ucrt64", "mingw64")
+  if (Sys.getenv("CMDSTANR_USE_RTOOLS") != "") {
+    toolchain <- "x86_64-w64-mingw32.static.posix"
+  }
+  repair_path(file.path(rtools4x_home_path(), toolchain, "bin"))
 }
 
 rtools4x_version <- function() {

--- a/R/model.R
+++ b/R/model.R
@@ -672,7 +672,7 @@ compile <- function(quiet = TRUE,
       ),
       run_log <- wsl_compatible_run(
         command = make_cmd(),
-        args = c(wsl_safe_path(tmp_exe),
+        args = c(wsl_safe_path(repair_path(tmp_exe)),
                 cpp_options_to_compile_flags(cpp_options),
                 stancflags_val),
         wd = cmdstan_path(),

--- a/R/utils.R
+++ b/R/utils.R
@@ -85,7 +85,7 @@ is_rosetta2 <- function() {
 
 # Returns the type of make command to use to compile depending on the OS
 make_cmd <- function() {
-  if (os_is_windows() && !os_is_wsl()) {
+  if (os_is_windows() && !os_is_wsl() && (Sys.getenv("CMDSTANR_USE_RTOOLS") == "")) {
     "mingw32-make.exe"
   } else {
     "make"

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,4 +1,6 @@
 context("install")
+# Current tests need CmdStan 2.35 for stock rtools, but is not yet released
+skip_if(Sys.getenv("CMDSTANR_USE_RTOOLS") != "")
 
 cmdstan_test_tarball_url <- Sys.getenv("CMDSTAN_TEST_TARBALL_URL")
 if (!nzchar(cmdstan_test_tarball_url)) {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Add CMDSTANR_USE_RTOOLS envvar to force use of stock RTools.

Closes #979 



#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
