### PR TITLE
For #1026: update `repair_path()` to work with network paths, add test.

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -128,8 +128,9 @@ repair_path <- function(path) {
   }
   path <- path.expand(path)
   path <- gsub("\\\\", "/", path)
-  # WSL cmdstan path is a network path and needs the leading //
-  path <- gsub("//(?!wsl)", "/", path, perl = TRUE)
+  # Network paths (such as the cmdstan path on WSL) need the leading //
+  # https://github.com/stan-dev/cmdstanr/issues/1026
+  path <- gsub("(?<!^)//", "/", path, perl = TRUE)
   # remove trailing "/"
   path <- gsub("/$","", path)
   path

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -143,6 +143,8 @@ test_that("cmdstan_diagnose works if bin/diagnose deleted file", {
 test_that("repair_path() fixes slashes", {
   # all slashes should be single "/", and no trailing slash
   expect_equal(repair_path("a//b\\c/"), "a/b/c")
+  # but leading double slash is needed for UNC paths on  (e.g. the cmdstan path on WSL)
+  expect_equal(repair_path("\\\\wsl//my-project//"), "//wsl/my-project")
 })
 
 test_that("repair_path works with zero length path or non-string path", {


### PR DESCRIPTION
#### Submission Checklist

- [ x] Run unit tests
- [ x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes issue #1026 by allowing `repair_path()` to work with network paths. Updates the unit test accordingly.

#### Copyright and Licensing

(I filled in my name since that's part of the issue template)

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):

Benjamin Schneider

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)

#### Unit Test Results

```r
══ Results ═════════════════════════════════════════════════════════
Duration: 4639.4 s

── Skipped tests (13) ──────────────────────────────────────────────
• !mpi_toolchain_present() is TRUE (1): test-model-sample_mpi.R:4:3
• empty test (1): test-fit-shared.R:454:1
• loo cannot be loaded (4): test-fit-mcmc.R:275:3,
  test-fit-mcmc.R:282:3, test-fit-mcmc.R:314:3,
  test-fit-mcmc.R:324:3
• os_is_windows() is TRUE (1): test-install.R:133:3
• os_is_wsl() is TRUE (3): test-install.R:158:3,
  test-model-expose-functions.R:4:1, test-model-methods.R:2:1       
• Sys.getenv("CMDSTANR_OPENCL_TESTS") %in% c("1", "true") is not    
  TRUE (3): test-opencl.R:34:3, test-opencl.R:70:3,
  test-opencl.R:107:3

[ FAIL 0 | WARN 0 | SKIP 13 | PASS 1782 ]
```
