### PR TITLE
feat: provide guidance if tmp csv file is not found in Quarto rendering

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -138,7 +138,15 @@ read_cmdstan_csv <- function(files,
     files <- file.path(temp_storage, basename(files))
   }
   format <- assert_valid_draws_format(format)
-  assert_file_exists(files, access = "r", extension = "csv")
+  csv_file_exists <- check_file_exists(files, access = "r", extension = "csv")
+  if (!isTRUE(csv_file_exists)) {
+    if (isTRUE(getOption("knitr.in.progress")) &&
+          any(grepl("/tmp", files))) {
+      stop(paste0(csv_file_exists, "\n  To avoid this error when using Quarto cache,\n  see `cmdstanr_output_dir` in `?cmdstanr_global_options`"))
+    } else {
+        stop(csv_file_exists)
+    }
+  }
   metadata <- NULL
   warmup_draws <- list()
   draws <- list()

--- a/R/csv.R
+++ b/R/csv.R
@@ -141,8 +141,9 @@ read_cmdstan_csv <- function(files,
   csv_file_exists <- check_file_exists(files, access = "r", extension = "csv")
   if (!isTRUE(csv_file_exists)) {
     if (isTRUE(getOption("knitr.in.progress")) &&
-          any(grepl("/tmp", files))) {
-      stop(paste0(csv_file_exists, "\n  To avoid this error when using Quarto cache,\n  see `cmdstanr_output_dir` in `?cmdstanr_global_options`"))
+          is.null(getOption("cmdstanr_output_dir")) &&
+          any(grepl("csv$", files))) {
+      stop(paste0(csv_file_exists, "\n  If this error happened when using Quarto cache,\n  see `cmdstanr_output_dir` in `?cmdstanr_global_options`"))
     } else {
         stop(csv_file_exists)
     }

--- a/R/options.R
+++ b/R/options.R
@@ -27,7 +27,9 @@
 #' * `cmdstanr_output_dir`: The directory where CmdStan should write its output
 #' CSV files when fitting models. The default is a temporary directory. Files in
 #' a temporary directory are removed as part of \R garbage collection, while
-#' files in an explicitly defined directory are not automatically deleted.
+#' files in an explicitly defined directory are not automatically deleted. Note
+#' that Rmarkdown / Quarto cache does not store files in temporary directory,
+#' and re-rendering with cache fails if explicit directory has not been defined.
 #'
 #' * `cmdstanr_verbose`: Should more information be printed
 #' when compiling or running models, including showing how CmdStan was called

--- a/tests/testthat/test-csv.R
+++ b/tests/testthat/test-csv.R
@@ -78,6 +78,12 @@ test_that("read_cmdstan_csv() fails if the file does not exist", {
                "No file provided")
   expect_error(read_cmdstan_csv(character(0)),
                "No file provided")
+  # if knitr rendering and using temp directory, there is an additional message
+  old_opt <- options(knitr.in.progress = TRUE, cmdstanr_output_dir = NULL)
+  expect_error(read_cmdstan_csv(csv_files),
+               "File does not exist: 'resources/csv/model1-1-doesntexist.csv'\n  If this error happened when using Quarto cache,\n  see `cmdstanr_output_dir` in `?cmdstanr_global_options`",
+               fixed = TRUE)
+  options(old_opt)
 })
 
 test_that("read_cmdstan_csv() fails with empty csv file", {

--- a/tests/testthat/test-csv.R
+++ b/tests/testthat/test-csv.R
@@ -73,11 +73,11 @@ test_that("read_cmdstan_csv() fails for different variables", {
 test_that("read_cmdstan_csv() fails if the file does not exist", {
   csv_files <- c(test_path("resources", "csv", "model1-1-doesntexist.csv"))
   expect_error(read_cmdstan_csv(csv_files),
-               "Assertion on 'files' failed: File does not exist: 'resources/csv/model1-1-doesntexist.csv'.")
+               "File does not exist: 'resources/csv/model1-1-doesntexist.csv'")
   expect_error(read_cmdstan_csv(NULL),
-               "Assertion on 'files' failed: No file provided.")
+               "No file provided")
   expect_error(read_cmdstan_csv(character(0)),
-               "Assertion on 'files' failed: No file provided.")
+               "No file provided")
 })
 
 test_that("read_cmdstan_csv() fails with empty csv file", {


### PR DESCRIPTION
Quarto caches the fit object which has paths to the output csv files. By default the output csv files are in tmp directory which gets removed when rendering stops. Cache works if the cmdstanr_output_dir is not a temporary directory. Set cmdstanr_output_dir before creating the fit object
```
options(cmdstanr_output_dir = desired_path_to_a_non_temporary_directory)
```

This PR adds an informative message if the csv file is not found, running knitr, and file path has "/tmp"

This PR is pure organic without any AI assistance

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):

Aki Vehtari


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
