### PR TITLE
Default to `r_eff=FALSE` for `loo()` method 

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -1502,11 +1502,11 @@ CmdStanMCMC <- R6::R6Class(
 #'   `"log_lik"`. This argument is passed to the [`$draws()`][fit-method-draws]
 #'   method.
 #' @param r_eff (multiple options) How to handle the `r_eff` argument for `loo()`:
-#'   * `TRUE` (the default) will automatically call [loo::relative_eff.array()]
-#'   to compute the `r_eff` argument to pass to [loo::loo.array()].
-#'   * `FALSE` or `NULL` will avoid computing `r_eff` (which can sometimes be slow),
-#'   but the reported ESS and MCSE estimates can be over-optimistic if the
-#'   posterior draws are not (near) independent.
+#'   * `TRUE` will call [loo::relative_eff.array()] to compute the `r_eff`
+#'   argument to pass to [loo::loo.array()].
+#'   * `FALSE` (the default) or `NULL` will avoid computing `r_eff`,
+#'   which can be very slow. The reported ESS and MCSE estimates may be
+#'   over-optimistic if the posterior draws are not near independent.
 #'   * If `r_eff` is anything else, that object will be passed as the `r_eff`
 #'   argument to [loo::loo.array()].
 #' @param moment_match (logical) Whether to use a
@@ -1537,7 +1537,7 @@ CmdStanMCMC <- R6::R6Class(
 #' print(loo_result)
 #' }
 #'
-loo <- function(variables = "log_lik", r_eff = TRUE, moment_match = FALSE, ...) {
+loo <- function(variables = "log_lik", r_eff = FALSE, moment_match = FALSE, ...) {
   require_suggested_package("loo")
   if (length(variables) != 1) {
     stop("Only a single variable name is allowed for the 'variables' argument.", call. = FALSE)

--- a/man/fit-method-loo.Rd
+++ b/man/fit-method-loo.Rd
@@ -5,7 +5,7 @@
 \alias{loo}
 \title{Leave-one-out cross-validation (LOO-CV)}
 \usage{
-loo(variables = "log_lik", r_eff = TRUE, moment_match = FALSE, ...)
+loo(variables = "log_lik", r_eff = FALSE, moment_match = FALSE, ...)
 }
 \arguments{
 \item{variables}{(string) The name of the variable in the Stan program
@@ -15,11 +15,11 @@ method.}
 
 \item{r_eff}{(multiple options) How to handle the \code{r_eff} argument for \code{loo()}:
 \itemize{
-\item \code{TRUE} (the default) will automatically call \code{\link[loo:relative_eff]{loo::relative_eff.array()}}
-to compute the \code{r_eff} argument to pass to \code{\link[loo:loo]{loo::loo.array()}}.
-\item \code{FALSE} or \code{NULL} will avoid computing \code{r_eff} (which can sometimes be slow),
-but the reported ESS and MCSE estimates can be over-optimistic if the
-posterior draws are not (near) independent.
+\item \code{TRUE} will call \code{\link[loo:relative_eff]{loo::relative_eff.array()}} to compute the \code{r_eff}
+argument to pass to \code{\link[loo:loo]{loo::loo.array()}}.
+\item \code{FALSE} (the default) or \code{NULL} will avoid computing \code{r_eff},
+which can be very slow. The reported ESS and MCSE estimates may be
+over-optimistic if the posterior draws are not near independent.
 \item If \code{r_eff} is anything else, that object will be passed as the \code{r_eff}
 argument to \code{\link[loo:loo]{loo::loo.array()}}.
 }}


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Changes default from `TRUE` to `FALSE` for the `r_eff` argument to the `loo()` method. This is based on @avehtari's comment at https://discourse.mc-stan.org/t/loo-subsample-slower-than-loo/39556/5

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
