### PR TITLE
Don't require `fixed_param` for models with zero parameters (only GQs) for CmdStan >= 2.36

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -786,6 +786,7 @@ read_csv_metadata <- function(csv_file) {
     }
   }
   if (csv_file_info$method != "diagnose" &&
+      !isTRUE(csv_file_info$algorithm == "fixed_param") &&
       length(csv_file_info$sampler_diagnostics) == 0 &&
       length(csv_file_info$variables) == 0) {
     stop("Supplied CSV file does not contain any variable names or data!", call. = FALSE)

--- a/R/csv.R
+++ b/R/csv.R
@@ -719,7 +719,7 @@ read_csv_metadata <- function(csv_file) {
         dense_inv_metric <- TRUE
       } else if (inv_metric_next) {
         inv_metric_split <- strsplit(gsub("# ", "", line), ",")
-        numeric_inv_metric_split <- rapply(inv_metric_split, as.numeric)
+        numeric_inv_metric_split <- suppressWarnings(rapply(inv_metric_split, as.numeric))
         if (inv_metric_rows == -1 && dense_inv_metric) {
           inv_metric_rows <- length(inv_metric_split[[1]])
           inv_metric_rows_to_read <- inv_metric_rows

--- a/R/model.R
+++ b/R/model.R
@@ -1208,7 +1208,7 @@ sample <- function(data = NULL,
     }
   }
 
-  if (cmdstan_version() >= "2.27.0" && !fixed_param) {
+  if (cmdstan_version() >= "2.27.0" && cmdstan_version() < "2.36.0" && !fixed_param) {
     if (self$has_stan_file() && file.exists(self$stan_file())) {
       if (!is.null(self$variables()) && length(self$variables()$parameters) == 0) {
         stop("Model contains no parameters. Please use 'fixed_param = TRUE'.", call. = FALSE)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

As of CmdStan 2.36 `fixed_param` is not required if the model has no parameters (e.g. only generated quantities). 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
