### PR TITLE
Remove unsupported array syntax formatting example

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -969,26 +969,6 @@ CmdStanModel$set("public", name = "check_syntax", value = check_syntax)
 #' @examples
 #' \dontrun{
 #'
-#' # Example of fixing old syntax
-#' # real x[2] --> array[2] real x;
-#' file <- write_stan_file("
-#' parameters {
-#'   real x[2];
-#' }
-#' model {
-#'   x ~ std_normal();
-#' }
-#' ")
-#'
-#' # set compile=FALSE then call format to fix old syntax
-#' mod <- cmdstan_model(file, compile = FALSE)
-#' mod$format(canonicalize = list("deprecations"))
-#'
-#' # overwrite the original file instead of just printing it
-#' mod$format(canonicalize = list("deprecations"), overwrite_file = TRUE)
-#' mod$compile()
-#'
-#'
 #' # Example of removing unnecessary whitespace
 #' file <- write_stan_file("
 #' data {
@@ -1003,8 +983,14 @@ CmdStanModel$set("public", name = "check_syntax", value = check_syntax)
 #'  poisson_lpmf(y | lambda);
 #' }
 #' ")
+#'
+#' # set compile=FALSE then call format to fix old syntax
 #' mod <- cmdstan_model(file, compile = FALSE)
-#' mod$format(canonicalize = TRUE)
+#' mod$format(canonicalize = list("deprecations"))
+#'
+#' # overwrite the original file instead of just printing it
+#' mod$format(canonicalize = list("deprecations"), overwrite_file = TRUE)
+#' mod$compile()
 #' }
 #'
 format <- function(overwrite_file = FALSE,

--- a/man/model-method-format.Rd
+++ b/man/model-method-format.Rd
@@ -47,26 +47,6 @@ model directly back to the file or prints it for inspection.
 \examples{
 \dontrun{
 
-# Example of fixing old syntax
-# real x[2] --> array[2] real x;
-file <- write_stan_file("
-parameters {
-  real x[2];
-}
-model {
-  x ~ std_normal();
-}
-")
-
-# set compile=FALSE then call format to fix old syntax
-mod <- cmdstan_model(file, compile = FALSE)
-mod$format(canonicalize = list("deprecations"))
-
-# overwrite the original file instead of just printing it
-mod$format(canonicalize = list("deprecations"), overwrite_file = TRUE)
-mod$compile()
-
-
 # Example of removing unnecessary whitespace
 file <- write_stan_file("
 data {
@@ -81,8 +61,14 @@ model {
  poisson_lpmf(y | lambda);
 }
 ")
+
+# set compile=FALSE then call format to fix old syntax
 mod <- cmdstan_model(file, compile = FALSE)
-mod$format(canonicalize = TRUE)
+mod$format(canonicalize = list("deprecations"))
+
+# overwrite the original file instead of just printing it
+mod$format(canonicalize = list("deprecations"), overwrite_file = TRUE)
+mod$compile()
 }
 
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Flagged in #1007, one of the code examples for the `format` method is for updating deprecated array syntax, which is not supported in CmdStan >= 2.34

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
