### PR TITLE
Don't recommend `rstan::read_stan_csv`

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -85,11 +85,6 @@
 #' # Plot posterior using bayesplot (ggplot2)
 #' mcmc_hist(fit_mcmc$draws("theta"))
 #'
-#' # For models fit using MCMC, if you like working with RStan's stanfit objects
-#' # then you can create one with rstan::read_stan_csv()
-#' # stanfit <- rstan::read_stan_csv(fit_mcmc$output_files())
-#'
-#'
 #' # Run 'optimize' method to get a point estimate (default is Stan's LBFGS algorithm)
 #' # and also demonstrate specifying data as a path to a file instead of a list
 #' my_data_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.data.json")

--- a/man/CmdStanModel.Rd
+++ b/man/CmdStanModel.Rd
@@ -104,11 +104,6 @@ as_draws_df(draws)
 # Plot posterior using bayesplot (ggplot2)
 mcmc_hist(fit_mcmc$draws("theta"))
 
-# For models fit using MCMC, if you like working with RStan's stanfit objects
-# then you can create one with rstan::read_stan_csv()
-# stanfit <- rstan::read_stan_csv(fit_mcmc$output_files())
-
-
 # Run 'optimize' method to get a point estimate (default is Stan's LBFGS algorithm)
 # and also demonstrate specifying data as a path to a file instead of a list
 my_data_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.data.json")

--- a/man/cmdstan_model.Rd
+++ b/man/cmdstan_model.Rd
@@ -90,11 +90,6 @@ as_draws_df(draws)
 # Plot posterior using bayesplot (ggplot2)
 mcmc_hist(fit_mcmc$draws("theta"))
 
-# For models fit using MCMC, if you like working with RStan's stanfit objects
-# then you can create one with rstan::read_stan_csv()
-# stanfit <- rstan::read_stan_csv(fit_mcmc$output_files())
-
-
 # Run 'optimize' method to get a point estimate (default is Stan's LBFGS algorithm)
 # and also demonstrate specifying data as a path to a file instead of a list
 my_data_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.data.json")

--- a/man/cmdstanr-package.Rd
+++ b/man/cmdstanr-package.Rd
@@ -120,11 +120,6 @@ as_draws_df(draws)
 # Plot posterior using bayesplot (ggplot2)
 mcmc_hist(fit_mcmc$draws("theta"))
 
-# For models fit using MCMC, if you like working with RStan's stanfit objects
-# then you can create one with rstan::read_stan_csv()
-# stanfit <- rstan::read_stan_csv(fit_mcmc$output_files())
-
-
 # Run 'optimize' method to get a point estimate (default is Stan's LBFGS algorithm)
 # and also demonstrate specifying data as a path to a file instead of a list
 my_data_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.data.json")

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -271,11 +271,6 @@ as_draws_df(draws)
 # Plot posterior using bayesplot (ggplot2)
 mcmc_hist(fit_mcmc$draws("theta"))
 
-# For models fit using MCMC, if you like working with RStan's stanfit objects
-# then you can create one with rstan::read_stan_csv()
-# stanfit <- rstan::read_stan_csv(fit_mcmc$output_files())
-
-
 # Run 'optimize' method to get a point estimate (default is Stan's LBFGS algorithm)
 # and also demonstrate specifying data as a path to a file instead of a list
 my_data_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.data.json")

--- a/man/model-method-pathfinder.Rd
+++ b/man/model-method-pathfinder.Rd
@@ -296,11 +296,6 @@ as_draws_df(draws)
 # Plot posterior using bayesplot (ggplot2)
 mcmc_hist(fit_mcmc$draws("theta"))
 
-# For models fit using MCMC, if you like working with RStan's stanfit objects
-# then you can create one with rstan::read_stan_csv()
-# stanfit <- rstan::read_stan_csv(fit_mcmc$output_files())
-
-
 # Run 'optimize' method to get a point estimate (default is Stan's LBFGS algorithm)
 # and also demonstrate specifying data as a path to a file instead of a list
 my_data_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.data.json")

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -370,11 +370,6 @@ as_draws_df(draws)
 # Plot posterior using bayesplot (ggplot2)
 mcmc_hist(fit_mcmc$draws("theta"))
 
-# For models fit using MCMC, if you like working with RStan's stanfit objects
-# then you can create one with rstan::read_stan_csv()
-# stanfit <- rstan::read_stan_csv(fit_mcmc$output_files())
-
-
 # Run 'optimize' method to get a point estimate (default is Stan's LBFGS algorithm)
 # and also demonstrate specifying data as a path to a file instead of a list
 my_data_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.data.json")

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -271,11 +271,6 @@ as_draws_df(draws)
 # Plot posterior using bayesplot (ggplot2)
 mcmc_hist(fit_mcmc$draws("theta"))
 
-# For models fit using MCMC, if you like working with RStan's stanfit objects
-# then you can create one with rstan::read_stan_csv()
-# stanfit <- rstan::read_stan_csv(fit_mcmc$output_files())
-
-
 # Run 'optimize' method to get a point estimate (default is Stan's LBFGS algorithm)
 # and also demonstrate specifying data as a path to a file instead of a list
 my_data_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.data.json")

--- a/vignettes/cmdstanr.Rmd
+++ b/vignettes/cmdstanr.Rmd
@@ -326,22 +326,6 @@ CmdStan itself provides a `diagnose` utility that can be called using
 the `$cmdstan_diagnose()` method. This method will print warnings but won't return anything.
 
 
-### Create a `stanfit` object
-
-If you have RStan installed then it is also possible to create a `stanfit`
-object from the csv output files written by CmdStan. This can be done by using
-`rstan::read_stan_csv()` in combination with the `$output_files()` method of the
-`CmdStanMCMC` object. This is only needed if you want to fit a model with
-CmdStanR but already have a lot of post-processing code that assumes a `stanfit`
-object. Otherwise we recommend using the post-processing functionality provided
-by CmdStanR itself.
-
-```{r stanfit, eval=FALSE}
-stanfit <- rstan::read_stan_csv(fit$output_files())
-```
-
-
-
 ## Running optimization and variational inference
 
 CmdStanR also supports running Stan's optimization algorithms and its algorithms


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

It seems like `rstan::read_stan_csv()` is not guaranteed to successfully handle CmdStan CSVs. We mention `read_stan_csv` various times in the CmdStanR doc so this PR removes those mentions. At this point I think cmdstanr and posterior provide the necessary functionality that this isn't losing anything important. What do you think @andrjohns? 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
