### PR TITLE
Fix handling of `save_single_paths` argument for pathfinder

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cmdstanr (development version)
 
+* `pathfinder()` now respects `save_single_paths = TRUE` instead of always
+passing `0` to CmdStan.
 * Informative error when exposing functions using names that are reserved 
 keywords (@VisruthSK, #1154)
 * `save_cmdstan_config` and `save_metric` default to `FALSE` but can be 

--- a/R/args.R
+++ b/R/args.R
@@ -989,7 +989,7 @@ validate_pathfinder_args <- function(self) {
   checkmate::assert_integerish(self$save_single_paths, null.ok = TRUE,
                                lower = 0, upper = 1, len = 1)
   if (!is.null(self$save_single_paths)) {
-    self$save_single_paths <- 0
+    self$save_single_paths <- as.integer(self$save_single_paths)
   }
   if (!is.null(self$psis_resample) && is.logical(self$psis_resample)) {
     self$psis_resample <- as.integer(self$psis_resample)

--- a/tests/testthat/test-model-pathfinder.R
+++ b/tests/testthat/test-model-pathfinder.R
@@ -133,6 +133,31 @@ test_that("pathfinder() method runs when all arguments specified", {
   expect_s3_class(fit, "CmdStanPathfinder")
 })
 
+test_that("pathfinder() saves single path outputs", {
+  output_dir <- withr::local_tempdir()
+
+  expect_pathfinder_output(
+    fit <- mod$pathfinder(
+      data = data_list,
+      output_dir = output_dir,
+      output_basename = "pathfinder",
+      seed = 123,
+      refresh = 0,
+      num_paths = 2,
+      single_path_draws = 10,
+      draws = 10,
+      save_single_paths = TRUE
+    )
+  )
+
+  expect_equal(basename(fit$output_files()), "pathfinder-1.csv")
+  single_path_files <- file.path(
+    output_dir,
+    paste0("pathfinder-1_path_", 1:2, ".csv")
+  )
+  expect_equal(file.exists(single_path_files), rep(TRUE, 2))
+})
+
 test_that("pathfinder() method runs when the stan file is removed", {
   stan_file_tmp <- tempfile(pattern = "tmp", fileext = ".stan")
   file.copy(stan_program, stan_file_tmp)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Previously `save_single_paths = TRUE` could be ignored silently. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
