### PR TITLE
Fix untar() on Windows 11

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -204,7 +204,8 @@ install_cmdstan <- function(dir = NULL,
     untar_rc <- utils::untar(
       dest_file,
       exdir = dir_cmdstan,
-      extras = "--strip-components 1"
+      extras = "--strip-components 1",
+      tar = if (os_is_windows()) "tar.exe" else Sys.getenv("TAR")
     )
     if (untar_rc != 0) {
       stop("Problem extracting tarball. Exited with return code: ", untar_rc, call. = FALSE)


### PR DESCRIPTION
Closes #1029

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Uses @svethitov's suggestion in https://github.com/stan-dev/cmdstanr/issues/1029#issuecomment-2466214417 of manually specifying `tar.exe` on Windows 11 to avoid issue with `Sys.getenv("TAR")`. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
