### PR TITLE
Expand default RTools toolchain usage to all R versions

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -22,13 +22,10 @@
 #'   C++ toolchain. It is called internally by `install_cmdstan()` but can also
 #'   be called directly by the user. On Windows only, calling the function with
 #'   the `fix = TRUE` argument will attempt to install the necessary toolchain
-#'   components if they are not found. For Windows users with RTools44 no additional
-#'   toolchain configuration is required. For users with older versions of RTools,
-#'   the function will install `mingw32-make` and `g++` from MSYS using the
-#'   RTools-provided `pacman` package manager. This can also be manually requested
-#'   by setting the environment variable `CMDSTANR_USE_MSYS_TOOLCHAIN` to 'true'
+#'   components if they are not found. For Windows users with RTools and CmdStan
+#'   versions >= 2.35 no additional toolchain configuration is required.
 #'
-#'   NOTE: When installing CmdStan on Windows with RTools44 and CmdStan versions
+#'   NOTE: When installing CmdStan on Windows with RTools and CmdStan versions
 #'   prior to 2.35.0, the above additional toolchain configuration
 #'   is still required. To enable this configuration, set the environment variable
 #'   `CMDSTANR_USE_MSYS_TOOLCHAIN` to 'true' and call
@@ -115,9 +112,9 @@ install_cmdstan <- function(dir = NULL,
     .cmdstanr$WSL <- FALSE
   }
   if (os_is_windows() && !os_is_wsl() && isTRUE(version < "2.35.0")) {
-    # RTools44 can be used unmodified with CmdStan 2.35+
+    # RTools can be used unmodified with CmdStan 2.35+
     # For new installs of older versions, users need to install mingw32-make and MSYS gcc
-    if (Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") == "" && rtools4x_version() == "44") {
+    if (Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") == "") {
       stop("CmdStan versions prior to 2.35.0 require additional toolchain configuration on Windows.\n",
             "Please set the environment variable CMDSTANR_USE_MSYS_TOOLCHAIN to 'true' and \n",
             "call `check_cmdstan_toolchain(fix = TRUE)` before installing CmdStan.", call. = FALSE)
@@ -663,8 +660,8 @@ check_rtools4x_windows_toolchain <- function(fix = FALSE, quiet = FALSE) {
       call. = FALSE
     )
   }
-  # No additional utilities/toolchains are needed with RTools44
-  if (rtools4x_version() >= "44" && Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") == "") {
+  # No additional utilities/toolchains are needed with RTools4
+  if (Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") == "") {
     return(invisible(NULL))
   }
   if (!is_toolchain_installed(app = "g++", path = toolchain_path) ||
@@ -879,7 +876,7 @@ rtools4x_toolchain_path <- function() {
   if (arch_is_aarch64()) {
     toolchain <- "aarch64-w64-mingw32.static.posix"
   } else {
-    if (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" ||
+    if (Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" ||
         isTRUE(cmdstan_version(error_on_NA=FALSE) < "2.35.0")) {
       toolchain <- ifelse(is_ucrt_toolchain(), "ucrt64", "mingw64")
     } else {

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,7 +97,7 @@ make_cmd <- function() {
   if (Sys.getenv("MAKE") != "") {
     Sys.getenv("MAKE")
   } else if (os_is_windows() && !os_is_wsl() &&
-        (rtools4x_version() < "44" || Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" || isTRUE(cmdstan_version(error_on_NA=FALSE) < "2.35.0"))) {
+        (Sys.getenv("CMDSTANR_USE_MSYS_TOOLCHAIN") != "" || isTRUE(cmdstan_version(error_on_NA=FALSE) < "2.35.0"))) {
     "mingw32-make.exe"
   } else {
     "make"

--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -120,13 +120,10 @@ The \code{check_cmdstan_toolchain()} function attempts to check for the required
 C++ toolchain. It is called internally by \code{install_cmdstan()} but can also
 be called directly by the user. On Windows only, calling the function with
 the \code{fix = TRUE} argument will attempt to install the necessary toolchain
-components if they are not found. For Windows users with RTools44 no additional
-toolchain configuration is required. For users with older versions of RTools,
-the function will install \code{mingw32-make} and \verb{g++} from MSYS using the
-RTools-provided \code{pacman} package manager. This can also be manually requested
-by setting the environment variable \code{CMDSTANR_USE_MSYS_TOOLCHAIN} to 'true'
+components if they are not found. For Windows users with RTools and CmdStan
+versions >= 2.35 no additional toolchain configuration is required.
 
-NOTE: When installing CmdStan on Windows with RTools44 and CmdStan versions
+NOTE: When installing CmdStan on Windows with RTools and CmdStan versions
 prior to 2.35.0, the above additional toolchain configuration
 is still required. To enable this configuration, set the environment variable
 \code{CMDSTANR_USE_MSYS_TOOLCHAIN} to 'true' and call


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

I had a look at the original [Math PR](https://github.com/stan-dev/math/pull/2999) adding compatibility with RTools `make`, and realised that it was compatible with all versions of RTools - not just RTools44!

This PR expands #1054 to use the stock Rtools toolchain for all cmdstan 2.35+ installations on Windows

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
