### PR TITLE
Make use of untar() platform independent in `install_cmdstan()`

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -203,8 +203,7 @@ install_cmdstan <- function(dir = NULL,
   } else {
     untar_rc <- utils::untar(
       dest_file,
-      exdir = dir_cmdstan,
-      extras = "--strip-components 1"
+      exdir = dir
     )
     if (untar_rc != 0) {
       stop("Problem extracting tarball. Exited with return code: ", untar_rc, call. = FALSE)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #1029
Uses @WardBrian [suggestion](https://github.com/stan-dev/cmdstanr/issues/1029#issuecomment-2476999046) of switching `untar`'s `exdir` to point to the parent directory, which would allow us to

> drop the --strip-components flag entirely, and then it wouldn't matter which tar implementation gets used, including internal. That way the testing/verifying the change is platform independent

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
