### PR TITLE
add show_messages and show_exceptions to generate_quantities

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -2095,12 +2095,16 @@ generate_quantities <- function(fitted_params,
                                 sig_figs = NULL,
                                 parallel_chains = getOption("mc.cores", 1),
                                 threads_per_chain = NULL,
-                                opencl_ids = NULL) {
+                                opencl_ids = NULL,
+                                show_messages = TRUE,
+                                show_exceptions = TRUE) {
   fitted_params_files <- process_fitted_params(fitted_params)
   procs <- CmdStanGQProcs$new(
     num_procs = length(fitted_params_files),
     parallel_procs = checkmate::assert_integerish(parallel_chains, lower = 1, null.ok = TRUE),
-    threads_per_proc = assert_valid_threads(threads_per_chain, self$cpp_options(), multiple_chains = TRUE)
+    threads_per_proc = assert_valid_threads(threads_per_chain, self$cpp_options(), multiple_chains = TRUE),
+    show_stderr_messages = show_exceptions,
+    show_stdout_messages = show_messages
   )
   model_variables <- NULL
   if (is_variables_method_supported(self)) {

--- a/man/model-method-generate-quantities.Rd
+++ b/man/model-method-generate-quantities.Rd
@@ -14,7 +14,9 @@ generate_quantities(
   sig_figs = NULL,
   parallel_chains = getOption("mc.cores", 1),
   threads_per_chain = NULL,
-  opencl_ids = NULL
+  opencl_ids = NULL,
+  show_messages = TRUE,
+  show_exceptions = TRUE
 )
 }
 \arguments{
@@ -103,6 +105,19 @@ the Stan case study \href{https://mc-stan.org/users/documentation/case-studies/r
 the OpenCL device to use for fitting. The model must be compiled with
 \code{cpp_options = list(stan_opencl = TRUE)} for this argument to have an
 effect.}
+
+\item{show_messages}{(logical) When \code{TRUE} (the default), prints all output
+during the execution process, such as iteration numbers and elapsed times.
+If the output is silenced then the \code{\link[=fit-method-output]{$output()}} method
+of the resulting fit object can be used to display the silenced messages.}
+
+\item{show_exceptions}{(logical) When \code{TRUE} (the default), prints all
+informational messages, for example rejection of the current proposal.
+Disable if you wish to silence these messages, but this is not usually
+recommended unless you are very confident that the model is correct up to
+numerical error. If the messages are silenced then the
+\code{\link[=fit-method-output]{$output()}} method of the resulting fit object can be
+used to display the silenced messages.}
 }
 \value{
 A \code{\link{CmdStanGQ}} object.

--- a/tests/testthat/test-model-generate_quantities.R
+++ b/tests/testthat/test-model-generate_quantities.R
@@ -92,3 +92,14 @@ test_that("generate_quantities() warns if threads specified but not enabled", {
     "'threads_per_chain' will have no effect"
   )
 })
+
+test_that("no output with show_messages = FALSE", {
+  output <- utils::capture.output(
+    fit_gq <- mod_gq$generate_quantities(
+      fitted_params = fit,
+      data = data_list,
+      show_messages = FALSE
+    )
+  )
+  expect_equal(length(output), 0)
+})

--- a/tests/testthat/test-model-pathfinder.R
+++ b/tests/testthat/test-model-pathfinder.R
@@ -150,3 +150,10 @@ test_that("no error when checking estimates after failure", {
   expect_silent(fit$summary()) # no error
 })
 
+test_that("no output with show_messages = FALSE", {
+  output <- utils::capture.output(
+    fit <- mod$pathfinder(data = data_list, show_messages = FALSE, seed = 123)
+  )
+  expect_equal(length(output), 0)
+})
+


### PR DESCRIPTION
#### Summary

Closes #1140. `generate_quantities` was missing arguments `show_messages` and `show_exceptions`. This PR adds them, and also adds tests.

- R/model.R — `generate_quantities()` method
    - Added `show_messages = TRUE` and `show_exceptions = TRUE` to the function signature
    - Passed them to `CmdStanGQProcs$new()` as `show_stdout_messages = show_messages` and `show_stderr_messages = show_exceptions`
- `tests/testthat/test-model-generate_quantities.R` and 
    - Added test: `"no output with show_messages = FALSE"`
- `tests/testthat/test-model-pathfinder.R`
    - Added test: "no output with show_messages = FALSE" (pathfinder already had the arguments implemented, just lacked a test)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):

Aki Vehtari

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
