### PR TITLE
Make sure `metadata()` has correct value for `num_chains`

### DIFF
--- a/R/csv.R
+++ b/R/csv.R
@@ -188,6 +188,9 @@ read_cmdstan_csv <- function(files,
     }
   }
   metadata <- csv_metadata[[1]]
+  if (metadata$method == "sample") {
+    metadata$num_chains <- length(csv_metadata)
+  }
   uniq_seed <- unique(metadata$seed)
   if (length(uniq_seed) == 1) {
     metadata$seed <- uniq_seed

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -423,7 +423,8 @@ test_that("diagnostic_summary() works", {
   expect_equal(fit$diagnostic_summary(NULL), list())
 })
 
-test_that("metadata()$time has chains rowss", {
+test_that("metadata()$time has chains rows", {
+  expect_equal(fit_mcmc$metadata()$num_chains, fit_mcmc$num_chains())
   expect_equal(nrow(fit_mcmc$metadata()$time), fit_mcmc$num_chains())
   expect_equal(nrow(fit_mcmc_0$metadata()$time), fit_mcmc_0$num_chains())
   expect_equal(nrow(fit_mcmc_1$metadata()$time), fit_mcmc_1$num_chains())


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

fixes #1186
Fixes `num_chains` in `fit$metadata()`. Previously it was always returning `1`. I suppose it should really be `chains` instead of `num_chains` to match CmdStanR's arguments, but since we've been using `num_chains`  (inherited from the CmdStan CSV names) I'll leave it as `num_chains` for backwards compatibility. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
