### PR TITLE
Remove use of "beta" from Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,7 +34,7 @@ analysis.
 
 #### Installing the R package
 
-You can install the latest beta release of the **cmdstanr** R package with
+You can install the latest release of the **cmdstanr** R package with
 
 ```r
 # we recommend running this in a fresh R session or restarting your current session


### PR DESCRIPTION
Remove's "beta" from description of R package in the readme. Technically we're haven't done the 1.0 release, but it's quite stable and several people have expressed confusion over whether we consider it unstable based on the use of "beta" to describe the R package releases.

#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Please describe the purpose of the pull request.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
