### PR TITLE
fix: fix init with draws or fit object and without .stan file

### DIFF
--- a/R/args.R
+++ b/R/args.R
@@ -1035,6 +1035,38 @@ validate_exe_file <- function(exe_file) {
 }
 
 
+#' Build a model_variables structure from a draws object
+#'
+#' When a model has been created without a Stan file,
+#' `model$variables()` is unavailable. This helper infers parameter
+#' names and whether each is a scalar or container from
+#' `posterior::variables(as_draws_df(...))`. In that representation
+#' containers are expanded (e.g. `beta[1]`, `gamma[1,2]`) while
+#' scalars appear as bare names (e.g. `sigma`). A name without `[` is
+#' a scalar; a name with `[` is a container whose base name is
+#' extracted.
+#'
+#' @noRd
+#' @param draws A draws object (any format supported by posterior).
+#' @return A list with a `parameters` element in the same format as
+#'   `model$variables()`. The dimensions is stored as 0 for scalars
+#'   and 1 for containers, which is sufficient for `process_init.draws()`.
+model_variables_from_draws <- function(draws) {
+  df_vars <- posterior::variables(posterior::as_draws_df(draws))
+  df_vars <- df_vars[!grepl("__$", df_vars)]
+  has_bracket <- grepl("\\[", df_vars)
+  scalars <- df_vars[!has_bracket]
+  containers <- unique(sub("\\[.*", "", df_vars[has_bracket]))
+  parameters <- list()
+  for (var_name in scalars) {
+    parameters[[var_name]] <- list(type = "real", dimensions = 0L)
+  }
+  for (var_name in containers) {
+    parameters[[var_name]] <- list(type = "real", dimensions = 1L)
+  }
+  list(parameters = parameters)
+}
+
 #' Generic for processing inits
 #' @noRd
 process_init <- function(init, ...) {
@@ -1080,12 +1112,11 @@ process_init.default <- function(init, ...) {
 process_init.draws <- function(init, num_procs, model_variables = NULL,
                                warn_partial = getOption("cmdstanr_warn_inits", TRUE),
                                ...) {
-  if (!is.null(model_variables)) {
-    variable_names = names(model_variables$parameters)
-  } else {
-    variable_names = colnames(draws)[!grepl("__", colnames(draws))]
-  }
   draws <- posterior::as_draws_df(init)
+  if (is.null(model_variables)) {
+    model_variables <- model_variables_from_draws(draws)
+  }
+  variable_names = names(model_variables$parameters)
   # Since all other process_init functions return `num_proc` inits
   # This will only happen if a raw draws object is passed
   if (nrow(draws) < num_procs) {
@@ -1266,9 +1297,6 @@ process_init.CmdStanMCMC <- function(init, num_procs, model_variables = NULL,
                                      ...) {
   validate_fit_init(init, model_variables)
   draws_df = init$draws(format = "df")
-  if (is.null(model_variables)) {
-    model_variables = list(parameters = colnames(draws_df)[2:(length(colnames(draws_df)) - 3)])
-  }
   init_draws_df = posterior::resample_draws(draws_df, ndraws = num_procs,
                                             method = "simple_no_replace")
   init_draws_lst = process_init(init_draws_df,
@@ -1293,9 +1321,6 @@ process_init_approx <- function(init, num_procs, model_variables = NULL,
   validate_fit_init(init, model_variables)
   # Convert from data.table to data.frame
   draws_df = init$draws(format = "df")
-  if (is.null(model_variables)) {
-    model_variables = list(parameters = colnames(draws_df)[3:(length(colnames(draws_df)) - 3)])
-  }
   draws_df$lw = draws_df$lp__ - draws_df$lp_approx__
   # Replace NaN and Inf with -Inf
   draws_df$lw[!is.finite(draws_df$lw)] <- -Inf
@@ -1326,14 +1351,15 @@ process_init_approx <- function(init, num_procs, model_variables = NULL,
       draws_df$weight = posterior::pareto_smooth(
         exp(draws_df$lw - max(draws_df$lw)), tail = "right", r_eff=1, return_k=FALSE)
   }
-  init_draws_df = posterior::resample_draws(draws_df, ndraws = num_procs,
-                                            weights = draws_df$weight, method = "simple_no_replace")
-  init_draws_lst = process_init(init_draws_df,
-                                num_procs = num_procs, model_variables = model_variables, warn_partial)
-  return(init_draws_lst)
-}
-
-
+    init_draws_df = posterior::resample_draws(draws_df, ndraws = num_procs,
+                                              weights = draws_df$weight, method = "simple_no_replace")
+    init_draws_df = posterior::subset_draws(init_draws_df,
+      variable = setdiff(posterior::variables(init_draws_df), c("lw", "weight")))
+    init_draws_lst = process_init(init_draws_df,
+                                  num_procs = num_procs, model_variables = model_variables, warn_partial)
+    return(init_draws_lst)
+  }
+  
 #' Write initial values to files if provided as a `CmdStanPathfinder` class
 #' @noRd
 #' @param init A `CmdStanPathfinder` class
@@ -1352,12 +1378,11 @@ process_init.CmdStanPathfinder <- function(init, num_procs, model_variables = NU
     validate_fit_init(init, model_variables)
     # Convert from data.table to data.frame
     draws_df = init$draws(format = "df")
-    if (is.null(model_variables)) {
-      model_variables = list(parameters = colnames(draws_df)[3:(length(colnames(draws_df)) - 3)])
-    }
     draws_df$weight = rep(1.0, nrow(draws_df))
     init_draws_df = posterior::resample_draws(draws_df, ndraws = num_procs,
       weights = draws_df$weight, method = "simple_no_replace")
+    init_draws_df = posterior::subset_draws(init_draws_df,
+      variable = setdiff(posterior::variables(init_draws_df), "weight"))
     init_draws_lst = process_init(init_draws_df,
       num_procs = num_procs, model_variables = model_variables, warn_partial)
     return(init_draws_lst)
@@ -1418,9 +1443,6 @@ process_init.CmdStanMLE <- function(init, num_procs, model_variables = NULL,
   # Convert from data.table to data.frame
   validate_fit_init(init, model_variables)
   draws_df = init$draws(format = "df")
-  if (is.null(model_variables)) {
-    model_variables = list(parameters = colnames(draws_df)[2:(length(colnames(draws_df)) - 3)])
-  }
   init_draws_df = draws_df[rep(1, num_procs),]
   init_draws_lst_lst = process_init(init_draws_df,
                                     num_procs = num_procs, model_variables = model_variables, warn_partial)

--- a/R/args.R
+++ b/R/args.R
@@ -1039,30 +1039,34 @@ validate_exe_file <- function(exe_file) {
 #'
 #' When a model has been created without a Stan file,
 #' `model$variables()` is unavailable. This helper infers parameter
-#' names and whether each is a scalar or container from
-#' `posterior::variables(as_draws_df(...))`. In that representation
-#' containers are expanded (e.g. `beta[1]`, `gamma[1,2]`) while
-#' scalars appear as bare names (e.g. `sigma`). A name without `[` is
-#' a scalar; a name with `[` is a container whose base name is
-#' extracted.
+#' names and dimensions from `posterior::variables(as_draws_df(...))`.
+#' In that representation containers are expanded (e.g. `beta[1]`,
+#' `gamma[1,2]`) while scalars appear as bare names (e.g. `sigma`).
+#' The number of dimensions is inferred from the index pattern:
+#' `mu[1]` has 1, `mu[1,2]` has 2, etc.
 #'
 #' @noRd
 #' @param draws A draws object (any format supported by posterior).
 #' @return A list with a `parameters` element in the same format as
-#'   `model$variables()`. The dimensions is stored as 0 for scalars
-#'   and 1 for containers, which is sufficient for `process_init.draws()`.
+#'   `model$variables()`.
 model_variables_from_draws <- function(draws) {
   df_vars <- posterior::variables(posterior::as_draws_df(draws))
   df_vars <- df_vars[!grepl("__$", df_vars)]
   has_bracket <- grepl("\\[", df_vars)
   scalars <- df_vars[!has_bracket]
-  containers <- unique(sub("\\[.*", "", df_vars[has_bracket]))
+  # For containers, extract base name and count dimensions from the
+  # index pattern of the first occurrence (e.g. "mu[1,2]" -> 2 dims)
+  container_vars <- df_vars[has_bracket]
+  container_names <- sub("\\[.*", "", container_vars)
+  container_indices <- sub("^[^\\[]*\\[(.*)\\]$", "\\1", container_vars)
   parameters <- list()
   for (var_name in scalars) {
     parameters[[var_name]] <- list(type = "real", dimensions = 0L)
   }
-  for (var_name in containers) {
-    parameters[[var_name]] <- list(type = "real", dimensions = 1L)
+  for (var_name in unique(container_names)) {
+    idx <- match(var_name, container_names)
+    ndims <- length(strsplit(container_indices[idx], ",")[[1]])
+    parameters[[var_name]] <- list(type = "real", dimensions = ndims)
   }
   list(parameters = parameters)
 }

--- a/R/args.R
+++ b/R/args.R
@@ -81,7 +81,7 @@ CmdStanArgs <- R6::R6Class(
       init <- process_init(init, num_inits, model_variables)
       self$init <- init
       self$opencl_ids <- opencl_ids
-      self$num_threads = NULL
+      self$num_threads <- NULL
       self$method_args$validate(num_procs = length(self$proc_ids))
       if (is.logical(self$save_cmdstan_config)) {
         self$save_cmdstan_config <- as.integer(self$save_cmdstan_config)
@@ -984,7 +984,7 @@ validate_pathfinder_args <- function(self) {
     self$num_elbo_draws <- as.integer(self$num_elbo_draws)
   }
   if (!is.null(self$save_single_paths) && is.logical(self$save_single_paths)) {
-    self$save_single_paths = as.integer(self$save_single_paths)
+    self$save_single_paths <- as.integer(self$save_single_paths)
   }
   checkmate::assert_integerish(self$save_single_paths, null.ok = TRUE,
                                lower = 0, upper = 1, len = 1)
@@ -992,12 +992,12 @@ validate_pathfinder_args <- function(self) {
     self$save_single_paths <- 0
   }
   if (!is.null(self$psis_resample) && is.logical(self$psis_resample)) {
-    self$psis_resample = as.integer(self$psis_resample)
+    self$psis_resample <- as.integer(self$psis_resample)
   }
   checkmate::assert_integerish(self$psis_resample, null.ok = TRUE,
                                lower = 0, upper = 1, len = 1)
   if (!is.null(self$calculate_lp) && is.logical(self$calculate_lp)) {
-    self$calculate_lp = as.integer(self$calculate_lp)
+    self$calculate_lp <- as.integer(self$calculate_lp)
   }
   checkmate::assert_integerish(self$calculate_lp, null.ok = TRUE,
                                lower = 0, upper = 1, len = 1)
@@ -1018,22 +1018,8 @@ validate_pathfinder_args <- function(self) {
 }
 
 
-# Validation helpers ------------------------------------------------------
 
-#' Validate exe file exists
-#' @noRd
-#' @param exe_file Path to executable.
-#' @return Either throws an error or returns `invisible(TRUE)`
-validate_exe_file <- function(exe_file) {
-  if (!length(exe_file) ||
-      !nzchar(exe_file) ||
-      !file.exists(exe_file)) {
-    stop("Model not compiled. Try running the compile() method first.",
-         call. = FALSE)
-  }
-  invisible(TRUE)
-}
-
+# Init helpers ------------------------------------------------------------
 
 #' Build a model_variables structure from a draws object
 #'
@@ -1120,7 +1106,7 @@ process_init.draws <- function(init, num_procs, model_variables = NULL,
   if (is.null(model_variables)) {
     model_variables <- model_variables_from_draws(draws)
   }
-  variable_names = names(model_variables$parameters)
+  variable_names <- names(model_variables$parameters)
   # Since all other process_init functions return `num_proc` inits
   # This will only happen if a raw draws object is passed
   if (nrow(draws) < num_procs) {
@@ -1130,12 +1116,12 @@ process_init.draws <- function(init, num_procs, model_variables = NULL,
     draws <- posterior::resample_draws(draws, ndraws = num_procs,
                                        method ="simple_no_replace")
   }
-  draws_rvar = posterior::as_draws_rvars(draws)
+  draws_rvar <- posterior::as_draws_rvars(draws)
   variable_names <- variable_names[variable_names %in% names(draws_rvar)]
   draws_rvar <- posterior::subset_draws(draws_rvar, variable = variable_names)
-  inits = lapply(1:num_procs, function(draw_iter) {
-    init_i = lapply(variable_names, function(var_name) {
-      x = .remove_leftmost_dim(posterior::draws_of(
+  inits <- lapply(1:num_procs, function(draw_iter) {
+    init_i <- lapply(variable_names, function(var_name) {
+      x <- .remove_leftmost_dim(posterior::draws_of(
         posterior::subset_draws(draws_rvar[[var_name]], draw=draw_iter)))
       if (model_variables$parameters[[var_name]]$dimensions == 0) {
         return(as.double(x))
@@ -1143,25 +1129,25 @@ process_init.draws <- function(init, num_procs, model_variables = NULL,
         return(x)
       }
     })
-    bad_names = unlist(lapply(variable_names, function(var_name) {
-      x = drop(posterior::draws_of(drop(
+    bad_names <- unlist(lapply(variable_names, function(var_name) {
+      x <- drop(posterior::draws_of(drop(
         posterior::subset_draws(draws_rvar[[var_name]], draw=draw_iter))))
       if (any(is.infinite(x)) || any(is.na(x))) {
         return(var_name)
       }
       return("")
     }))
-    any_na_or_inf = bad_names != ""
+    any_na_or_inf <- bad_names != ""
     if (any(any_na_or_inf)) {
-      err_msg = paste0(paste(bad_names[any_na_or_inf], collapse = ", "), " contains NA or Inf values!")
+      err_msg <- paste0(paste(bad_names[any_na_or_inf], collapse = ", "), " contains NA or Inf values!")
       if (length(any_na_or_inf) > 1) {
-        err_msg = paste0("Variables: ", err_msg)
+        err_msg <- paste0("Variables: ", err_msg)
       } else {
-        err_msg = paste0("Variable: ", err_msg)
+        err_msg <- paste0("Variable: ", err_msg)
       }
       stop(err_msg)
     }
-    names(init_i) = variable_names
+    names(init_i) <- variable_names
     return(init_i)
   })
   return(process_init(inits, num_procs, model_variables, warn_partial))
@@ -1276,8 +1262,7 @@ process_init.function <- function(init, num_procs, model_variables = NULL,
 
 #' Validate a fit is a valid init
 #' @noRd
-validate_fit_init = function(init, model_variables) {
-  # Convert from data.table to data.frame
+validate_fit_init <- function(init, model_variables) {
   if (all(init$return_codes() == 1)) {
     stop("We are unable to create initial values from a model with no samples. Please check the results of the model used for inits before continuing.")
   } else if (!is.null(model_variables) &&!any(names(model_variables$parameters) %in% init$metadata()$stan_variables)) {
@@ -1300,10 +1285,10 @@ process_init.CmdStanMCMC <- function(init, num_procs, model_variables = NULL,
                                      warn_partial = getOption("cmdstanr_warn_inits", TRUE),
                                      ...) {
   validate_fit_init(init, model_variables)
-  draws_df = init$draws(format = "df")
-  init_draws_df = posterior::resample_draws(draws_df, ndraws = num_procs,
+  draws_df <- init$draws(format = "df")
+  init_draws_df <- posterior::resample_draws(draws_df, ndraws = num_procs,
                                             method = "simple_no_replace")
-  init_draws_lst = process_init(init_draws_df,
+  init_draws_lst <- process_init(init_draws_df,
                                 num_procs = num_procs, model_variables = model_variables)
   return(init_draws_lst)
 }
@@ -1324,46 +1309,46 @@ process_init_approx <- function(init, num_procs, model_variables = NULL,
                                 ...) {
   validate_fit_init(init, model_variables)
   # Convert from data.table to data.frame
-  draws_df = init$draws(format = "df")
-  draws_df$lw = draws_df$lp__ - draws_df$lp_approx__
+  draws_df <- init$draws(format = "df")
+  draws_df$lw <- draws_df$lp__ - draws_df$lp_approx__
   # Replace NaN and Inf with -Inf
   draws_df$lw[!is.finite(draws_df$lw)] <- -Inf
   # Calculate unique draws based on 'lw' using base R functions
-  unique_draws = length(unique(draws_df$lw))
+  unique_draws <- length(unique(draws_df$lw))
   if (num_procs > unique_draws) {
     if (inherits(init, "CmdStanPathfinder")) {
-      algo_name = " Pathfinder "
-      extra_msg = " Try running Pathfinder with psis_resample=FALSE."
+      algo_name <- " Pathfinder "
+      extra_msg <- " Try running Pathfinder with psis_resample=FALSE."
     } else if (inherits(init, "CmdStanVB")) {
-      algo_name = " CmdStanVB "
-      extra_msg = ""
+      algo_name <- " CmdStanVB "
+      extra_msg <- ""
     } else if (inherits(init, "CmdStanLaplace")) {
-      algo_name = " CmdStanLaplace "
-      extra_msg = ""
+      algo_name <- " CmdStanLaplace "
+      extra_msg <- ""
     } else {
-      algo_name = ""
-      extra_msg = ""
+      algo_name <- ""
+      extra_msg <- ""
     }
     stop(paste0("Not enough distinct draws (", num_procs, ") in", algo_name ,
       "fit to create inits.", extra_msg))
   }
   if (unique_draws < (0.95 * nrow(draws_df))) {
-    temp_df = stats::aggregate(.draw ~ lw, data = draws_df, FUN = min)
-    draws_df = posterior::as_draws_df(merge(temp_df, draws_df, by = 'lw'))
-    draws_df$weight = exp(draws_df$lw - max(draws_df$lw))
+    temp_df <- stats::aggregate(.draw ~ lw, data = draws_df, FUN = min)
+    draws_df <- posterior::as_draws_df(merge(temp_df, draws_df, by = 'lw'))
+    draws_df$weight <- exp(draws_df$lw - max(draws_df$lw))
   } else {
-      draws_df$weight = posterior::pareto_smooth(
+      draws_df$weight <- posterior::pareto_smooth(
         exp(draws_df$lw - max(draws_df$lw)), tail = "right", r_eff=1, return_k=FALSE)
   }
-    init_draws_df = posterior::resample_draws(draws_df, ndraws = num_procs,
+    init_draws_df <- posterior::resample_draws(draws_df, ndraws = num_procs,
                                               weights = draws_df$weight, method = "simple_no_replace")
-    init_draws_df = posterior::subset_draws(init_draws_df,
+    init_draws_df <- posterior::subset_draws(init_draws_df,
       variable = setdiff(posterior::variables(init_draws_df), c("lw", "weight")))
-    init_draws_lst = process_init(init_draws_df,
+    init_draws_lst <- process_init(init_draws_df,
                                   num_procs = num_procs, model_variables = model_variables, warn_partial)
     return(init_draws_lst)
   }
-  
+
 #' Write initial values to files if provided as a `CmdStanPathfinder` class
 #' @noRd
 #' @param init A `CmdStanPathfinder` class
@@ -1381,13 +1366,13 @@ process_init.CmdStanPathfinder <- function(init, num_procs, model_variables = NU
   if (!init$metadata()$calculate_lp) {
     validate_fit_init(init, model_variables)
     # Convert from data.table to data.frame
-    draws_df = init$draws(format = "df")
-    draws_df$weight = rep(1.0, nrow(draws_df))
-    init_draws_df = posterior::resample_draws(draws_df, ndraws = num_procs,
+    draws_df <- init$draws(format = "df")
+    draws_df$weight <- rep(1.0, nrow(draws_df))
+    init_draws_df <- posterior::resample_draws(draws_df, ndraws = num_procs,
       weights = draws_df$weight, method = "simple_no_replace")
-    init_draws_df = posterior::subset_draws(init_draws_df,
+    init_draws_df <- posterior::subset_draws(init_draws_df,
       variable = setdiff(posterior::variables(init_draws_df), "weight"))
-    init_draws_lst = process_init(init_draws_df,
+    init_draws_lst <- process_init(init_draws_df,
       num_procs = num_procs, model_variables = model_variables, warn_partial)
     return(init_draws_lst)
   } else {
@@ -1446,12 +1431,30 @@ process_init.CmdStanMLE <- function(init, num_procs, model_variables = NULL,
                                     ...) {
   # Convert from data.table to data.frame
   validate_fit_init(init, model_variables)
-  draws_df = init$draws(format = "df")
-  init_draws_df = draws_df[rep(1, num_procs),]
-  init_draws_lst_lst = process_init(init_draws_df,
+  draws_df <- init$draws(format = "df")
+  init_draws_df <- draws_df[rep(1, num_procs),]
+  init_draws_lst_lst <- process_init(init_draws_df,
                                     num_procs = num_procs, model_variables = model_variables, warn_partial)
   return(init_draws_lst_lst)
 }
+
+
+# Validation helpers ------------------------------------------------------
+
+#' Validate exe file exists
+#' @noRd
+#' @param exe_file Path to executable.
+#' @return Either throws an error or returns `invisible(TRUE)`
+validate_exe_file <- function(exe_file) {
+  if (!length(exe_file) ||
+      !nzchar(exe_file) ||
+      !file.exists(exe_file)) {
+    stop("Model not compiled. Try running the compile() method first.",
+         call. = FALSE)
+  }
+  invisible(TRUE)
+}
+
 
 #' Validate initial values
 #'

--- a/tests/testthat/test-model-init.R
+++ b/tests/testthat/test-model-init.R
@@ -310,59 +310,64 @@ test_that("Initial values for single-element containers treated correctly", {
   )
 })
 
-test_that("Pathfinder inits do not drop dimensions", {
+test_that("Inits from fit/draws work for exe-only models with various parameter types", {
   modcode <- "
-  data {
-    int N;
-    vector[N] y;
-  }
-
   parameters {
-    real theta_scalar;
-    array[1] real theta_array1;
-    matrix[N, 1] mu;
-    matrix[1, N] mu_2;
-    vector<lower=0>[N] sigma;
+    real mu_scalar;
+    matrix[1, 1] mu_mat;
+    array[1] real mu_arr1;
+    array[1, 1] real mu_arr2;
+    array[1, 1, 1] real mu_arr3;
+    matrix[3, 1] mu_matN1;
+    matrix[1, 3] mu_mat1N;
   }
-
   model {
-    target += normal_lupdf(theta_scalar | 0, 1);
-    target += normal_lupdf(theta_array1 | 0, 1);
-    target += normal_lupdf(y | mu[:, 1], sigma);
-    target += normal_lupdf(y | mu_2[1], sigma);
+    target += normal_lupdf(mu_scalar | 0, 1);
+    target += normal_lupdf(to_vector(mu_mat) | 0, 1);
+    target += normal_lupdf(mu_arr1 | 0, 1);
+    target += normal_lupdf(to_array_1d(mu_arr2) | 0, 1);
+    target += normal_lupdf(to_array_1d(mu_arr3) | 0, 1);
+    target += normal_lupdf(to_vector(mu_matN1) | 0, 1);
+    target += normal_lupdf(to_vector(mu_mat1N) | 0, 1);
   }
   "
+  # model with stan file
   mod <- cmdstan_model(write_stan_file(modcode), force_recompile = TRUE)
-  data <- list(N = 100, y = rnorm(100))
+  # Pathfinder
   utils::capture.output(
-    pf <- mod$pathfinder(data = data, psis_resample = FALSE)
+    pf <- mod$pathfinder(psis_resample = FALSE, calculate_lp = FALSE)
   )
+  
+  # Pathfinder inits with stan file (1 chain)
   expect_no_error(
     utils::capture.output(
-      fit <- mod$sample(data = data, init = pf, chains = 1,
+      fit <- mod$sample(init = pf, chains = 1,
                         iter_warmup = 100, iter_sampling = 100)
     )
   )
+  # Pathfinder inits with stan file (2 chains)
   expect_no_error(
     utils::capture.output(
-      fit <- mod$sample(data = data, init = pf, chains = 2,
+      fit <- mod$sample(init = pf, chains = 2,
                         iter_warmup = 100, iter_sampling = 100)
     )
   )
 
-  # Same test but with exe_file only (no Stan file)
+  # exe-only model (no stan file)
   tmp_exe <- tempfile(fileext = cmdstan_ext())
   file.copy(mod$exe_file(), tmp_exe)
   mod_nostan <- cmdstan_model(exe_file = tmp_exe)
+  # Pathfinder inits without stan file (1 chain)
   expect_no_error(
     utils::capture.output(
-      fit <- mod_nostan$sample(data = data, init = pf, chains = 1,
+      fit <- mod_nostan$sample(init = pf, chains = 1,
                                iter_warmup = 100, iter_sampling = 100)
     )
   )
+  # Pathfinder inits without stan file (2 chains)
   expect_no_error(
     utils::capture.output(
-      fit <- mod_nostan$sample(data = data, init = pf, chains = 2,
+      fit <- mod_nostan$sample(init = pf, chains = 2,
                                iter_warmup = 100, iter_sampling = 100)
     )
   )

--- a/tests/testthat/test-model-init.R
+++ b/tests/testthat/test-model-init.R
@@ -318,12 +318,16 @@ test_that("Pathfinder inits do not drop dimensions", {
   }
 
   parameters {
+    real theta_scalar;
+    array[1] real theta_array1;
     matrix[N, 1] mu;
     matrix[1, N] mu_2;
     vector<lower=0>[N] sigma;
   }
 
   model {
+    target += normal_lupdf(theta_scalar | 0, 1);
+    target += normal_lupdf(theta_array1 | 0, 1);
     target += normal_lupdf(y | mu[:, 1], sigma);
     target += normal_lupdf(y | mu_2[1], sigma);
   }
@@ -337,6 +341,29 @@ test_that("Pathfinder inits do not drop dimensions", {
     utils::capture.output(
       fit <- mod$sample(data = data, init = pf, chains = 1,
                         iter_warmup = 100, iter_sampling = 100)
+    )
+  )
+  expect_no_error(
+    utils::capture.output(
+      fit <- mod$sample(data = data, init = pf, chains = 2,
+                        iter_warmup = 100, iter_sampling = 100)
+    )
+  )
+
+  # Same test but with exe_file only (no Stan file)
+  tmp_exe <- tempfile(fileext = cmdstan_ext())
+  file.copy(mod$exe_file(), tmp_exe)
+  mod_nostan <- cmdstan_model(exe_file = tmp_exe)
+  expect_no_error(
+    utils::capture.output(
+      fit <- mod_nostan$sample(data = data, init = pf, chains = 1,
+                               iter_warmup = 100, iter_sampling = 100)
+    )
+  )
+  expect_no_error(
+    utils::capture.output(
+      fit <- mod_nostan$sample(data = data, init = pf, chains = 2,
+                               iter_warmup = 100, iter_sampling = 100)
     )
   )
 })


### PR DESCRIPTION
Closes #1088 

Fix init from fit objects when model has no Stan file

When a `CmdStanModel` is created with only `exe_file` (no `.stan` file), using a fit object (e.g. from `$pathfinder()`) as `init` fails with the uninformative error `"'init' contains empty lists."`.

#### Root cause

Without a Stan file, `model$variables()` is unavailable, so `model_variables` is `NULL` throughout the init processing pipeline. Four functions (`process_init.CmdStanMCMC`, `process_init_approx`, `process_init.CmdStanPathfinder`, `process_init.CmdStanMLE`) had fallback code that constructed `model_variables$parameters` as a **character vector** of column names, but `process_init.draws()` expects it to be a **named list** with `$dimensions` metadata. This caused `names(model_variables$parameters)` to return `NULL`, producing empty init lists.

#### Fix

- Added `model_variables_from_draws()` helper that infers parameter names and number of dimensions from `posterior::variables(as_draws_df(...))`: names without `[` are scalars, names with `[` are containers (base name extracted via `sub("\\[.*", "", ...)`), and the number of `,` determine the number of dimensions.
- `process_init.draws()` calls this helper when `model_variables` is `NULL`, so it works without a Stan file.
- Removed the broken column-index-based fallbacks from the four intermediate `process_init.*` methods — they now pass `model_variables` through as-is and let `process_init.draws()` handle the `NULL` case.
- Cleaned up extra columns (`lw`, `weight`) that `process_init_approx` and the Pathfinder no-lp branch add to draws before passing downstream.
- "Pathfinder inits do not drop dimensions" test was renamed to "Inits from fit/draws work for exe-only models with various parameter types" and modified to test more different containers, and to include test case for exe-file-only model to .

#### Notes

- Using  `model$variables()` when Stan file is available still has benefit of creating the init list only with the actual model variables.
- Using `model_variables_from_draws()`  has downside of including transformed paramaters and generated quantities, although that is unlikely to have big performance effect.
- When the init is based on a fit  object, it would be possible to to get the names of the parameters and dimensions (and drop transformed parameters and generated quantities) with `fit$variable_skeleton(transformed_parameters = FALSE, generated_quantities = FALSE)` but that causes compilation of model methods which adds overhead, and thus was not added here.
- The design of the fix is by me. Coding and testing was assisted by Claude

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):

Aki Vehtari

By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
