### PR TITLE
Reuse compiled model methods across models

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -335,14 +335,16 @@ CmdStanFit$set("public", name = "init", value = init)
 #'   [unconstrain_variables()], [unconstrain_draws()], [variable_skeleton()],
 #'   [hessian()]
 #'
-init_model_methods <- function(seed = 1, verbose = FALSE, hessian = FALSE) {
+init_model_methods <- function(seed = 1, verbose = FALSE, hessian = FALSE, force_recompile = FALSE) {
   if (os_is_wsl()) {
     stop("Additional model methods are not currently available with ",
           "WSL CmdStan and will not be compiled",
           call. = FALSE)
   }
   require_suggested_package("Rcpp")
-  if (length(private$model_methods_env_$hpp_code_) == 0) {
+  if (length(private$model_methods_env_$hpp_code_) == 0 && (
+        is.null(private$model_methods_env_$obj_file_) ||
+        !file.exists(private$model_methods_env_$obj_file_))) {
     stop("Model methods cannot be used with a pre-compiled Stan executable, ",
           "the model must be compiled again", call. = FALSE)
   }
@@ -352,7 +354,7 @@ init_model_methods <- function(seed = 1, verbose = FALSE, hessian = FALSE) {
             "errors that you encounter")
   }
   if (is.null(private$model_methods_env_$model_ptr)) {
-    expose_model_methods(private$model_methods_env_, verbose, hessian)
+    expose_model_methods(private$model_methods_env_, verbose, hessian, force_recompile = FALSE)
   }
   if (!("model_ptr_" %in% ls(private$model_methods_env_))) {
     initialize_model_pointer(private$model_methods_env_, self$data_file(), seed)

--- a/R/fit.R
+++ b/R/fit.R
@@ -326,6 +326,7 @@ CmdStanFit$set("public", name = "init", value = init)
 #' @param seed (integer) The random seed to use when initializing the model.
 #' @param verbose (logical) Whether to show verbose logging during compilation.
 #' @param hessian (logical) Whether to expose the (experimental) hessian method.
+#' @param force_recompile (logical) Whether to recompile model methods, even if cached
 #'
 #' @examples
 #' \dontrun{

--- a/R/install.R
+++ b/R/install.R
@@ -494,6 +494,8 @@ build_cmdstan <- function(dir,
 clean_cmdstan <- function(dir = cmdstan_path(),
                           cores = getOption("mc.cores", 2),
                           quiet = FALSE) {
+  unlink(file.path(dir, "model_methods.o"))
+  unlink(file.path(dir, "model_methods.cpp"))
   withr::with_envvar(
     c("HOME" = short_path(Sys.getenv("HOME"))),
     withr::with_path(

--- a/R/model.R
+++ b/R/model.R
@@ -681,7 +681,7 @@ compile <- function(quiet = TRUE,
         run_log <- wsl_compatible_run(
           command = make_cmd(),
           args = c(wsl_safe_path(repair_path(tmp_exe)),
-                  cpp_options_to_compile_flags(cpp_options),
+                  cpp_options_to_compile_flags(c(cpp_options, list("KEEP_OBJECT"="true", "CXXFLAGS += -fPIC"))),
                   stancflags_val),
           wd = cmdstan_path(),
           echo = !quiet || is_verbose_mode(),
@@ -735,6 +735,7 @@ compile <- function(quiet = TRUE,
       file.remove(exe)
     }
     file.copy(tmp_exe, exe, overwrite = TRUE)
+    private$model_methods_env_$obj_file_ <- paste0(temp_file_no_ext, ".o")
     if (os_is_wsl()) {
       res <- processx::run(
         command = "wsl",

--- a/R/utils.R
+++ b/R/utils.R
@@ -836,6 +836,8 @@ initialize_method_functions <- function(env, so_name) {
     function(...) { .Call("get_param_metadata_", ..., PACKAGE = so_name) }
   env$unconstrain_variables <-
     function(...) { .Call("unconstrain_variables_", ..., PACKAGE = so_name) }
+  env$unconstrain_draws <-
+    function(...) { .Call("unconstrain_draws_", ..., PACKAGE = so_name) }
   env$constrain_variables <-
     function(...) { .Call("constrain_variables_", ..., PACKAGE = so_name) }
   env$unconstrained_param_names <-

--- a/inst/include/model_methods.cpp
+++ b/inst/include/model_methods.cpp
@@ -140,7 +140,7 @@ RcppExport SEXP unconstrain_variables_(SEXP ext_model_ptr, SEXP variables_) {
   END_RCPP
 }
 
-RcppExport SEXP unconstrain_draws(SEXP ext_model_ptr, SEXP variables_) {
+RcppExport SEXP unconstrain_draws_(SEXP ext_model_ptr, SEXP variables_) {
   BEGIN_RCPP
   Rcpp::XPtr<stan::model::model_base> ptr(ext_model_ptr);
   Eigen::MatrixXd variables = Rcpp::as<Eigen::MatrixXd>(variables_);

--- a/man/fit-method-init_model_methods.Rd
+++ b/man/fit-method-init_model_methods.Rd
@@ -6,7 +6,12 @@
 \title{Compile additional methods for accessing the model log-probability function
 and parameter constraining and unconstraining.}
 \usage{
-init_model_methods(seed = 1, verbose = FALSE, hessian = FALSE)
+init_model_methods(
+  seed = 1,
+  verbose = FALSE,
+  hessian = FALSE,
+  force_recompile = FALSE
+)
 }
 \arguments{
 \item{seed}{(integer) The random seed to use when initializing the model.}
@@ -14,6 +19,8 @@ init_model_methods(seed = 1, verbose = FALSE, hessian = FALSE)
 \item{verbose}{(logical) Whether to show verbose logging during compilation.}
 
 \item{hessian}{(logical) Whether to expose the (experimental) hessian method.}
+
+\item{force_recompile}{(logical) Whether to recompile model methods, even if cached}
 }
 \description{
 The \verb{$init_model_methods()} method compiles and initializes the


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Updated implementation of #894.

Now that we use the standard Windows toolchain, I can resurrect the PR for caching the compilation of model methods. Users will now only have to compile the model methods once for one model, and future calls for other models to `$init_model_methods()` will simply link the existing cmdstan model object against the cached compiled model methods.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
