### PR TITLE
Model specific version

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -234,7 +234,7 @@ CmdStanModel <- R6::R6Class(
     precompile_stanc_options_ = NULL,
     precompile_include_paths_ = NULL,
     variables_ = NULL,
-    cmdstan_version_ = cmdstan_version()
+    cmdstan_version_ = NULL
   ),
   public = list(
     functions = NULL,
@@ -272,6 +272,12 @@ CmdStanModel <- R6::R6Class(
       if (!is.null(stan_file) && compile) {
         self$compile(...)
       }
+
+      # for now, set this based on current version
+      # at initialize so its never null
+      # in the future, will be set only if/when we have a binary
+      # as the version the model was compiled with
+      private$cmdstan_version_ <- cmdstan_version()
       if (length(self$exe_file()) > 0 && file.exists(self$exe_file())) {
         cpp_options <- model_compile_info(self$exe_file(), self$cmdstan_version())
         for (cpp_option_name in names(cpp_options)) {

--- a/R/path.R
+++ b/R/path.R
@@ -234,11 +234,19 @@ unset_cmdstan_path <- function() {
 }
 
 # fake a cmdstan version (only used in tests)
-fake_cmdstan_version <- function(version) {
+fake_cmdstan_version <- function(version, mod = NULL) {
   .cmdstanr$VERSION <- version
+  if (!is.null(mod)) {
+    if (!is.null(mod$.__enclos_env__$private$exe_info_)) {
+      mod$.__enclos_env__$private$exe_info_$stan_version <- version
+    }
+    if (!is.null(mod$.__enclos_env__$private$cmdstan_version_)) {
+      mod$.__enclos_env__$private$cmdstan_version_ <- version
+    }
+  }
 }
-reset_cmdstan_version <- function() {
-  .cmdstanr$VERSION <- read_cmdstan_version(cmdstan_path())
+reset_cmdstan_version <- function(mod = NULL) {
+  fake_cmdstan_version(read_cmdstan_version(cmdstan_path()), mod = mod)
 }
 
 .home_path <- function() {

--- a/tests/testthat/test-model-sample.R
+++ b/tests/testthat/test-model-sample.R
@@ -316,13 +316,13 @@ test_that("Correct behavior if fixed_param not set when the model has no paramet
   "
   stan_file <- write_stan_file(code)
   m <- cmdstan_model(stan_file)
-  fake_cmdstan_version("2.35.0")
+  fake_cmdstan_version("2.35.0", m)
   expect_error(
     m$sample(),
     "Model contains no parameters. Please use 'fixed_param = TRUE'."
   )
 
-  reset_cmdstan_version()
+  reset_cmdstan_version(m)
   if (cmdstan_version() >= "2.36.0") {
     # as of 2.36.0 we don't need fixed_param if no parameters
     expect_no_error(
@@ -334,13 +334,13 @@ test_that("Correct behavior if fixed_param not set when the model has no paramet
 })
 
 test_that("sig_figs warning if version less than 2.25", {
-  fake_cmdstan_version("2.24.0")
+  fake_cmdstan_version("2.24.0", mod)
   expect_warning(
     expect_sample_output(mod$sample(data = data_list, chains = 1, refresh = 0, sig_figs = 3)),
     "The 'sig_figs' argument is only supported with cmdstan 2.25+ and will be ignored!",
     fixed = TRUE
   )
-  reset_cmdstan_version()
+  reset_cmdstan_version(mod)
 })
 
 test_that("Errors are suppressed with show_exceptions", {

--- a/tests/testthat/test-model-variables.R
+++ b/tests/testthat/test-model-variables.R
@@ -5,7 +5,7 @@ set_cmdstan_path()
 test_that("$variables() errors if version less than 2.27", {
   mod <- testing_model("bernoulli")
   ver <- cmdstan_version()
-  .cmdstanr$VERSION <- "2.26.0"
+  fake_cmdstan_version("2.26.0", mod = mod)
   expect_error(
     mod$variables(),
     "$variables() is only supported for CmdStan 2.27 or newer",

--- a/tests/testthat/test-opencl.R
+++ b/tests/testthat/test-opencl.R
@@ -107,15 +107,15 @@ test_that("all methods run with valid opencl_ids", {
 
 test_that("error for runtime selection of OpenCL devices if version less than 2.26", {
   skip_if_not(Sys.getenv("CMDSTANR_OPENCL_TESTS") %in% c("1", "true"))
-  fake_cmdstan_version("2.25.0")
 
   stan_file <- testing_stan_file("bernoulli")
   mod <- cmdstan_model(stan_file = stan_file, cpp_options = list(stan_opencl = TRUE),
                        force_recompile = TRUE)
+  fake_cmdstan_version("2.25.0", mod)
   expect_error(
     mod$sample(data = testing_data("bernoulli"), chains = 1, refresh = 0, opencl_ids = c(1,1)),
     "Runtime selection of OpenCL devices is only supported with CmdStan version 2.26 or newer",
     fixed = TRUE
   )
-  reset_cmdstan_version()
+  reset_cmdstan_version(mod)
 })


### PR DESCRIPTION
#### Submission Checklist

- [X] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Precursor to #1022 .

To properly handle options when cmdstanr is provided a pre-compiled binary, we need to base arg checking on the cpp args and cmdstan version that the binary was complied with. This version may or may not be the same as the version currently set. This PR does not solve this problem completely. It is a precursor to the solution by at least storing **a** cmdstan version value in the model object.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Max Planck Institute of Animal Behavior


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
