### PR TITLE
Update Test-coverage.yaml

### DIFF
--- a/.github/workflows/Test-coverage.yaml
+++ b/.github/workflows/Test-coverage.yaml
@@ -2,15 +2,15 @@
 # Github Actions workflow to analyze CmdStanR code, test coverage
 # yamllint disable rule:line-length
 
-name: Test coverage
-
-'on':
+on:
   push:
     branches:
       - master
   pull_request:
-    branches:
-      - master
+
+name: Test coverage
+
+permissions: read-all
 
 jobs:
   test-coverage:
@@ -38,16 +38,18 @@ jobs:
       - uses: n1hility/cancel-previous-runs@v3
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          workflow: Test-coverage.yml
+          workflow: Test-coverage.yaml
         if: "!startsWith(github.ref, 'refs/tags/') && github.ref != 'refs/heads/master'"
+
       - uses: actions/checkout@v4
 
-      - uses: r-lib/actions/setup-r@v2.11.3
-      - uses: r-lib/actions/setup-pandoc@v2.11.3
+      - uses: r-lib/actions/setup-r@v2
+      - uses: r-lib/actions/setup-pandoc@v2
 
-      - uses: r-lib/actions/setup-r-dependencies@v2.11.3
+      - uses: r-lib/actions/setup-r-dependencies@v2
         with:
-          extra-packages: any::rcmdcheck, local::., any::covr, any::gridExtra
+          extra-packages: any::rcmdcheck, local::., any::covr, any::gridExtra, any::xml2
+          needs: coverage
 
       - name: Install cmdstan
         run: |
@@ -57,16 +59,55 @@ jobs:
 
       - name: Test coverage (Linux)
         if: runner.os == 'Linux'
-        run: covr::codecov(type = "tests")
+        run: |
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package"),
+            type = "tests"
+          )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} 
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Test coverage (Windows)
         if: runner.os == 'Windows'
         run: |
           options(covr.gcov = 'C:/rtools44/mingw64/bin/gcov.exe');
-          covr::codecov(type = "tests", function_exclusions = "sample_mpi")
+          cov <- covr::package_coverage(
+            quiet = FALSE,
+            clean = FALSE,
+            install_path = file.path(normalizePath(Sys.getenv("RUNNER_TEMP"), winslash = "/"), "package"),
+            type = "tests",
+            function_exclusions = "sample_mpi"
+          )
+          print(cov)
+          covr::to_cobertura(cov)
         shell: Rscript {0}
         env:
-          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }} 
+          CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+
+      - uses: codecov/codecov-action@v5
+        with:
+          # Fail if error if not on PR, or if on PR and token is given
+          fail_ci_if_error: ${{ github.event_name != 'pull_request' || secrets.CODECOV_TOKEN }}
+          files: ./cobertura.xml
+          plugins: noop
+          disable_search: true
+          token: ${{ secrets.CODECOV_TOKEN }}
+
+      - name: Show testthat output
+        if: always()
+        run: |
+          ## --------------------------------------------------------------------
+          find '${{ runner.temp }}/package' -name 'testthat.Rout*' -exec cat '{}' \; || true
+        shell: bash
+
+      - name: Upload test results
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-test-failures
+          path: ${{ runner.temp }}/package


### PR DESCRIPTION
#### Submission Checklist

- [ ] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

It doesn't seem like codecov is properly tracking the coverage for the package. This PR updates the test coverage yaml file to be close to the latest from `r-lib/actions`. We can't use exactly their file, but this tries to get as close as possible while keeping the custom stuff we need for cmdstanr. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Columbia University**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
