### PR TITLE
Fix compilation failures for Stan models with `#include` statements

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -868,6 +868,7 @@ get_standalone_hpp <- function(stan_file, stancflags) {
     unlink(hpp_path)
     hpp
   } else {
+    stop(status$stderr, call. = FALSE)
     invisible(NULL)
   }
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -868,7 +868,6 @@ get_standalone_hpp <- function(stan_file, stancflags) {
     unlink(hpp_path)
     hpp
   } else {
-    stop(status$stderr, call. = FALSE)
     invisible(NULL)
   }
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Compilation can fail for some systems when looking for include paths, as the quoting of arguments is handled differently when being passed to `make` as opposed to directly to `stanc`

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
