### PR TITLE
Include CmdStan CPPFLAGS when exposing functions

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -783,6 +783,7 @@ check_sundials_fpic <- function(verbose) {
 rcpp_source_stan <- function(code, env, verbose = FALSE, ...) {
   check_sundials_fpic(verbose)
   cxxflags <- get_cmdstan_flags("CXXFLAGS")
+  cppflags <- get_cmdstan_flags("CPPFLAGS")
   cmdstanr_includes <- system.file("include", package = "cmdstanr", mustWork = TRUE)
   cmdstanr_includes <- paste0(" -I\"", cmdstanr_includes,"\"")
   libs <- c("LDLIBS", "LIBSUNDIALS", "TBB_TARGETS", "LDFLAGS_TBB", "SUNDIALS_TARGETS")
@@ -790,11 +791,14 @@ rcpp_source_stan <- function(code, env, verbose = FALSE, ...) {
   if (.Platform$OS.type == "windows") {
     libs <- paste(libs, "-fopenmp")
   }
+  if (cmdstan_version() <= "2.30.1") {
+    cppflags <- paste0(cppflags, " -DCMDSTAN_JSON")
+  }
   withr::with_path(repair_path(file.path(cmdstan_path(),"stan/lib/stan_math/lib/tbb")),
     withr::with_makevars(
       c(
         USE_CXX14 = 1,
-        PKG_CPPFLAGS = ifelse(cmdstan_version() <= "2.30.1", "-DCMDSTAN_JSON", ""),
+        PKG_CPPFLAGS = cppflags,
         PKG_CXXFLAGS = paste0(cxxflags, cmdstanr_includes, collapse = " "),
         PKG_LIBS = libs
       ),


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

From [issue on the forums](https://discourse.mc-stan.org/t/tbb-interface-new-flag-is-not-working/35664/5): some flags in `make/local` (e.g., `TBB_INTERFACE_NEW`, etc.) weren't being passed to Rcpp when exposing functions and model methods  

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
