### PR TITLE
`$lp_approx()`, `$mle()` should return numeric vectors regardless of default draws format 

### DIFF
--- a/R/fit.R
+++ b/R/fit.R
@@ -768,7 +768,8 @@ CmdStanFit$set("public", name = "lp", value = lp)
 # will be used by a subset of fit objects below
 #' @rdname fit-method-lp
 lp_approx <- function() {
-  as.numeric(self$draws()[, "lp_approx__"])
+  x <- self$draws(variables = "lp_approx__", format = "draws_matrix")
+  as.numeric(x[, "lp_approx__"])
 }
 
 
@@ -1973,8 +1974,8 @@ CmdStanMLE <- R6::R6Class(
 #' }
 #'
 mle <- function(variables = NULL) {
-  x <- self$draws(variables)
-  x <- x[, colnames(x) != "lp__"]
+  x <- self$draws(variables = variables, format = "draws_matrix")
+  x <- x[, colnames(x) != "lp__", drop = FALSE]
   stats::setNames(as.numeric(x), posterior::variables(x))
 }
 CmdStanMLE$set("public", name = "mle", value = mle)

--- a/tests/testthat/test-fit-laplace.R
+++ b/tests/testthat/test-fit-laplace.R
@@ -41,6 +41,19 @@ test_that("lp(), lp_approx() methods return vectors (reading csv works)", {
   expect_equal(length(lg), length(lp))
 })
 
+test_that("lp_approx() ignores non-matrix default draws formats", {
+  expected <- fit_laplace$draws(
+    variables = "lp_approx__",
+    format = "draws_matrix"
+  )
+  expected <- as.numeric(expected[, "lp_approx__"])
+
+  for (format in c("draws_array", "draws_df")) {
+    withr::local_options(list(cmdstanr_draws_format = format))
+    expect_equal(fit_laplace$lp_approx(), expected)
+  }
+})
+
 test_that("time() method works after laplace", {
   run_times <- fit_laplace$time()
   checkmate::expect_list(run_times, names = "strict", any.missing = FALSE)

--- a/tests/testthat/test-fit-mle.R
+++ b/tests/testthat/test-fit-mle.R
@@ -10,6 +10,17 @@ test_that("mle and lp methods work after optimization", {
   checkmate::expect_numeric(fit_mle$lp(), len = 1)
 })
 
+test_that("mle() ignores non-matrix default draws formats", {
+  expected <- fit_mle$draws(format = "draws_matrix")
+  expected <- expected[, colnames(expected) != "lp__", drop = FALSE]
+  expected <- stats::setNames(as.numeric(expected), posterior::variables(expected))
+
+  for (format in c("draws_array", "draws_df")) {
+    withr::local_options(list(cmdstanr_draws_format = format))
+    expect_equal(fit_mle$mle(), expected)
+  }
+})
+
 test_that("summary method works after optimization", {
   x <- fit_mle$summary()
   expect_s3_class(x, "draws_summary")

--- a/tests/testthat/test-fit-vb.R
+++ b/tests/testthat/test-fit-vb.R
@@ -71,6 +71,19 @@ test_that("lp(), lp_approx() methods return vectors (reading csv works)", {
   expect_equal(length(lg), length(lp))
 })
 
+test_that("lp_approx() ignores non-matrix default draws formats", {
+  expected <- fit_vb$draws(
+    variables = "lp_approx__",
+    format = "draws_matrix"
+  )
+  expected <- as.numeric(expected[, "lp_approx__"])
+
+  for (format in c("draws_array", "draws_df")) {
+    withr::local_options(list(cmdstanr_draws_format = format))
+    expect_equal(fit_vb$lp_approx(), expected)
+  }
+})
+
 test_that("vb works with scientific notation args", {
   x <- fit_vb_sci_not$summary()
   expect_s3_class(x, "draws_summary")


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Ensure that `$lp_approx()` and `$mle()` methods return numeric vectors regardless of default draws format 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
