### PR TITLE
Fix handling of `include_paths` for pre-compiled models

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -11,6 +11,7 @@ set to `TRUE` for an entire R session via new global options. (#1159)
 * `save_metric_files()` now gives an informative error when metric files were not created and keeps saved metric files after the fitted model is garbage-collected. (#1021)
 * `cmdstan_model()` no longer fails when `MAKEFLAGS` enables directory-printing 
 output while reading `STANCFLAGS` from `make`. (#1163)
+* `cmdstan_model()` now retains include paths when initialized with both a Stan file and a precompiled executable, fixing model introspection for programs that use `#include` (#1094).
 * `laplace()` no longer overwrites the internally generated optimizer CSV when
 `mode = NULL` and `output_basename` is supplied. The internally generated
 optimizer CSV now uses the filename `<output_basename>-mode-1.csv`.

--- a/R/model.R
+++ b/R/model.R
@@ -270,6 +270,8 @@ CmdStanModel <- R6::R6Class(
           assert_file_exists(private$exe_file_, access = "r", extension = ext)
           private$model_name_ <- gsub(" ", "_", strip_ext(basename(private$exe_file_)))
         }
+        private$include_paths_ <-
+          private$precompile_include_paths_ %||% args$include_paths
       }
       if (!is.null(stan_file) && compile) {
         self$compile(...)

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -109,6 +109,64 @@ test_that("compilation works with include_paths", {
   )
 })
 
+test_that("precompiled models retain include paths", {
+  model_dir <- withr::local_tempdir()
+  write_stan_file(
+    "
+    functions {
+      real silly_logit(real x) {
+        return logit(x);
+      }
+    }
+    ",
+    dir = file.path(model_dir, "utils"),
+    basename = "silly.stan"
+  )
+  stan_file <- write_stan_file(
+    "
+    #include utils/silly.stan
+    data {
+      int<lower=0> N;
+      array[N] int<lower=0, upper=1> y;
+    }
+    parameters {
+      real<lower=0, upper=1> theta;
+    }
+    model {
+      theta ~ beta(1, 1);
+      y ~ bernoulli(theta);
+    }
+    generated quantities {
+      real theta_lin = silly_logit(theta);
+    }
+    ",
+    dir = model_dir,
+    basename = "bernoulli.stan"
+  )
+  compiled_model <- cmdstan_model(
+    stan_file,
+    include_paths = model_dir,
+    quiet = TRUE
+  )
+
+  model_with_explicit_path <- cmdstan_model(
+    stan_file,
+    exe_file = compiled_model$exe_file(),
+    compile = FALSE,
+    include_paths = model_dir
+  )
+  expect_equal(model_with_explicit_path$include_paths(), model_dir)
+  expect_no_error(model_with_explicit_path$variables())
+
+  model_with_automatic_path <- cmdstan_model(
+    stan_file,
+    exe_file = compiled_model$exe_file(),
+    compile = FALSE
+  )
+  expect_equal(model_with_automatic_path$include_paths(), dirname(stan_file))
+  expect_no_error(model_with_automatic_path$variables())
+})
+
 test_that("name in STANCFLAGS is set correctly", {
   local_reproducible_output()
   out <- utils::capture.output(mod$compile(quiet = FALSE, force_recompile = TRUE))


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #1094.

When `cmdstan_model()` is initialized with both `stan_file` and an existing `exe_file`, the executable-backed model doesn't retain the include path inferred from `dirname(stan_file)`. Explicit `include_paths` are also dropped. As a result, methods like `$variables()` can't parse Stan programs that use `#include`.

To fix this we keep the precompile include path when the executable is supplied. 


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)