### PR TITLE
Use default rtools & actions versions in CI

### DIFF
--- a/.github/workflows/R-CMD-check-wsl.yaml
+++ b/.github/workflows/R-CMD-check-wsl.yaml
@@ -38,10 +38,10 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2.11.3
-      - uses: r-lib/actions/setup-pandoc@v2.11.3
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r-dependencies@v2.11.3
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           extra-packages: any::rcmdcheck, local::.
 
@@ -71,7 +71,7 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
-      - uses: r-lib/actions/check-r-package@v2.11.3
+      - uses: r-lib/actions/check-r-package@v2
         env:
           _R_CHECK_CRAN_INCOMING_: false
 

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -23,14 +23,14 @@ jobs:
       fail-fast: false
       matrix:
         config:
-          - {os: macOS-latest, r: 'devel', rtools: '', opencl: true}
-          - {os: macOS-latest, r: 'release', rtools: '', opencl: true}
-          - {os: windows-latest, r: 'devel', rtools: '45'}
-          - {os: windows-latest, r: 'release', rtools: '45'}
-          - {os: windows-latest, r: 'oldrel', rtools: '43'}
-          - {os: ubuntu-latest, r: 'devel', rtools: '', opencl: true}
-          - {os: ubuntu-latest, r: 'release', rtools: '', opencl: true}
-          - {os: ubuntu-latest, r: 'oldrel', rtools: '', opencl: true}
+          - {os: macOS-latest, r: 'devel', opencl: true}
+          - {os: macOS-latest, r: 'release', opencl: true}
+          - {os: windows-latest, r: 'devel' }
+          - {os: windows-latest, r: 'release'}
+          - {os: windows-latest, r: 'oldrel'}
+          - {os: ubuntu-latest, r: 'devel', opencl: true}
+          - {os: ubuntu-latest, r: 'release', opencl: true}
+          - {os: ubuntu-latest, r: 'oldrel', opencl: true}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -50,10 +50,9 @@ jobs:
 
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2.11.3
+      - uses: r-lib/actions/setup-r@v2
         with:
           r-version: ${{ matrix.config.r }}
-          rtools-version: ${{ matrix.config.rtools }}
 
       - name: Install R Package Build Dependencies on MacOS
         if: ${{ runner.os == 'macOS' }}
@@ -61,9 +60,9 @@ jobs:
         with:
           type: 'minimal'
 
-      - uses: r-lib/actions/setup-pandoc@v2.11.3
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r-dependencies@v2.11.3
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache: "always"
           extra-packages: any::rcmdcheck, local::.
@@ -96,7 +95,7 @@ jobs:
           sessioninfo::session_info(pkgs, include_base = TRUE)
         shell: Rscript {0}
 
-      - uses: r-lib/actions/check-r-package@v2.11.3
+      - uses: r-lib/actions/check-r-package@v2
         env:
           _R_CHECK_CRAN_INCOMING_: false
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Cuts down on a bit of the CI churn/noise by using the default version of rtools for the given r-version, and using the higher-level actions version (e.g., `@v2` instead of `@v2.11.3`)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
