### PR TITLE
Fix accidental mangling of model namespace name

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -250,7 +250,7 @@ CmdStanModel <- R6::R6Class(
         checkmate::assert_flag(compile)
         private$stan_file_ <- absolute_path(stan_file)
         private$stan_code_ <- readLines(stan_file)
-        private$model_name_ <- sub(" ", "_", strip_ext(basename(private$stan_file_)))
+        private$model_name_ <- gsub(" ", "_", strip_ext(basename(private$stan_file_)))
         private$precompile_cpp_options_ <- args$cpp_options %||% list()
         private$precompile_stanc_options_ <- assert_valid_stanc_options(args$stanc_options) %||% list()
         if (!is.null(args$user_header) || !is.null(args$cpp_options[["USER_HEADER"]]) ||
@@ -268,7 +268,7 @@ CmdStanModel <- R6::R6Class(
         private$exe_file_ <- repair_path(absolute_path(exe_file))
         if (is.null(stan_file)) {
           assert_file_exists(private$exe_file_, access = "r", extension = ext)
-          private$model_name_ <- sub(" ", "_", strip_ext(basename(private$exe_file_)))
+          private$model_name_ <- gsub(" ", "_", strip_ext(basename(private$exe_file_)))
         }
       }
       if (!is.null(stan_file) && compile) {
@@ -623,7 +623,9 @@ compile <- function(quiet = TRUE,
       stanc_built_options <- c(stanc_built_options, paste0("--", option_name))
     } else if (is.null(option_name) || !nzchar(option_name)) {
       stanc_built_options <- c(stanc_built_options, paste0("--", stanc_options[[i]]))
-    } else {
+    } else if (option_name == "name") { # Quoting model name mangles generated namespace
+      stanc_built_options <- c(stanc_built_options, paste0("--", option_name, "=", stanc_options[[i]]))
+    }  else {
       stanc_built_options <- c(stanc_built_options, paste0("--", option_name, "=", "'", stanc_options[[i]], "'"))
     }
   }
@@ -645,7 +647,7 @@ compile <- function(quiet = TRUE,
   if (!dry_run) {
 
     if (compile_standalone) {
-      expose_stan_functions(self$functions, !quiet)
+      expose_stan_functions(self$functions, verbose = !quiet)
     }
 
     withr::with_envvar(

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -113,11 +113,11 @@ test_that("name in STANCFLAGS is set correctly", {
   local_reproducible_output()
   out <- utils::capture.output(mod$compile(quiet = FALSE, force_recompile = TRUE))
   if(os_is_windows() && !os_is_wsl()) {
-    out_no_name <- "bin/stanc.exe --name='bernoulli_model' --o"
-    out_name <- "bin/stanc.exe --name='bernoulli2_model' --o"
+    out_no_name <- "bin/stanc.exe --name=bernoulli_model --o"
+    out_name <- "bin/stanc.exe --name=bernoulli2_model --o"
   } else {
-    out_no_name <- "bin/stanc --name='bernoulli_model' --o"
-    out_name <- "bin/stanc --name='bernoulli2_model' --o"
+    out_no_name <- "bin/stanc --name=bernoulli_model --o"
+    out_name <- "bin/stanc --name=bernoulli2_model --o"
   }
   expect_output(print(out), out_no_name)
 
@@ -848,9 +848,9 @@ test_that("STANCFLAGS from get_cmdstan_flags() are included in compile output", 
   )
   out <- utils::capture.output(mod$compile(quiet = FALSE, force_recompile = TRUE))
   if(os_is_windows() && !os_is_wsl()) {
-    out_w_flags <- "bin/stanc.exe --name='bernoulli_model'[[:space:]]+--O1[[:space:]]+--warn-pedantic[[:space:]]+--o"
+    out_w_flags <- "bin/stanc.exe --name=bernoulli_model[[:space:]]+--O1[[:space:]]+--warn-pedantic[[:space:]]+--o"
   } else {
-    out_w_flags <- "bin/stanc --name='bernoulli_model'[[:space:]]+--O1[[:space:]]+--warn-pedantic[[:space:]]+--o"
+    out_w_flags <- "bin/stanc --name=bernoulli_model[[:space:]]+--O1[[:space:]]+--warn-pedantic[[:space:]]+--o"
   }
   expect_output(print(out), out_w_flags)
 })


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Related to #1197, the model name argument is currently passed to `stanc` as a quoted string (i.e., `stanc --name='bernoulli_model'`), causing `stanc` to treat the quotes as part of the model name and escape/mangle them in the generated c++ (e.g., `x39bernoulli_modelx39_namespace`).

Additionally the pre-processing step for replacing spaces with underscores to generate the model name from filename is currently using the `sub()` function instead of `gsub()`, causing only the first space to be replaced (i.e., `name with spaces.stan` -> `name_with spaces`)

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
