### PR TITLE
Install package build deps on MacOS

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -55,6 +55,12 @@ jobs:
           r-version: ${{ matrix.config.r }}
           rtools-version: ${{ matrix.config.rtools }}
 
+      - name: Install R Package Build Dependencies on MacOS
+        if: ${{ runner.os == 'macOS' }}
+        uses: r-hub/actions/setup-r-sysreqs@v1
+        with:
+          type: 'minimal'
+
       - uses: r-lib/actions/setup-pandoc@v2.11.3
 
       - uses: r-lib/actions/setup-r-dependencies@v2.11.3


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The MacOS R-Devel CI has been failing since R no longer bundles `libintl`, and the current `setup-r-dependencies` action [doesn't install system dependencies on macos](https://github.com/r-lib/actions/issues/998), so it was recommended we use separate action for this

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
