### PR TITLE
Remove extra parameter breaking tests

### DIFF
--- a/tests/testthat/test-fit-gq.R
+++ b/tests/testthat/test-fit-gq.R
@@ -90,7 +90,7 @@ test_that("print() method works after gq", {
   # make sure the row order is correct
   out <- capture.output(fit_gq$print(c("y_rep[1]", "sum_y", "y_rep[3]")))
   expect_length(out, 4)
-  expect_match(out[1], " variable", out[1])
+  expect_match(out[1], " variable")
   expect_match(out[2], " y_rep[1]", fixed = TRUE)
   expect_match(out[3], " sum_y")
   expect_match(out[4], " y_rep[3]", fixed = TRUE)

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -151,7 +151,7 @@ test_that("print() method works after mcmc", {
   # make sure the row order is correct
   out <- capture.output(fit$print(c("theta[1]", "tau", "mu", "theta_raw[3]")))
   expect_length(out, 5)
-  expect_match(out[1], " variable", out[1])
+  expect_match(out[1], " variable")
   expect_match(out[2], " theta[1]", fixed = TRUE)
   expect_match(out[3], " tau")
   expect_match(out[4], " mu")


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The R-devel tests are currently failing with a `grepl` error:
```
Error in grepl(as.character(pattern), x, ignore.case, FALSE, perl, fixed,  : 
  NA in coercion to boolean
```

It looks like this is caused by a couple of the `expect_match` calls accidentally including the input variable twice:

```r
expect_match(out[1], " variable", out[1])
```

The second `out[1]` is assumed to be a boolean argument and R tries to convert it. I think it's only started to error recently since they've been majorly reworking the handling of boolean types in R's C API (but that's just a guess)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
