### PR TITLE
fix translation of log liks before exponentiation

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -1543,7 +1543,8 @@ loo <- function(variables = "log_lik", r_eff = TRUE, moment_match = FALSE, ...) 
   if (is.logical(r_eff)) {
     if (isTRUE(r_eff)) {
       r_eff_cores <- list(...)[["cores"]] %||% getOption("mc.cores", 1)
-      r_eff <- loo::relative_eff(exp(LLarray + max(-LLarray)), cores = r_eff_cores)
+      r_eff <- loo::relative_eff(exp(sweep(LLarray, 3, apply(LLarray, 3, max), FUN = "-")),
+                                 cores = r_eff_cores)
     } else {
       r_eff <- NULL
     }


### PR DESCRIPTION
Should fix https://github.com/stan-dev/loo/issues/272. 

`$loo()` had the following line
```
r_eff <- loo::relative_eff(exp(LLarray + max(-LLarray)), cores = r_eff_cores)
```
It was possible to get `Inf` from exp, and the autocovariance function failed with input which was all `Inf`. There are two issued with this line, 1) it's using the maximum of whole -LLarray, but it would be better to translate each variable in LLarray with its own maximum, and 2) it's making the smallest value 0, while it should be the largest value which is 0. This PR fixes these two issues.

