### PR TITLE
Update WSL CI to use WSL2

### DIFF
--- a/.github/workflows/R-CMD-check-wsl.yaml
+++ b/.github/workflows/R-CMD-check-wsl.yaml
@@ -47,13 +47,12 @@ jobs:
       - uses: Vampire/setup-wsl@v4
         with:
             distribution: Ubuntu-22.04
-            use-cache: 'false'
+            wsl-version: 2
+            use-cache: 'true'
             set-as-default: 'true'
+
       - name: Install WSL Dependencies
         run: |
-          # Bugfix for current gzip (for unpacking apt packages) under WSLv1:
-          # https://github.com/microsoft/WSL/issues/8219#issuecomment-1110508016
-          echo -en '\x10' | sudo dd of=/usr/bin/gzip count=1 bs=1 conv=notrunc seek=$((0x189))
           sudo apt-get update
           sudo apt-get install -y build-essential libopenmpi-dev
         shell: wsl-bash {0}

--- a/.github/workflows/R-CMD-check-wsl.yaml
+++ b/.github/workflows/R-CMD-check-wsl.yaml
@@ -7,7 +7,7 @@ name: Unit tests - WSL Backend
 'on':
   push:
     branches:
-      - gha-wsl2
+      - master
   pull_request:
     branches:
       - master
@@ -17,7 +17,7 @@ jobs:
     if: "! contains(github.event.head_commit.message, '[ci skip]')"
     runs-on: windows-latest
 
-    name: windows-latest-WSLv1
+    name: windows-latest-WSL2
 
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true

--- a/.github/workflows/R-CMD-check-wsl.yaml
+++ b/.github/workflows/R-CMD-check-wsl.yaml
@@ -7,7 +7,7 @@ name: Unit tests - WSL Backend
 'on':
   push:
     branches:
-      - master
+      - gha-wsl2
   pull_request:
     branches:
       - master


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The WSL CI has been hanging/timing-out for the last few runs, this PR updates the action to use WSL2 (only recently became available) which seems to fix the issue

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
