### PR TITLE
Informative error message for sampler_diagnostics() with fixed_param

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -1616,6 +1616,9 @@ CmdStanMCMC$set("public", name = "loo", value = loo)
 #' }
 #'
 sampler_diagnostics <- function(inc_warmup = FALSE, format = getOption("cmdstanr_draws_format", "draws_array")) {
+  if (isTRUE(private$metadata_$algorithm == "fixed_param")) {
+    stop("There are no sampler diagnostics when fixed_param = TRUE.", call. = FALSE)
+  }
   if (is.null(private$sampler_diagnostics_) &&
       !length(self$output_files(include_failed = FALSE))) {
     stop("No chains finished successfully. Unable to retrieve the sampler diagnostics.", call. = FALSE)

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -19,6 +19,12 @@ fit_mcmc_3 <- testing_fit("logistic", method = "sample",
                           iter_sampling = 0,
                           save_warmup = 1,
                           refresh = 0, metric = "dense_e")
+fit_mcmc_fixed_param <- testing_fit("logistic", method = "sample",
+                                    seed = 1234, chains = 1,
+                                    iter_warmup = 100,
+                                    iter_sampling = 0,
+                                    save_warmup = 1,
+                                    refresh = 0, fixed_param = TRUE)
 PARAM_NAMES <- c("alpha", "beta[1]", "beta[2]", "beta[3]")
 
 test_that("draws() stops for unkown variables", {
@@ -398,4 +404,11 @@ test_that("metadata()$time has chains rowss", {
   expect_equal(nrow(fit_mcmc_1$metadata()$time), fit_mcmc_1$num_chains())
   expect_equal(nrow(fit_mcmc_2$metadata()$time), fit_mcmc_2$num_chains())
   expect_equal(nrow(fit_mcmc_3$metadata()$time), fit_mcmc_3$num_chains())
+})
+
+test_that("sampler_diagnostics() throws informative error when fixed_param=TRUE", {
+  expect_error(
+    fit_mcmc_fixed_param$sampler_diagnostics(),
+    "There are no sampler diagnostics when fixed_param = TRUE"
+  )
 })


### PR DESCRIPTION
closes #1032

#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Ensure there's an informative error message when calling `sampler_diagnostics()` when `fixed_param=TRUE`. 


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
