### PR TITLE
Test pathfinder for initialization with psis_resample=FALSE

### DIFF
--- a/tests/testthat/test-fit-init.R
+++ b/tests/testthat/test-fit-init.R
@@ -64,7 +64,8 @@ test_that("Multi Pathfinder method works as init", {
 test_that("Pathfinder method with psis_resample as false works as init", {
   mod_logistic <- testing_model("logistic")
   utils::capture.output(fit_path_init <- mod_logistic$pathfinder(
-    seed=1234, data = data_list_logistic, refresh = 0, num_paths = 1))
+    seed=1234, data = data_list_logistic, refresh = 0, num_paths = 1,
+    psis_resample = FALSE))
   expect_no_error(test_inits(mod_logistic, fit_path_init, data_list_logistic))
 })
 


### PR DESCRIPTION


#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #976. As pointed out by @wpetry, the test for using pathfinder for inits when `psis_resample=FALSE` was missing the `psis_resample=FALSE`. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
