### PR TITLE
Don't call `init` functions an extra time to validate them

### DIFF
--- a/R/args.R
+++ b/R/args.R
@@ -1238,21 +1238,22 @@ process_init.function <- function(init, num_procs, model_variables = NULL,
                                   warn_partial = getOption("cmdstanr_warn_inits", TRUE),
                                   ...) {
   args <- formals(init)
-  if (is.null(args)) {
-    fn_test <- init()
-    init_list <- lapply(seq_len(num_procs), function(i) init())
-  } else {
+  has_chain_id <- !is.null(args)
+  if (has_chain_id) {
     if (!identical(names(args), "chain_id")) {
       stop("If 'init' is a function it must have zero arguments ",
            "or only argument 'chain_id'.", call. = FALSE)
     }
-    fn_test <- init(1)
-    init_list <- lapply(seq_len(num_procs), function(i) init(i))
   }
-  if (!is.list(fn_test) || is.data.frame(fn_test)) {
-    stop("If 'init' is a function it must return a single list.")
+
+  init_list <- vector("list", num_procs)
+  for (i in seq_len(num_procs)) {
+    init_list[[i]] <- if (has_chain_id) init(i) else init()
+    if (!is.list(init_list[[i]]) || is.data.frame(init_list[[i]])) {
+      stop("If 'init' is a function it must return a single list.", call. = FALSE)
+    }
   }
-  process_init(init_list, num_procs, model_variables)
+  process_init(init_list, num_procs, model_variables, warn_partial)
 }
 
 #' Validate a fit is a valid init

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -26,44 +26,40 @@
 #'   variables declared in the parameters block of the Stan program. One of the
 #'   following:
 #'  * A real number `x>0`. This initializes _all_ parameters randomly between
-#'   `[-x,x]` on the _unconstrained_ parameter space.;
-#'  * The number `0`. This initializes _all_ parameters to `0`;
+#'  `[-x,x]` on the _unconstrained_ parameter space.
+#'  * The number `0`. This initializes _all_ parameters to `0`.
 #'  * A character vector of paths (one per chain) to JSON or Rdump files
-#'   containing initial values for all or some parameters. See
-#'   [write_stan_json()] to write \R objects to JSON files compatible with
-#'   CmdStan.
+#'  containing initial values for all or some parameters. See
+#'  [write_stan_json()] to write \R objects to JSON files compatible with
+#'  CmdStan.
 #'  * A list of lists containing initial values for all or some parameters. For
-#'   MCMC the list should contain a sublist for each chain. For other model
-#'   fitting methods there should be just one sublist. The sublists should have
-#'   named elements corresponding to the parameters for which you are specifying
-#'   initial values. See **Examples**.
+#'  MCMC the list should contain a sublist for each chain. For other model
+#'  fitting methods there should be just one sublist. The sublists should have
+#'  named elements corresponding to the parameters for which you are specifying
+#'  initial values. See **Examples**.
 #'  * A function that returns a single list with names corresponding to the
-#'   parameters for which you are specifying initial values. The function can
-#'   take no arguments or a single argument `chain_id`. For MCMC, if the
-#'   function has argument `chain_id` it will be supplied with the chain id
-#'   (from 1 to number of chains) when called to generate the initial values.
-#'   See
+#'  parameters for which you are specifying initial values. The function can
+#'  take no arguments or a single argument `chain_id`. For MCMC, if the function
+#'  has argument `chain_id` it will be supplied with the chain id (from 1 to
+#'  number of chains) when called to generate the initial values. See
 #'  **Examples**.
 #'  * A [`CmdStanMCMC`], [`CmdStanMLE`], [`CmdStanVB`], [`CmdStanPathfinder`],
-#'  or [`CmdStanLaplace`] fit object.
-#'  If the fit object's parameters are only a subset of the model
-#'  parameters then the other parameters will be drawn by Stan's default
-#'  initialization. The fit object must have at least some parameters that are the
-#'  same name and dimensions as the current Stan model. For the `sample` and
-#'  `pathfinder` method, if the fit object has fewer draws than the requested
-#'  number of chains/paths then the inits will be drawn using sampling with
-#'  replacement. Otherwise sampling without replacement will be used.
-#'  When a [`CmdStanPathfinder`] fit object is used as the init, if
-#'. `psis_resample` was set to `FALSE` and `calculate_lp` was
-#'  set to `TRUE` (default), then resampling without replacement with Pareto
-#'  smoothed weights will be used. If `psis_resample` was set to `TRUE` or
-#'  `calculate_lp` was set to `FALSE` then sampling without replacement with
-#'  uniform weights will be used to select the draws.
-#'  PSIS resampling is used to select the draws for  [`CmdStanVB`],
-#'  and [`CmdStanLaplace`] fit objects.
-#'
-#'  * A type inheriting from `posterior::draws`. If the draws object has less
-#'  samples than the number of requested chains/paths then the inits will be
+#'  or [`CmdStanLaplace`] fit object. If the fit object's parameters are only a
+#'  subset of the model parameters then the other parameters will be drawn by
+#'  Stan's default initialization. The fit object must have at least some
+#'  parameters that are the same name and dimensions as the current Stan model.
+#'  For the `sample` and `pathfinder` method, if the fit object has fewer draws
+#'  than the requested number of chains/paths then the inits will be drawn using
+#'  sampling with replacement. Otherwise sampling without replacement will be
+#'  used. When a [`CmdStanPathfinder`] fit object is used as the init, if
+#'  `psis_resample` was set to `FALSE` and `calculate_lp` was set to `TRUE`
+#'  (default), then resampling without replacement with Pareto smoothed weights
+#'  will be used. If `psis_resample` was set to `TRUE` or `calculate_lp` was set
+#'  to `FALSE` then sampling without replacement with uniform weights will be
+#'  used to select the draws. PSIS resampling is used to select the draws for
+#'  [`CmdStanVB`], and [`CmdStanLaplace`] fit objects.
+#'  * A type inheriting from `posterior::draws`. If the draws object has fewer
+#'  draws than the number of requested chains/paths then the inits will be
 #'  drawn using sampling with replacement. Otherwise sampling without
 #'  replacement will be used. If the draws object's parameters are only a subset
 #'  of the model parameters then the other parameters will be drawn by Stan's

--- a/man/model-method-diagnose.Rd
+++ b/man/model-method-diagnose.Rd
@@ -43,8 +43,8 @@ variables declared in the parameters block of the Stan program. One of the
 following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
-\item The number \code{0}. This initializes \emph{all} parameters to \code{0};
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.
+\item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
 \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
@@ -56,30 +56,27 @@ named elements corresponding to the parameters for which you are specifying
 initial values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the
-function has argument \code{chain_id} it will be supplied with the chain id
-(from 1 to number of chains) when called to generate the initial values.
-See
+take no arguments or a single argument \code{chain_id}. For MCMC, if the function
+has argument \code{chain_id} it will be supplied with the chain id (from 1 to
+number of chains) when called to generate the initial values. See
 \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
-or \code{\link{CmdStanLaplace}} fit object.
-If the fit object's parameters are only a subset of the model
-parameters then the other parameters will be drawn by Stan's default
-initialization. The fit object must have at least some parameters that are the
-same name and dimensions as the current Stan model. For the \code{sample} and
-\code{pathfinder} method, if the fit object has fewer draws than the requested
-number of chains/paths then the inits will be drawn using sampling with
-replacement. Otherwise sampling without replacement will be used.
-When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-. \code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was
-set to \code{TRUE} (default), then resampling without replacement with Pareto
-smoothed weights will be used. If \code{psis_resample} was set to \code{TRUE} or
-\code{calculate_lp} was set to \code{FALSE} then sampling without replacement with
-uniform weights will be used to select the draws.
-PSIS resampling is used to select the draws for  \code{\link{CmdStanVB}},
-and \code{\link{CmdStanLaplace}} fit objects.
-\item A type inheriting from \code{posterior::draws}. If the draws object has less
-samples than the number of requested chains/paths then the inits will be
+or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
+subset of the model parameters then the other parameters will be drawn by
+Stan's default initialization. The fit object must have at least some
+parameters that are the same name and dimensions as the current Stan model.
+For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
+than the requested number of chains/paths then the inits will be drawn using
+sampling with replacement. Otherwise sampling without replacement will be
+used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
+(default), then resampling without replacement with Pareto smoothed weights
+will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
+to \code{FALSE} then sampling without replacement with uniform weights will be
+used to select the draws. PSIS resampling is used to select the draws for
+\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+\item A type inheriting from \code{posterior::draws}. If the draws object has fewer
+draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without
 replacement will be used. If the draws object's parameters are only a subset
 of the model parameters then the other parameters will be drawn by Stan's

--- a/man/model-method-laplace.Rd
+++ b/man/model-method-laplace.Rd
@@ -57,8 +57,8 @@ variables declared in the parameters block of the Stan program. One of the
 following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
-\item The number \code{0}. This initializes \emph{all} parameters to \code{0};
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.
+\item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
 \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
@@ -70,30 +70,27 @@ named elements corresponding to the parameters for which you are specifying
 initial values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the
-function has argument \code{chain_id} it will be supplied with the chain id
-(from 1 to number of chains) when called to generate the initial values.
-See
+take no arguments or a single argument \code{chain_id}. For MCMC, if the function
+has argument \code{chain_id} it will be supplied with the chain id (from 1 to
+number of chains) when called to generate the initial values. See
 \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
-or \code{\link{CmdStanLaplace}} fit object.
-If the fit object's parameters are only a subset of the model
-parameters then the other parameters will be drawn by Stan's default
-initialization. The fit object must have at least some parameters that are the
-same name and dimensions as the current Stan model. For the \code{sample} and
-\code{pathfinder} method, if the fit object has fewer draws than the requested
-number of chains/paths then the inits will be drawn using sampling with
-replacement. Otherwise sampling without replacement will be used.
-When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-. \code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was
-set to \code{TRUE} (default), then resampling without replacement with Pareto
-smoothed weights will be used. If \code{psis_resample} was set to \code{TRUE} or
-\code{calculate_lp} was set to \code{FALSE} then sampling without replacement with
-uniform weights will be used to select the draws.
-PSIS resampling is used to select the draws for  \code{\link{CmdStanVB}},
-and \code{\link{CmdStanLaplace}} fit objects.
-\item A type inheriting from \code{posterior::draws}. If the draws object has less
-samples than the number of requested chains/paths then the inits will be
+or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
+subset of the model parameters then the other parameters will be drawn by
+Stan's default initialization. The fit object must have at least some
+parameters that are the same name and dimensions as the current Stan model.
+For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
+than the requested number of chains/paths then the inits will be drawn using
+sampling with replacement. Otherwise sampling without replacement will be
+used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
+(default), then resampling without replacement with Pareto smoothed weights
+will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
+to \code{FALSE} then sampling without replacement with uniform weights will be
+used to select the draws. PSIS resampling is used to select the draws for
+\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+\item A type inheriting from \code{posterior::draws}. If the draws object has fewer
+draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without
 replacement will be used. If the draws object's parameters are only a subset
 of the model parameters then the other parameters will be drawn by Stan's

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -63,8 +63,8 @@ variables declared in the parameters block of the Stan program. One of the
 following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
-\item The number \code{0}. This initializes \emph{all} parameters to \code{0};
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.
+\item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
 \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
@@ -76,30 +76,27 @@ named elements corresponding to the parameters for which you are specifying
 initial values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the
-function has argument \code{chain_id} it will be supplied with the chain id
-(from 1 to number of chains) when called to generate the initial values.
-See
+take no arguments or a single argument \code{chain_id}. For MCMC, if the function
+has argument \code{chain_id} it will be supplied with the chain id (from 1 to
+number of chains) when called to generate the initial values. See
 \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
-or \code{\link{CmdStanLaplace}} fit object.
-If the fit object's parameters are only a subset of the model
-parameters then the other parameters will be drawn by Stan's default
-initialization. The fit object must have at least some parameters that are the
-same name and dimensions as the current Stan model. For the \code{sample} and
-\code{pathfinder} method, if the fit object has fewer draws than the requested
-number of chains/paths then the inits will be drawn using sampling with
-replacement. Otherwise sampling without replacement will be used.
-When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-. \code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was
-set to \code{TRUE} (default), then resampling without replacement with Pareto
-smoothed weights will be used. If \code{psis_resample} was set to \code{TRUE} or
-\code{calculate_lp} was set to \code{FALSE} then sampling without replacement with
-uniform weights will be used to select the draws.
-PSIS resampling is used to select the draws for  \code{\link{CmdStanVB}},
-and \code{\link{CmdStanLaplace}} fit objects.
-\item A type inheriting from \code{posterior::draws}. If the draws object has less
-samples than the number of requested chains/paths then the inits will be
+or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
+subset of the model parameters then the other parameters will be drawn by
+Stan's default initialization. The fit object must have at least some
+parameters that are the same name and dimensions as the current Stan model.
+For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
+than the requested number of chains/paths then the inits will be drawn using
+sampling with replacement. Otherwise sampling without replacement will be
+used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
+(default), then resampling without replacement with Pareto smoothed weights
+will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
+to \code{FALSE} then sampling without replacement with uniform weights will be
+used to select the draws. PSIS resampling is used to select the draws for
+\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+\item A type inheriting from \code{posterior::draws}. If the draws object has fewer
+draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without
 replacement will be used. If the draws object's parameters are only a subset
 of the model parameters then the other parameters will be drawn by Stan's

--- a/man/model-method-pathfinder.Rd
+++ b/man/model-method-pathfinder.Rd
@@ -69,8 +69,8 @@ variables declared in the parameters block of the Stan program. One of the
 following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
-\item The number \code{0}. This initializes \emph{all} parameters to \code{0};
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.
+\item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
 \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
@@ -82,30 +82,27 @@ named elements corresponding to the parameters for which you are specifying
 initial values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the
-function has argument \code{chain_id} it will be supplied with the chain id
-(from 1 to number of chains) when called to generate the initial values.
-See
+take no arguments or a single argument \code{chain_id}. For MCMC, if the function
+has argument \code{chain_id} it will be supplied with the chain id (from 1 to
+number of chains) when called to generate the initial values. See
 \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
-or \code{\link{CmdStanLaplace}} fit object.
-If the fit object's parameters are only a subset of the model
-parameters then the other parameters will be drawn by Stan's default
-initialization. The fit object must have at least some parameters that are the
-same name and dimensions as the current Stan model. For the \code{sample} and
-\code{pathfinder} method, if the fit object has fewer draws than the requested
-number of chains/paths then the inits will be drawn using sampling with
-replacement. Otherwise sampling without replacement will be used.
-When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-. \code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was
-set to \code{TRUE} (default), then resampling without replacement with Pareto
-smoothed weights will be used. If \code{psis_resample} was set to \code{TRUE} or
-\code{calculate_lp} was set to \code{FALSE} then sampling without replacement with
-uniform weights will be used to select the draws.
-PSIS resampling is used to select the draws for  \code{\link{CmdStanVB}},
-and \code{\link{CmdStanLaplace}} fit objects.
-\item A type inheriting from \code{posterior::draws}. If the draws object has less
-samples than the number of requested chains/paths then the inits will be
+or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
+subset of the model parameters then the other parameters will be drawn by
+Stan's default initialization. The fit object must have at least some
+parameters that are the same name and dimensions as the current Stan model.
+For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
+than the requested number of chains/paths then the inits will be drawn using
+sampling with replacement. Otherwise sampling without replacement will be
+used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
+(default), then resampling without replacement with Pareto smoothed weights
+will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
+to \code{FALSE} then sampling without replacement with uniform weights will be
+used to select the draws. PSIS resampling is used to select the draws for
+\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+\item A type inheriting from \code{posterior::draws}. If the draws object has fewer
+draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without
 replacement will be used. If the draws object's parameters are only a subset
 of the model parameters then the other parameters will be drawn by Stan's

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -73,8 +73,8 @@ variables declared in the parameters block of the Stan program. One of the
 following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
-\item The number \code{0}. This initializes \emph{all} parameters to \code{0};
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.
+\item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
 \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
@@ -86,30 +86,27 @@ named elements corresponding to the parameters for which you are specifying
 initial values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the
-function has argument \code{chain_id} it will be supplied with the chain id
-(from 1 to number of chains) when called to generate the initial values.
-See
+take no arguments or a single argument \code{chain_id}. For MCMC, if the function
+has argument \code{chain_id} it will be supplied with the chain id (from 1 to
+number of chains) when called to generate the initial values. See
 \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
-or \code{\link{CmdStanLaplace}} fit object.
-If the fit object's parameters are only a subset of the model
-parameters then the other parameters will be drawn by Stan's default
-initialization. The fit object must have at least some parameters that are the
-same name and dimensions as the current Stan model. For the \code{sample} and
-\code{pathfinder} method, if the fit object has fewer draws than the requested
-number of chains/paths then the inits will be drawn using sampling with
-replacement. Otherwise sampling without replacement will be used.
-When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-. \code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was
-set to \code{TRUE} (default), then resampling without replacement with Pareto
-smoothed weights will be used. If \code{psis_resample} was set to \code{TRUE} or
-\code{calculate_lp} was set to \code{FALSE} then sampling without replacement with
-uniform weights will be used to select the draws.
-PSIS resampling is used to select the draws for  \code{\link{CmdStanVB}},
-and \code{\link{CmdStanLaplace}} fit objects.
-\item A type inheriting from \code{posterior::draws}. If the draws object has less
-samples than the number of requested chains/paths then the inits will be
+or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
+subset of the model parameters then the other parameters will be drawn by
+Stan's default initialization. The fit object must have at least some
+parameters that are the same name and dimensions as the current Stan model.
+For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
+than the requested number of chains/paths then the inits will be drawn using
+sampling with replacement. Otherwise sampling without replacement will be
+used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
+(default), then resampling without replacement with Pareto smoothed weights
+will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
+to \code{FALSE} then sampling without replacement with uniform weights will be
+used to select the draws. PSIS resampling is used to select the draws for
+\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+\item A type inheriting from \code{posterior::draws}. If the draws object has fewer
+draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without
 replacement will be used. If the draws object's parameters are only a subset
 of the model parameters then the other parameters will be drawn by Stan's

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -79,8 +79,8 @@ variables declared in the parameters block of the Stan program. One of the
 following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
-\item The number \code{0}. This initializes \emph{all} parameters to \code{0};
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.
+\item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
 \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
@@ -92,30 +92,27 @@ named elements corresponding to the parameters for which you are specifying
 initial values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the
-function has argument \code{chain_id} it will be supplied with the chain id
-(from 1 to number of chains) when called to generate the initial values.
-See
+take no arguments or a single argument \code{chain_id}. For MCMC, if the function
+has argument \code{chain_id} it will be supplied with the chain id (from 1 to
+number of chains) when called to generate the initial values. See
 \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
-or \code{\link{CmdStanLaplace}} fit object.
-If the fit object's parameters are only a subset of the model
-parameters then the other parameters will be drawn by Stan's default
-initialization. The fit object must have at least some parameters that are the
-same name and dimensions as the current Stan model. For the \code{sample} and
-\code{pathfinder} method, if the fit object has fewer draws than the requested
-number of chains/paths then the inits will be drawn using sampling with
-replacement. Otherwise sampling without replacement will be used.
-When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-. \code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was
-set to \code{TRUE} (default), then resampling without replacement with Pareto
-smoothed weights will be used. If \code{psis_resample} was set to \code{TRUE} or
-\code{calculate_lp} was set to \code{FALSE} then sampling without replacement with
-uniform weights will be used to select the draws.
-PSIS resampling is used to select the draws for  \code{\link{CmdStanVB}},
-and \code{\link{CmdStanLaplace}} fit objects.
-\item A type inheriting from \code{posterior::draws}. If the draws object has less
-samples than the number of requested chains/paths then the inits will be
+or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
+subset of the model parameters then the other parameters will be drawn by
+Stan's default initialization. The fit object must have at least some
+parameters that are the same name and dimensions as the current Stan model.
+For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
+than the requested number of chains/paths then the inits will be drawn using
+sampling with replacement. Otherwise sampling without replacement will be
+used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
+(default), then resampling without replacement with Pareto smoothed weights
+will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
+to \code{FALSE} then sampling without replacement with uniform weights will be
+used to select the draws. PSIS resampling is used to select the draws for
+\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+\item A type inheriting from \code{posterior::draws}. If the draws object has fewer
+draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without
 replacement will be used. If the draws object's parameters are only a subset
 of the model parameters then the other parameters will be drawn by Stan's

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -63,8 +63,8 @@ variables declared in the parameters block of the Stan program. One of the
 following:
 \itemize{
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
-\verb{[-x,x]} on the \emph{unconstrained} parameter space.;
-\item The number \code{0}. This initializes \emph{all} parameters to \code{0};
+\verb{[-x,x]} on the \emph{unconstrained} parameter space.
+\item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths (one per chain) to JSON or Rdump files
 containing initial values for all or some parameters. See
 \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
@@ -76,30 +76,27 @@ named elements corresponding to the parameters for which you are specifying
 initial values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the
-function has argument \code{chain_id} it will be supplied with the chain id
-(from 1 to number of chains) when called to generate the initial values.
-See
+take no arguments or a single argument \code{chain_id}. For MCMC, if the function
+has argument \code{chain_id} it will be supplied with the chain id (from 1 to
+number of chains) when called to generate the initial values. See
 \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
-or \code{\link{CmdStanLaplace}} fit object.
-If the fit object's parameters are only a subset of the model
-parameters then the other parameters will be drawn by Stan's default
-initialization. The fit object must have at least some parameters that are the
-same name and dimensions as the current Stan model. For the \code{sample} and
-\code{pathfinder} method, if the fit object has fewer draws than the requested
-number of chains/paths then the inits will be drawn using sampling with
-replacement. Otherwise sampling without replacement will be used.
-When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-. \code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was
-set to \code{TRUE} (default), then resampling without replacement with Pareto
-smoothed weights will be used. If \code{psis_resample} was set to \code{TRUE} or
-\code{calculate_lp} was set to \code{FALSE} then sampling without replacement with
-uniform weights will be used to select the draws.
-PSIS resampling is used to select the draws for  \code{\link{CmdStanVB}},
-and \code{\link{CmdStanLaplace}} fit objects.
-\item A type inheriting from \code{posterior::draws}. If the draws object has less
-samples than the number of requested chains/paths then the inits will be
+or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
+subset of the model parameters then the other parameters will be drawn by
+Stan's default initialization. The fit object must have at least some
+parameters that are the same name and dimensions as the current Stan model.
+For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
+than the requested number of chains/paths then the inits will be drawn using
+sampling with replacement. Otherwise sampling without replacement will be
+used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
+(default), then resampling without replacement with Pareto smoothed weights
+will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
+to \code{FALSE} then sampling without replacement with uniform weights will be
+used to select the draws. PSIS resampling is used to select the draws for
+\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+\item A type inheriting from \code{posterior::draws}. If the draws object has fewer
+draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without
 replacement will be used. If the draws object's parameters are only a subset
 of the model parameters then the other parameters will be drawn by Stan's

--- a/tests/testthat/test-model-init.R
+++ b/tests/testthat/test-model-init.R
@@ -207,6 +207,47 @@ test_that("init can be a function", {
   )
 })
 
+test_that("init function is called once for each init", {
+  n_calls <- 0
+  init_fun <- function() {
+    n_calls <<- n_calls + 1
+    # Using a counter as an init value is not a sensible MCMC init strategy,
+    # but it makes it clear whether the values from each call are written.
+    list(alpha = n_calls, beta = 1:3)
+  }
+  init_paths_zero_arg <- process_init(init_fun, num_procs = 2)
+  withr::defer(unlink(init_paths_zero_arg))
+  expect_equal(n_calls, 2)
+  expect_equal(
+    vapply(init_paths_zero_arg, function(path) {
+      jsonlite::read_json(path, simplifyVector = TRUE)$alpha
+    }, numeric(1), USE.NAMES = FALSE),
+    1:2
+  )
+
+  chain_ids <- integer()
+  init_fun <- function(chain_id) {
+    chain_ids <<- c(chain_ids, chain_id)
+    list(alpha = 0, beta = 1:3)
+  }
+  init_paths_chain_id <- process_init(init_fun, num_procs = 2)
+  withr::defer(unlink(init_paths_chain_id))
+  expect_equal(chain_ids, 1:2)
+})
+
+test_that("init function return value is validated for each init", {
+  init_fun <- function(chain_id) {
+    if (chain_id == 2) {
+      return(data.frame(alpha = 0, beta = 1:3))
+    }
+    list(alpha = 0, beta = 1:3)
+  }
+  expect_error(
+    process_init(init_fun, num_procs = 2),
+    "If 'init' is a function it must return a single list"
+  )
+})
+
 test_that("error if init function specified incorrectly", {
   init_fun <- function(a, b) list(a, b)
   expect_error(
@@ -272,6 +313,17 @@ test_that("print message if not all parameters are initialized", {
 
 test_that("No message printed if options(cmdstanr_warn_inits=FALSE)", {
   withr::local_options(list(cmdstanr_warn_inits = FALSE))
+  model_variables <- list(
+    parameters = list(
+      alpha = list(dimensions = 0),
+      beta = list(dimensions = 1)
+    )
+  )
+  init_paths <- expect_message(
+    process_init(function() list(alpha = 1), 1, model_variables),
+    regexp = NA
+  )
+  withr::defer(unlink(init_paths))
   expect_message(
     utils::capture.output(mod_logistic$optimize(data = data_list_logistic, init = list(list(a = 0)), seed = 123)),
     regexp = NA


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

When inits were specified using a function we were calling the function an extra time to validate it before using it, but we can just validate it at the time we use it. 

Also made a few tiny edits to `init` argument doc. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
