### PR TITLE
Fix new roxygen2 warning about single line aliases

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -915,12 +915,13 @@ CmdStanFit$set("public", name = "cmdstan_diagnose", value = cmdstan_diagnose)
 #'
 #' @name fit-method-save_output_files
 #' @aliases fit-method-save_data_file fit-method-save_latent_dynamics_files
-#'   fit-method-save_profile_files fit-method-output_files fit-method-data_file
-#'   fit-method-latent_dynamics_files fit-method-profile_files
-#'   fit-method-save_config_files fit-method-save_metric_files save_output_files
-#'   save_data_file save_latent_dynamics_files save_profile_files
-#'   save_config_files save_metric_files output_files data_file
-#'   latent_dynamics_files profile_files config_files metric_files
+#' @aliases fit-method-save_profile_files fit-method-output_files fit-method-data_file
+#' @aliases fit-method-latent_dynamics_files fit-method-profile_files
+#' @aliases fit-method-save_config_files fit-method-save_metric_files
+#' @aliases save_output_files save_data_file save_latent_dynamics_files
+#' @aliases save_profile_files save_config_files save_metric_files
+#' @aliases output_files data_file latent_dynamics_files profile_files
+#' @aliases config_files metric_files
 #'
 #' @description All fitted model objects have methods for saving (moving to a
 #'   specified location) the files created by CmdStanR to hold CmdStan output


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The new version of roxygen2 throws a warning if `@aliases` is more than one line. The solution is to use multiple `@aliases` tags. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
