### PR TITLE
Use stock Rtools toolchain by default for RTools44+

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -42,12 +42,6 @@ jobs:
           echo "CMDSTAN_PATH=${HOME}/.cmdstan" >> $GITHUB_ENV
         shell: bash
 
-      - name: Use stock RTools for Windows R-Devel
-        if: ${{ matrix.config.os == 'windows-latest' && matrix.config.r == 'devel' }}
-        run: |
-          echo "CMDSTANR_USE_RTOOLS=TRUE" >> $GITHUB_ENV
-        shell: bash
-
       - uses: n1hility/cancel-previous-runs@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,7 +32,7 @@ URL: https://mc-stan.org/cmdstanr/, https://discourse.mc-stan.org
 BugReports: https://github.com/stan-dev/cmdstanr/issues
 Encoding: UTF-8
 LazyData: true
-RoxygenNote: 7.3.1
+RoxygenNote: 7.3.2
 Roxygen: list(markdown = TRUE, r6 = FALSE)
 SystemRequirements: CmdStan (https://mc-stan.org/users/interfaces/cmdstan)
 Depends:

--- a/R/install.R
+++ b/R/install.R
@@ -20,8 +20,19 @@
 #'
 #'   The `check_cmdstan_toolchain()` function attempts to check for the required
 #'   C++ toolchain. It is called internally by `install_cmdstan()` but can also
-#'   be called directly by the user.
+#'   be called directly by the user. On Windows only, calling the function with
+#'   the `fix = TRUE` argument will attempt to install the necessary toolchain
+#'   components if they are not found. For Windows users with RTools44 no additional
+#'   toolchain configuration is required. For users with older versions of RTools,
+#'   the function will install `mingw32-make` and `g++` from MSYS using the
+#'   RTools-provided `pacman` package manager. This can also be manually requested
+#'   by setting the environment variable `CMDSTANR_USE_MSYS_TOOLCHAIN` to 'true'
 #'
+#'   NOTE: When installing CmdStan on Windows with RTools44 and CmdStan versions
+#'   prior to 2.35.0, the above additional toolchain configuration
+#'   is still required. To enable this configuration, set the environment variable
+#'   `CMDSTANR_USE_MSYS_TOOLCHAIN` to 'true' and call
+#'   `check_cmdstan_toolchain(fix = TRUE)`.
 #'
 #' @export
 #' @param dir (string) The path to the directory in which to install CmdStan.

--- a/R/install.R
+++ b/R/install.R
@@ -866,7 +866,7 @@ rtools4x_toolchain_path <- function() {
   if (arch_is_aarch64()) {
     toolchain <- "aarch64-w64-mingw32.static.posix"
   } else {
-    if (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "") {
+    if (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" || cmdstan_version() < "2.35.0") {
       toolchain <- ifelse(is_ucrt_toolchain(), "ucrt64", "mingw64")
     } else {
       toolchain <- "x86_64-w64-mingw32.static.posix"

--- a/R/install.R
+++ b/R/install.R
@@ -103,6 +103,13 @@ install_cmdstan <- function(dir = NULL,
   } else {
     .cmdstanr$WSL <- FALSE
   }
+  if (os_is_windows() && !os_is_wsl() && version < "2.35.0") {
+    if (Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") == "") {
+      stop("CmdStan versions prior to 2.35.0 require additional toolchain configuration on Windows.\n",
+            "Please set the environment variable CMDSTANR_USE_MSYS_TOOLCHAIN to 'true' and \n",
+            "call `check_cmdstan_toolchain(fix = TRUE)` before installing CmdStan.", call. = FALSE)
+    }
+  }
   if (check_toolchain) {
     check_cmdstan_toolchain(fix = FALSE, quiet = quiet)
   }

--- a/R/install.R
+++ b/R/install.R
@@ -103,7 +103,7 @@ install_cmdstan <- function(dir = NULL,
   } else {
     .cmdstanr$WSL <- FALSE
   }
-  if (os_is_windows() && !os_is_wsl() && version < "2.35.0") {
+  if (os_is_windows() && !os_is_wsl() && isTRUE(version < "2.35.0")) {
     if (Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") == "") {
       stop("CmdStan versions prior to 2.35.0 require additional toolchain configuration on Windows.\n",
             "Please set the environment variable CMDSTANR_USE_MSYS_TOOLCHAIN to 'true' and \n",

--- a/R/install.R
+++ b/R/install.R
@@ -104,7 +104,9 @@ install_cmdstan <- function(dir = NULL,
     .cmdstanr$WSL <- FALSE
   }
   if (os_is_windows() && !os_is_wsl() && isTRUE(version < "2.35.0")) {
-    if (Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") == "") {
+    # RTools44 can be used unmodified with CmdStan 2.35+
+    # For new installs of older versions, users need to install mingw32-make and MSYS gcc
+    if (Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") == "" && rtools4x_version() == "44") {
       stop("CmdStan versions prior to 2.35.0 require additional toolchain configuration on Windows.\n",
             "Please set the environment variable CMDSTANR_USE_MSYS_TOOLCHAIN to 'true' and \n",
             "call `check_cmdstan_toolchain(fix = TRUE)` before installing CmdStan.", call. = FALSE)

--- a/R/install.R
+++ b/R/install.R
@@ -643,7 +643,8 @@ check_rtools4x_windows_toolchain <- function(fix = FALSE, quiet = FALSE) {
       call. = FALSE
     )
   }
-  if (Sys.getenv("CMDSTANR_USE_RTOOLS") != "") {
+  # No additional utilities/toolchains are needed with RTools44
+  if (rtools4x_version() >= "44" && Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") == "") {
     return(invisible(NULL))
   }
   if (!is_toolchain_installed(app = "g++", path = toolchain_path) ||
@@ -855,10 +856,11 @@ toolchain_PATH_env_var <- function() {
 }
 
 rtools4x_toolchain_path <- function() {
-  toolchain <- ifelse(is_ucrt_toolchain(), "ucrt64", "mingw64")
-  if (Sys.getenv("CMDSTANR_USE_RTOOLS") != "") {
-    if (arch_is_aarch64()) {
-      toolchain <- "aarch64-w64-mingw32.static.posix"
+  if (arch_is_aarch64()) {
+    toolchain <- "aarch64-w64-mingw32.static.posix"
+  } else {
+    if (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "") {
+      toolchain <- ifelse(is_ucrt_toolchain(), "ucrt64", "mingw64")
     } else {
       toolchain <- "x86_64-w64-mingw32.static.posix"
     }

--- a/R/install.R
+++ b/R/install.R
@@ -866,7 +866,8 @@ rtools4x_toolchain_path <- function() {
   if (arch_is_aarch64()) {
     toolchain <- "aarch64-w64-mingw32.static.posix"
   } else {
-    if (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" || cmdstan_version() < "2.35.0") {
+    if (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" ||
+        isTRUE(cmdstan_version(error_on_NA=FALSE) < "2.35.0")) {
       toolchain <- ifelse(is_ucrt_toolchain(), "ucrt64", "mingw64")
     } else {
       toolchain <- "x86_64-w64-mingw32.static.posix"

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,7 +96,8 @@ arch_is_aarch64 <- function() {
 make_cmd <- function() {
   if (Sys.getenv("MAKE") != "") {
     Sys.getenv("MAKE")
-  } else if (os_is_windows() && !os_is_wsl() && (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" || cmdstan_version() < "2.35.0")) {
+  } else if (os_is_windows() && !os_is_wsl() &&
+        (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" || isTRUE(cmdstan_version(error_on_NA=FALSE) < "2.35.0"))) {
     "mingw32-make.exe"
   } else {
     "make"

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,7 +96,7 @@ arch_is_aarch64 <- function() {
 make_cmd <- function() {
   if (Sys.getenv("MAKE") != "") {
     Sys.getenv("MAKE")
-  } else if (os_is_windows() && !os_is_wsl() && (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "")) {
+  } else if (os_is_windows() && !os_is_wsl() && (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" || cmdstan_version() < "2.35.0")) {
     "mingw32-make.exe"
   } else {
     "make"

--- a/R/utils.R
+++ b/R/utils.R
@@ -96,7 +96,7 @@ arch_is_aarch64 <- function() {
 make_cmd <- function() {
   if (Sys.getenv("MAKE") != "") {
     Sys.getenv("MAKE")
-  } else if (os_is_windows() && !os_is_wsl() && (Sys.getenv("CMDSTANR_USE_RTOOLS") == "")) {
+  } else if (os_is_windows() && !os_is_wsl() && (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "")) {
     "mingw32-make.exe"
   } else {
     "make"

--- a/man/fit-method-save_object.Rd
+++ b/man/fit-method-save_object.Rd
@@ -19,7 +19,7 @@ model object. Because the contents of the CmdStan output CSV files are only
 read into R lazily (i.e., as needed), the \verb{$save_object()} method is the
 safest way to guarantee that everything has been read in before saving.
 
-See the "Saving fitted model objects" sections of the
+See the "Saving fitted model objects" section of the
 \href{https://mc-stan.org/cmdstanr/articles/cmdstanr.html}{\emph{Getting started with CmdStanR}}
 vignette for some suggestions on faster model saving for large models.
 }

--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -118,7 +118,19 @@ should typically be followed by calling \code{rebuild_cmdstan()}.
 
 The \code{check_cmdstan_toolchain()} function attempts to check for the required
 C++ toolchain. It is called internally by \code{install_cmdstan()} but can also
-be called directly by the user.
+be called directly by the user. On Windows only, calling the function with
+the \code{fix = TRUE} argument will attempt to install the necessary toolchain
+components if they are not found. For Windows users with RTools44 no additional
+toolchain configuration is required. For users with older versions of RTools,
+the function will install \code{mingw32-make} and \verb{g++} from MSYS using the
+RTools-provided \code{pacman} package manager. This can also be manually requested
+by setting the environment variable \code{CMDSTANR_USE_MSYS_TOOLCHAIN} to 'true'
+
+NOTE: When installing CmdStan on Windows with RTools44 and CmdStan versions
+prior to 2.35.0, the above additional toolchain configuration
+is still required. To enable this configuration, set the environment variable
+\code{CMDSTANR_USE_MSYS_TOOLCHAIN} to 'true' and call
+\code{check_cmdstan_toolchain(fix = TRUE)}.
 }
 \examples{
 \dontrun{

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -26,13 +26,13 @@ test_that("install_cmdstan() successfully installs cmdstan", {
 
 test_that("install_cmdstan() errors if installation already exists", {
   install_dir <- cmdstan_default_install_path()
-  dir <- file.path(install_dir, "cmdstan-2.23.0")
+  dir <- file.path(install_dir, "cmdstan-2.35.0")
   if (!dir.exists(dir)) {
     dir.create(dir, recursive = TRUE)
   }
   expect_warning(
     install_cmdstan(dir = install_dir, overwrite = FALSE,
-                    version = "2.23.0", wsl = FALSE),
+                    version = "2.35.0", wsl = FALSE),
     "An installation already exists",
     fixed = TRUE
   )
@@ -74,13 +74,13 @@ test_that("install_cmdstan() errors if it times out", {
 
 test_that("install_cmdstan() errors if invalid version or URL", {
   expect_error(
-    install_cmdstan(version = "2.23.2", wsl = os_is_wsl()),
-    "Download of CmdStan failed with error: cannot open URL 'https://github.com/stan-dev/cmdstan/releases/download/v2.23.2/cmdstan-2.23.2.tar.gz'\nPlease check if the supplied version number is valid."
+    install_cmdstan(version = "2.35.5", wsl = os_is_wsl()),
+    "Download of CmdStan failed with error: cannot open URL 'https://github.com/stan-dev/cmdstan/releases/download/v2.35.5/cmdstan-2.35.5.tar.gz'\nPlease check if the supplied version number is valid."
   )
   expect_error(
-    install_cmdstan(release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.23.2/cmdstan-2.23.2.tar.gz",
+    install_cmdstan(release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.35.5/cmdstan-2.35.5.tar.gz",
                     wsl = os_is_wsl()),
-    "Download of CmdStan failed with error: cannot open URL 'https://github.com/stan-dev/cmdstan/releases/download/v2.23.2/cmdstan-2.23.2.tar.gz'\nPlease check if the supplied release URL is valid."
+    "Download of CmdStan failed with error: cannot open URL 'https://github.com/stan-dev/cmdstan/releases/download/v2.35.5/cmdstan-2.35.5.tar.gz'\nPlease check if the supplied release URL is valid."
   )
   expect_error(
     install_cmdstan(release_url = "https://github.com/stan-dev/cmdstan/releases/tag/v2.24.0", wsl = os_is_wsl()),

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -98,7 +98,7 @@ test_that("install_cmdstan() works with version and release_url", {
   expect_message(
     expect_output(
       install_cmdstan(dir = dir, overwrite = TRUE, cores = 4,
-                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.33.0/cmdstan-2.33.0.tar.gz",
+                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.33.0/cmdstan-2.35.0.tar.gz",
                       wsl = os_is_wsl()),
       "Compiling, linking C++ code",
       fixed = TRUE
@@ -110,7 +110,7 @@ test_that("install_cmdstan() works with version and release_url", {
     expect_message(
       expect_output(
         install_cmdstan(dir = dir, overwrite = TRUE, cores = 4,
-                        version = "2.33.0",
+                        version = "2.35.0",
                         # the URL is intentionally invalid to test that the version has higher priority
                         release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.27.3/cmdstan-2.27.3.tar.gz",
                         wsl = os_is_wsl()),
@@ -254,10 +254,10 @@ test_that("Install from release file works", {
     dir <- tempdir(check = TRUE)
   }
 
-  destfile = file.path(dir, "cmdstan-2.33.1.tar.gz")
+  destfile = file.path(dir, "cmdstan-2.35.0.tar.gz")
 
   download_with_retries(
-    "https://github.com/stan-dev/cmdstan/releases/download/v2.33.1/cmdstan-2.33.1.tar.gz",
+    "https://github.com/stan-dev/cmdstan/releases/download/v2.35.0/cmdstan-2.35.0.tar.gz",
     destfile)
 
   expect_message(

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -100,7 +100,7 @@ test_that("install_cmdstan() works with version and release_url", {
       install_cmdstan(dir = dir, overwrite = TRUE, cores = 4,
                       release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.35.0/cmdstan-2.35.0.tar.gz",
                       wsl = os_is_wsl()),
-      "Compiling, linking C++ code",
+      "Compiling C++ code",
       fixed = TRUE
     ),
     "Finished installing CmdStan",
@@ -114,7 +114,7 @@ test_that("install_cmdstan() works with version and release_url", {
                         # the URL is intentionally invalid to test that the version has higher priority
                         release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.27.3/cmdstan-2.27.3.tar.gz",
                         wsl = os_is_wsl()),
-        "Compiling, linking C++ code",
+        "Compiling C++ code",
         fixed = TRUE
       ),
       "Finished installing CmdStan",
@@ -123,7 +123,7 @@ test_that("install_cmdstan() works with version and release_url", {
     "version and release_url shouldn't both be specified",
     fixed = TRUE
   )
-  expect_true(dir.exists(file.path(dir, "cmdstan-2.33.0")))
+  expect_true(dir.exists(file.path(dir, "cmdstan-2.35.0")))
   set_cmdstan_path(cmdstan_default_path())
 })
 
@@ -265,7 +265,7 @@ test_that("Install from release file works", {
       install_cmdstan(dir = dir, cores = 2, quiet = FALSE, overwrite = TRUE,
                       release_file = destfile,
                       wsl = os_is_wsl()),
-      "Compiling, linking C++ code",
+      "Compiling C++ code",
       fixed = TRUE
     ),
     "CmdStan path set",

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -1,6 +1,4 @@
 context("install")
-# Current tests need CmdStan 2.35 for stock rtools, but is not yet released
-skip_if(Sys.getenv("CMDSTANR_USE_RTOOLS") != "")
 
 cmdstan_test_tarball_url <- Sys.getenv("CMDSTAN_TEST_TARBALL_URL")
 if (!nzchar(cmdstan_test_tarball_url)) {

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -98,7 +98,7 @@ test_that("install_cmdstan() works with version and release_url", {
   expect_message(
     expect_output(
       install_cmdstan(dir = dir, overwrite = TRUE, cores = 4,
-                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.33.0/cmdstan-2.35.0.tar.gz",
+                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.35.0/cmdstan-2.35.0.tar.gz",
                       wsl = os_is_wsl()),
       "Compiling, linking C++ code",
       fixed = TRUE


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

From CmdStan 2.35 and RTools44 onwards we do not need to download/install any additional toolchains/utilities (e.g., `mingw32-make`). This PR updates our handling of toolchains to default to stock RTools (for rtools44 only), unless manually requested by the user setting the `CMDSTANR_USE_MSYS_TOOLCHAIN` environment variable.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
