### PR TITLE
Workaround for https://github.com/r-lib/pak/issues/755

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -36,6 +36,7 @@ jobs:
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
       NOT_CRAN: true
       CMDSTANR_OPENCL_TESTS: ${{ matrix.config.opencl }}
+      PKG_SYSREQS_DB_UPDATE_TIMEOUT: 30
 
     steps:
       - name: cmdstan env vars


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This issue: https://github.com/r-lib/pak/issues/755 (also reported here: https://github.com/r-lib/actions/issues/994)
impacts github actions setup-r-dependenceis of ubuntu latest intermittently. I haven't seen it on main yet, but has it me when testing on my fork: https://github.com/katrinabrock/cmdstanr/actions/runs/14448908294/job/40516367645 Thought it would be good to per-emptively prevent this from causing CI failures.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Max Planck Institute of Animal Behavior


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
