### PR TITLE
And `cmdstanr_print_line_numbers` to list of global options

### DIFF
--- a/R/options.R
+++ b/R/options.R
@@ -18,6 +18,9 @@
 #' * `cmdstanr_max_rows`: The maximum number of rows of output to print when
 #' using the [`$print()`][fit-method-summary] method. The default is 10.
 #'
+#' * `cmdstanr_print_line_numbers`: Should line numbers be included when
+#' printing a Stan program? The default is `FALSE`.
+#'
 #' * `cmdstanr_no_ver_check`: Should the check for a more recent version of
 #' CmdStan be disabled? The default is `FALSE`.
 #'

--- a/man/cmdstanr_global_options.Rd
+++ b/man/cmdstanr_global_options.Rd
@@ -17,6 +17,8 @@ even if there were no Stan code changes since last compiled?  See
 \link[=model-method-compile]{compile} for more details. The default is \code{FALSE}.
 \item \code{cmdstanr_max_rows}: The maximum number of rows of output to print when
 using the \code{\link[=fit-method-summary]{$print()}} method. The default is 10.
+\item \code{cmdstanr_print_line_numbers}: Should line numbers be included when
+printing a Stan program? The default is \code{FALSE}.
 \item \code{cmdstanr_no_ver_check}: Should the check for a more recent version of
 CmdStan be disabled? The default is \code{FALSE}.
 \item \code{cmdstanr_output_dir}: The directory where CmdStan should write its output


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

`cmdstanr_print_line_numbers` was missing from the list of available global options

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
