### PR TITLE
Consolidate CmdStan path resolution

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -327,11 +327,17 @@ cmdstan_make_local <- function(dir = cmdstan_path(),
     }
     write(built_flags, file = make_local_path, append = append)
   }
-  if (file.exists(make_local_path)) {
-    return(trimws(strsplit(trimws(readChar(make_local_path, file.info(make_local_path)$size)), "\n")[[1]]))
-  } else {
+  make_local_contents <- tryCatch(
+    suppressWarnings(readLines(make_local_path, warn = FALSE)),
+    error = function(e) NULL
+  )
+  if (is.null(make_local_contents)) {
     return(NULL)
   }
+  if (length(make_local_contents) == 0) {
+    return("")
+  }
+  trimws(strsplit(trimws(paste(make_local_contents, collapse = "\n")), "\n", fixed = TRUE)[[1]])
 }
 
 #' @rdname install_cmdstan

--- a/R/path.R
+++ b/R/path.R
@@ -253,14 +253,6 @@ cmdstan_default_path <- function(dir = NULL) {
 
 latest_cmdstan_installed <- function(installs_path) {
   cmdstan_installs <- list.dirs(path = installs_path, recursive = FALSE, full.names = FALSE)
-  # if installed in cmdstan folder with no version move to cmdstan-version folder
-  if ("cmdstan" %in% cmdstan_installs) {
-    ver <- read_cmdstan_version(file.path(installs_path, "cmdstan"))
-    old_path <- file.path(installs_path, "cmdstan")
-    new_path <- file.path(installs_path, paste0("cmdstan-", ver))
-    file.rename(old_path, new_path)
-    cmdstan_installs <- list.dirs(path = installs_path, recursive = FALSE, full.names = FALSE)
-  }
   latest_cmdstan <- ""
   if (length(cmdstan_installs) > 0) {
     cmdstan_installs <- grep("^cmdstan-", cmdstan_installs, value = TRUE)

--- a/R/path.R
+++ b/R/path.R
@@ -50,7 +50,6 @@ set_cmdstan_path <- function(path = NULL) {
     } else {
       path <- cmdstan_default_path()
       if (is.null(path)) {
-        unset_cmdstan_path()
         return(invisible(NULL))
       }
     }

--- a/R/path.R
+++ b/R/path.R
@@ -40,8 +40,20 @@
 #'
 set_cmdstan_path <- function(path = NULL) {
   if (is.null(path)) {
-    env_path <- Sys.getenv("CMDSTAN")
-    path <- if (nzchar(env_path)) env_path else cmdstan_default_path()
+    env_path <- resolve_cmdstan_path_from_env()
+    if (isTRUE(is.na(env_path))) {
+      unset_cmdstan_path()
+      return(invisible(NULL))
+    }
+    if (!is.null(env_path)) {
+      path <- env_path
+    } else {
+      path <- cmdstan_default_path()
+      if (is.null(path)) {
+        unset_cmdstan_path()
+        return(invisible(NULL))
+      }
+    }
   }
   if (dir.exists(path)) {
     path <- absolute_path(path)
@@ -52,9 +64,7 @@ set_cmdstan_path <- function(path = NULL) {
         "cmdstanr now requires CmdStan v", cmdstan_min_version(), " or newer.",
         call. = FALSE
       )
-      .cmdstanr$PATH <- NULL
-      .cmdstanr$VERSION <- NULL
-      .cmdstanr$WSL <- FALSE
+      unset_cmdstan_path()
       return(invisible(path))
     }
     .cmdstanr$PATH <- path
@@ -62,7 +72,7 @@ set_cmdstan_path <- function(path = NULL) {
     .cmdstanr$WSL <- grepl("//wsl$", path, fixed = TRUE)
     message("CmdStan path set to: ", path)
   } else {
-    warning("Path not set. Can't find directory: ", path, call. = FALSE)
+    warning("CmdStan path not set. Can't find directory: ", path, call. = FALSE)
   }
   invisible(path)
 }
@@ -104,6 +114,12 @@ cmdstan_version <- function(error_on_NA = TRUE) {
 .cmdstanr$TEMP_DIR <- NULL
 .cmdstanr$WSL <- FALSE
 
+unset_cmdstan_path <- function() {
+  .cmdstanr$PATH <- NULL
+  .cmdstanr$VERSION <- NULL
+  .cmdstanr$WSL <- FALSE
+}
+
 # path to temp directory
 cmdstan_tempdir <- function() {
   .cmdstanr$TEMP_DIR
@@ -130,8 +146,36 @@ is_supported_cmdstan_version <- function(version) {
   isTRUE(cmp >= 0)
 }
 
-#' cmdstan_default_install_path
-#'
+resolve_cmdstan_path_from_env <- function() {
+  path <- Sys.getenv("CMDSTAN")
+  if (!nzchar(path)) {
+    return(NULL)
+  }
+  if (!dir.exists(path)) {
+    warning(
+      "CmdStan path not set. Can't find directory specified by environment ",
+      "variable 'CMDSTAN'.",
+      call. = FALSE
+    )
+    return(NA_character_)
+  }
+  path <- absolute_path(path)
+  version <- suppressWarnings(read_cmdstan_version(path))
+  if (!is.null(version)) {
+    return(path)
+  }
+  path <- cmdstan_default_path(dir = path)
+  if (is.null(path)) {
+    warning(
+      "CmdStan path not set. No CmdStan installation found in the path ",
+      "specified by the environment variable 'CMDSTAN'.",
+      call. = FALSE
+    )
+    return(NA_character_)
+  }
+  path
+}
+
 #' Path to where  [install_cmdstan()] with default settings installs CmdStan.
 #'
 #' @keywords internal
@@ -142,14 +186,24 @@ cmdstan_default_install_path <- function(wsl = FALSE) {
   if (wsl) {
     file.path(paste0(wsl_dir_prefix(wsl = TRUE), wsl_home_dir()), ".cmdstan")
   } else {
-    file.path(.home_path(), ".cmdstan")
+    file.path(home_path(), ".cmdstan")
   }
 }
 
-#' cmdstan_default_path
-#'
-#' Returns the path to the installation of CmdStan with the most recent release
-#' version.
+home_path <- function() {
+  home <- Sys.getenv("HOME")
+  if (os_is_windows()) {
+    userprofile <- Sys.getenv("USERPROFILE")
+    h_drivepath <- file.path(Sys.getenv("HOMEDRIVE"), Sys.getenv("HOMEPATH"))
+    win_home <- ifelse(userprofile == "", h_drivepath, userprofile)
+    if (win_home != "") {
+      home <- win_home
+    }
+  }
+  home
+}
+
+#' Path to the installation of CmdStan with the most recent release version
 #'
 #' For Windows systems with WSL CmdStan installs, if there are side-by-side WSL
 #' and native installs with the same version then the WSL is preferred.
@@ -182,9 +236,9 @@ cmdstan_default_path <- function(dir = NULL) {
   }
   if (dir.exists(installs_path) || wsl_path_exists) {
     latest_cmdstan <- ifelse(dir.exists(installs_path),
-                             .latest_cmdstan_installed(installs_path), "")
+                             latest_cmdstan_installed(installs_path), "")
     latest_wsl_cmdstan <- ifelse(wsl_path_exists,
-                                 .latest_cmdstan_installed(wsl_installs_path), "")
+                                 latest_cmdstan_installed(wsl_installs_path), "")
     if (!nzchar(latest_cmdstan) && !nzchar(latest_wsl_cmdstan)) {
       return(NULL)
     }
@@ -197,7 +251,7 @@ cmdstan_default_path <- function(dir = NULL) {
   NULL
 }
 
-.latest_cmdstan_installed <- function(installs_path) {
+latest_cmdstan_installed <- function(installs_path) {
   cmdstan_installs <- list.dirs(path = installs_path, recursive = FALSE, full.names = FALSE)
   # if installed in cmdstan folder with no version move to cmdstan-version folder
   if ("cmdstan" %in% cmdstan_installs) {
@@ -278,6 +332,7 @@ read_cmdstan_version <- function(path) {
   sub("CMDSTAN_VERSION := ", "", version_line)
 }
 
+
 #' Returns whether the supplied installation is a release candidate
 #' @noRd
 #' @param path Path to installation.
@@ -289,12 +344,6 @@ is_release_candidate <- function(path) {
   grepl(pattern = "-rc[0-9]*$", x = path)
 }
 
-# unset the path (only used in tests)
-unset_cmdstan_path <- function() {
-  .cmdstanr$PATH <- NULL
-  .cmdstanr$VERSION <- NULL
-  .cmdstanr$WSL <- FALSE
-}
 
 # fake a cmdstan version (only used in tests)
 fake_cmdstan_version <- function(version, mod = NULL) {
@@ -310,17 +359,4 @@ fake_cmdstan_version <- function(version, mod = NULL) {
 }
 reset_cmdstan_version <- function(mod = NULL) {
   fake_cmdstan_version(read_cmdstan_version(cmdstan_path()), mod = mod)
-}
-
-.home_path <- function() {
-  home <- Sys.getenv("HOME")
-  if (os_is_windows()) {
-    userprofile <- Sys.getenv("USERPROFILE")
-    h_drivepath <- file.path(Sys.getenv("HOMEDRIVE"), Sys.getenv("HOMEPATH"))
-    win_home <- ifelse(userprofile == "", h_drivepath, userprofile)
-    if (win_home != "") {
-      home <- win_home
-    }
-  }
-  home
 }

--- a/R/path.R
+++ b/R/path.R
@@ -255,6 +255,9 @@ latest_cmdstan_installed <- function(installs_path) {
   latest_cmdstan <- ""
   if (length(cmdstan_installs) > 0) {
     cmdstan_installs <- grep("^cmdstan-", cmdstan_installs, value = TRUE)
+    if (length(cmdstan_installs) == 0) {
+      return(latest_cmdstan)
+    }
     latest_cmdstan <- sort(cmdstan_installs, decreasing = TRUE)[1]
     if (is_release_candidate(latest_cmdstan)) {
       non_rc_path <- strsplit(latest_cmdstan, "-rc")[[1]][1]

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -35,46 +35,7 @@ startup_messages <- function() {
 }
 
 cmdstanr_initialize <- function() {
-  # First check for environment variable CMDSTAN, but if not found
-  # then see if default
-  path <- Sys.getenv("CMDSTAN")
-  if (isTRUE(nzchar(path))) { # CMDSTAN environment variable found
-    if (dir.exists(path)) {
-      path <- absolute_path(path)
-      suppressWarnings(suppressMessages(set_cmdstan_path(path)))
-      if (is.null(cmdstan_version(error_on_NA = FALSE))) {
-        path <- cmdstan_default_path(dir = path)
-        if (is.null(path)) {
-          warning(
-            "No CmdStan installation found in the path specified ",
-            "by the environment variable 'CMDSTAN'.",
-            call. = FALSE
-          )
-          .cmdstanr$PATH <- NULL
-          .cmdstanr$VERSION <- NULL
-          .cmdstanr$WSL <- FALSE
-        } else {
-          set_cmdstan_path(path)
-        }
-      }
-    } else {
-      warning(
-        "Can't find directory specified by environment variable 'CMDSTAN'. ",
-        "Path not set.",
-        call. = FALSE
-      )
-      .cmdstanr$PATH <- NULL
-      .cmdstanr$VERSION <- NULL
-      .cmdstanr$WSL <- FALSE
-    }
-
-  } else { # environment variable not found
-    path <- cmdstan_default_path()
-    if (!is.null(path)) {
-      suppressMessages(set_cmdstan_path(path))
-    }
-  }
-
+  suppressMessages(set_cmdstan_path())
   .cmdstanr$TEMP_DIR <- tempdir(check = TRUE)
   invisible(TRUE)
 }

--- a/man/cmdstan_default_install_path.Rd
+++ b/man/cmdstan_default_install_path.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/path.R
 \name{cmdstan_default_install_path}
 \alias{cmdstan_default_install_path}
-\title{cmdstan_default_install_path}
+\title{Path to where  \code{\link[=install_cmdstan]{install_cmdstan()}} with default settings installs CmdStan.}
 \usage{
 cmdstan_default_install_path(wsl = FALSE)
 }

--- a/man/cmdstan_default_path.Rd
+++ b/man/cmdstan_default_path.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/path.R
 \name{cmdstan_default_path}
 \alias{cmdstan_default_path}
-\title{cmdstan_default_path}
+\title{Path to the installation of CmdStan with the most recent release version}
 \usage{
 cmdstan_default_path(dir = NULL)
 }
@@ -14,10 +14,6 @@ Path to the CmdStan installation with the most recent release
 version, or \code{NULL} if no installation found.
 }
 \description{
-Returns the path to the installation of CmdStan with the most recent release
-version.
-}
-\details{
 For Windows systems with WSL CmdStan installs, if there are side-by-side WSL
 and native installs with the same version then the WSL is preferred.
 Otherwise, the most recent release is chosen, regardless of whether it is

--- a/man/cmdstanr-package.Rd
+++ b/man/cmdstanr-package.Rd
@@ -34,22 +34,22 @@ algorithms, and writing results to output files.
 \subsection{Advantages of RStan}{
 \itemize{
 \item Allows other developers to distribute R packages with \emph{pre-compiled}
-Stan programs (like \strong{rstanarm}) on CRAN. (Note: As of 2023, this
-can mostly be achieved with CmdStanR as well. See \href{https://mc-stan.org/cmdstanr/articles/cmdstanr-internals.html#developing-using-cmdstanr}{Developing using CmdStanR}.)
-\item Avoids use of R6 classes, which may result in more familiar syntax
-for many R users.
+Stan programs (like \strong{rstanarm}) on CRAN. (Note: As of 2023, this can
+mostly be achieved with CmdStanR as well. See \href{https://mc-stan.org/cmdstanr/articles/cmdstanr-internals.html#developing-using-cmdstanr}{Developing using CmdStanR}.)
+\item Avoids use of R6 classes, which may result in more familiar syntax for
+many R users.
 \item CRAN binaries available for Mac and Windows.
 }
 }
 
 \subsection{Advantages of CmdStanR}{
 \itemize{
-\item Compatible with latest versions of Stan. Keeping up with Stan
-releases is complicated for RStan, often requiring non-trivial
-changes to the \strong{rstan} package and new CRAN releases of both
-\strong{rstan} and \strong{StanHeaders}. With CmdStanR the latest improvements
-in Stan will be available from R immediately after updating CmdStan
-using \code{cmdstanr::install_cmdstan()}.
+\item Compatible with latest versions of Stan. Keeping up with Stan releases
+is complicated for RStan, often requiring non-trivial changes to the
+\strong{rstan} package and new CRAN releases of both \strong{rstan} and
+\strong{StanHeaders}. With CmdStanR the latest improvements in Stan will be
+available from R immediately after updating CmdStan using
+\code{cmdstanr::install_cmdstan()}.
 \item Running Stan via external processes results in fewer unexpected
 crashes, especially in RStudio.
 \item Less memory overhead.
@@ -229,6 +229,7 @@ Other contributors:
   \item Martin Modrák [contributor]
   \item Ven Popov [contributor]
   \item Visruth Srimath Kandali [contributor]
+  \item Aki Vehtari [contributor]
 }
 
 }

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -203,6 +203,18 @@ test_that("cmdstan_default_path() returns NULL for empty custom install director
   expect_null(cmdstan_default_path(dir = installs))
 })
 
+test_that("cmdstan_default_path() ignores unversioned cmdstan directory", {
+  installs <- withr::local_tempdir(pattern = "cmdstan-legacy-installs")
+  dir.create(file.path(installs, "cmdstan"), recursive = TRUE, showWarnings = FALSE)
+  dir.create(file.path(installs, "cmdstan-2.36.0"), recursive = TRUE, showWarnings = FALSE)
+
+  expect_equal(
+    cmdstan_default_path(dir = installs),
+    file.path(installs, "cmdstan-2.36.0")
+  )
+  expect_true(dir.exists(file.path(installs, "cmdstan")))
+})
+
 test_that("CmdStan version helpers handle invalid inputs", {
   expect_identical(cmdstan_min_version(), "2.35.0")
   expect_false(is_supported_cmdstan_version(NULL))

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -176,6 +176,21 @@ test_that("Setting path rejects unsupported CmdStan versions", {
   expect_false(isTRUE(.cmdstanr$WSL))
 })
 
+test_that("Explicit legacy cmdstan directory can still be set", {
+  unset_cmdstan_path()
+  legacy_install <- file.path(withr::local_tempdir(pattern = "cmdstan-legacy"), "cmdstan")
+  dir.create(legacy_install, recursive = TRUE, showWarnings = FALSE)
+  writeLines("CMDSTAN_VERSION := 2.38.0", con = file.path(legacy_install, "makefile"))
+
+  expect_message(
+    set_cmdstan_path(legacy_install),
+    paste("CmdStan path set to:", absolute_path(legacy_install)),
+    fixed = TRUE
+  )
+  expect_equal(cmdstan_path(), absolute_path(legacy_install))
+  expect_equal(cmdstan_version(), "2.38.0")
+})
+
 test_that("unset_cmdstan_path() also resets WSL state", {
   .cmdstanr$PATH <- PATH
   .cmdstanr$VERSION <- VERSION
@@ -213,6 +228,16 @@ test_that("cmdstan_default_path() ignores unversioned cmdstan directory", {
     file.path(installs, "cmdstan-2.36.0")
   )
   expect_true(dir.exists(file.path(installs, "cmdstan")))
+})
+
+test_that("cmdstan_default_path() returns NULL for legacy-only cmdstan directory", {
+  installs <- withr::local_tempdir(pattern = "cmdstan-legacy-only")
+  legacy_install <- file.path(installs, "cmdstan")
+  dir.create(legacy_install, recursive = TRUE, showWarnings = FALSE)
+  writeLines("CMDSTAN_VERSION := 2.38.0", con = file.path(legacy_install, "makefile"))
+
+  expect_null(cmdstan_default_path(dir = installs))
+  expect_true(dir.exists(legacy_install))
 })
 
 test_that("CmdStan version helpers handle invalid inputs", {

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -56,7 +56,7 @@ test_that("set_cmdstan_path() uses CMDSTAN env var when path is omitted", {
   expect_equal(cmdstan_path(), PATH)
 })
 
-test_that("set_cmdstan_path() clears cached state when no path is detected", {
+test_that("set_cmdstan_path() keeps cached state when no path is detected", {
   .cmdstanr$PATH <- PATH
   .cmdstanr$VERSION <- VERSION
   .cmdstanr$WSL <- TRUE
@@ -65,9 +65,9 @@ test_that("set_cmdstan_path() clears cached state when no path is detected", {
     cmdstan_default_path = function(dir = NULL) NULL
   )
   expect_silent(set_cmdstan_path())
-  expect_null(.cmdstanr$PATH)
-  expect_null(.cmdstanr$VERSION)
-  expect_false(isTRUE(.cmdstanr$WSL))
+  expect_equal(.cmdstanr$PATH, PATH)
+  expect_equal(.cmdstanr$VERSION, VERSION)
+  expect_identical(.cmdstanr$WSL, TRUE)
 })
 
 test_that("Unsupported CmdStan path from env var is rejected", {

--- a/tests/testthat/test-path.R
+++ b/tests/testthat/test-path.R
@@ -56,6 +56,20 @@ test_that("set_cmdstan_path() uses CMDSTAN env var when path is omitted", {
   expect_equal(cmdstan_path(), PATH)
 })
 
+test_that("set_cmdstan_path() clears cached state when no path is detected", {
+  .cmdstanr$PATH <- PATH
+  .cmdstanr$VERSION <- VERSION
+  .cmdstanr$WSL <- TRUE
+  local_mocked_bindings(
+    resolve_cmdstan_path_from_env = function() NULL,
+    cmdstan_default_path = function(dir = NULL) NULL
+  )
+  expect_silent(set_cmdstan_path())
+  expect_null(.cmdstanr$PATH)
+  expect_null(.cmdstanr$VERSION)
+  expect_false(isTRUE(.cmdstanr$WSL))
+})
+
 test_that("Unsupported CmdStan path from env var is rejected", {
   unset_cmdstan_path()
   .cmdstanr$WSL <- TRUE
@@ -84,7 +98,7 @@ test_that("Existing CMDSTAN env path with no install resets cached state", {
   withr::local_envvar(c(CMDSTAN = empty_parent))
   expect_warning(
     cmdstanr_initialize(),
-    "No CmdStan installation found in the path specified by the environment variable 'CMDSTAN'.",
+    "CmdStan path not set. No CmdStan installation found in the path specified by the environment variable 'CMDSTAN'.",
     fixed = TRUE
   )
   expect_null(.cmdstanr$PATH)

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -196,6 +196,14 @@ test_that("cmdstan_make_local() works", {
   cmdstan_make_local(cpp_options = as.list(exisiting_make_local), append = FALSE)
 })
 
+test_that("cmdstan_make_local() preserves empty make/local behavior", {
+  dir <- withr::local_tempdir()
+  dir.create(file.path(dir, "make"), recursive = TRUE, showWarnings = FALSE)
+  file.create(file.path(dir, "make", "local"))
+
+  expect_identical(cmdstan_make_local(dir = dir), "")
+})
+
 test_that("matching_variables() works", {
   ret <- matching_variables(c("beta"),  c("alpha", "beta[1]", "beta[2]", "beta[3]"))
   expect_equal(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -204,6 +204,28 @@ test_that("cmdstan_make_local() preserves empty make/local behavior", {
   expect_identical(cmdstan_make_local(dir = dir), "")
 })
 
+test_that("cmdstan_make_local() reads back written make flags", {
+  dir <- withr::local_tempdir()
+  dir.create(file.path(dir, "make"), recursive = TRUE, showWarnings = FALSE)
+
+  expect_null(cmdstan_make_local(dir = dir))
+  expect_equal(
+    cmdstan_make_local(
+      dir = dir,
+      cpp_options = list("CXX" = "clang++", STAN_THREADS = TRUE)
+    ),
+    c("CXX=clang++", "STAN_THREADS=true")
+  )
+  expect_equal(
+    cmdstan_make_local(dir = dir, cpp_options = list("PRECOMPILED_HEADERS" = FALSE)),
+    c("CXX=clang++", "STAN_THREADS=true", "PRECOMPILED_HEADERS=false")
+  )
+  expect_equal(
+    cmdstan_make_local(dir = dir, cpp_options = list("CXX" = "g++"), append = FALSE),
+    "CXX=g++"
+  )
+})
+
 test_that("matching_variables() works", {
   ret <- matching_variables(c("beta"),  c("alpha", "beta[1]", "beta[2]", "beta[3]"))
   expect_equal(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

(PR summary generated by codex) 

This PR follows up on the WSL CI fix by consolidating CmdStan path resolution and cleaning up a few related path helpers.

  - Routes package startup through `set_cmdstan_path()` so startup and explicit `set_cmdstan_path()` calls use the same resolution logic.
  - Centralizes `CMDSTAN` handling in `resolve_cmdstan_path_from_env()`.
  - Clears cached CmdStan path/version/WSL state consistently for explicit invalid CMDSTAN and unsupported versions
  - Removes the legacy auto-migration of an unversioned `cmdstan/` directory to `cmdstan-<version>`.
  - Updates `cmdstan_make_local()` to read `make/local` without using `file.info()`, which avoids fragile file metadata calls.



#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
