### PR TITLE
Update selection of `make` command post CmdStan 2.35

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -92,8 +92,12 @@ arch_is_aarch64 <- function() {
 }
 
 # Returns the type of make command to use to compile depending on the OS
+# First checks if $MAKE is set, otherwise falls back to system-specific default
 make_cmd <- function() {
-  if (os_is_windows() && !os_is_wsl() && (Sys.getenv("CMDSTANR_USE_RTOOLS") == "")) {
+  if (Sys.getenv("MAKE") != "") {
+    Sys.getenv("MAKE")
+  } else if ((cmdstan_version() < "2.35.0") && os_is_windows() && !os_is_wsl() &&
+      (Sys.getenv("CMDSTANR_USE_RTOOLS") == "")) {
     "mingw32-make.exe"
   } else {
     "make"


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

closes #1035

Updates the way we select which `make` command to use: 

- Uses `Sys.getenv("MAKE")` if set, otherwise: 
- If using CmdStan  <2.35.0 and on Windows (not WSL) uses `mingw32-make`
- Otherwise uses `make` 



#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
