### PR TITLE
sampling statement -> distribution statement

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -683,9 +683,9 @@ CmdStanFit$set("public", name = "constrain_variables", value = constrain_variabl
 #'   Laplace approximation the unnormalized density of the approximation to
 #'   the posterior is available via the `$lp_approx()` method.
 #'
-#'   See the [Log Probability Increment vs. Sampling
-#'   Statement](https://mc-stan.org/docs/reference-manual/sampling-statements.html)
-#'   section of the Stan Reference Manual for details on when normalizing
+#'   See the [Increment log density and Distribution
+#'   Statements](https://mc-stan.org/docs/reference-manual/statements.html)
+#'   sections of the Stan Reference Manual for details on when normalizing
 #'   constants are dropped from log probability calculations.
 #'
 #' @section Details:

--- a/man/fit-method-lp.Rd
+++ b/man/fit-method-lp.Rd
@@ -24,8 +24,8 @@ the posterior is available via the \verb{$lp_approx()} method. For
 Laplace approximation the unnormalized density of the approximation to
 the posterior is available via the \verb{$lp_approx()} method.
 
-See the \href{https://mc-stan.org/docs/reference-manual/sampling-statements.html}{Log Probability Increment vs. Sampling Statement}
-section of the Stan Reference Manual for details on when normalizing
+See the \href{https://mc-stan.org/docs/reference-manual/statements.html}{Increment log density and Distribution Statements}
+sections of the Stan Reference Manual for details on when normalizing
 constants are dropped from log probability calculations.
 }
 \section{Details}{


### PR DESCRIPTION
The docs for 2.35 will have the change sampling statement -> distribution statement. This PR fixes the only mention in `cmdstanr` + uses new URL for the chapter