### PR TITLE
Fix tests for Windows ARM64 and add to CI

### DIFF
--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -44,6 +44,7 @@ jobs:
           - {os: ubuntu-latest, r: 'devel', opencl: true}
           - {os: ubuntu-latest, r: 'release', opencl: true}
           - {os: ubuntu-latest, r: 'oldrel', opencl: true}
+          - {os: windows-11-arm, r: 'release'}
     env:
       R_REMOTES_NO_ERRORS_FROM_WARNINGS: true
       GITHUB_PAT: ${{ secrets.GITHUB_TOKEN }}
@@ -56,6 +57,10 @@ jobs:
       - name: cmdstan env vars
         run: |
           echo "CMDSTAN_PATH=${HOME}/.cmdstan" >> $GITHUB_ENV
+          # GHA Windows ARM containers configured with RTOOLS45_HOME instead of RTOOLS45_AARCH64_HOME
+          if [[ "${{ matrix.config.os }}" == "windows-11-arm" ]]; then
+            echo "RTOOLS45_AARCH64_HOME=C:/rtools45-aarch64" >> $GITHUB_ENV
+          fi
         shell: bash
 
       - uses: actions/checkout@v7
@@ -75,7 +80,7 @@ jobs:
       - uses: r-lib/actions/setup-r-dependencies@v2
         with:
           cache: "always"
-          extra-packages: any::rcmdcheck, local::.
+          extra-packages: any::rcmdcheck, local::., ${{ matrix.config.os == 'windows-11-arm' && 'RcppCore/RcppParallel' || '' }}
 
       - name: Debug Windows toolchain resolution
         if: ${{ runner.os == 'Windows' }}

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -91,7 +91,7 @@ test_that("install_cmdstan() works with version and release_url", {
   expect_message(
     expect_output(
       install_cmdstan(dir = dir, overwrite = TRUE, cores = CORES,
-                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.36.0/cmdstan-2.36.0.tar.gz",
+                      release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.37.0/cmdstan-2.37.0.tar.gz",
                       wsl = os_is_wsl()),
       "Compiling C++ code",
       fixed = TRUE
@@ -103,7 +103,7 @@ test_that("install_cmdstan() works with version and release_url", {
     expect_message(
       expect_output(
         install_cmdstan(dir = dir, overwrite = TRUE, cores = CORES,
-                        version = "2.36.0",
+                        version = "2.37.0",
                         # the URL is intentionally invalid to test that the version has higher priority
                         release_url = "https://github.com/stan-dev/cmdstan/releases/download/v2.27.3/cmdstan-2.27.3.tar.gz",
                         wsl = os_is_wsl()),
@@ -116,7 +116,7 @@ test_that("install_cmdstan() works with version and release_url", {
     "version and release_url shouldn't both be specified",
     fixed = TRUE
   )
-  expect_true(dir.exists(file.path(dir, "cmdstan-2.36.0")))
+  expect_true(dir.exists(file.path(dir, "cmdstan-2.37.0")))
   set_cmdstan_path()
 })
 
@@ -161,15 +161,15 @@ test_that("github_download_url constructs correct url", {
 test_that("extract_cmdstan_version_from_archive_name parses realistic inputs", {
   expect_equal(
     extract_cmdstan_version_from_archive_name(
-      "https://github.com/stan-dev/cmdstan/releases/download/v2.36.0/cmdstan-2.36.0.tar.gz"
+      "https://github.com/stan-dev/cmdstan/releases/download/v2.37.0/cmdstan-2.37.0.tar.gz"
     ),
-    "2.36.0"
+    "2.37.0"
   )
   expect_equal(
     extract_cmdstan_version_from_archive_name(
-      "https://github.com/stan-dev/cmdstan/releases/download/v2.36.0/cmdstan-2.36.0-linux-arm64.tar.gz"
+      "https://github.com/stan-dev/cmdstan/releases/download/v2.37.0/cmdstan-2.37.0-linux-arm64.tar.gz"
     ),
-    "2.36.0"
+    "2.37.0"
   )
   expect_equal(
     extract_cmdstan_version_from_archive_name(
@@ -185,7 +185,7 @@ test_that("extract_cmdstan_version_from_archive_name parses realistic inputs", {
   )
   expect_null(
     extract_cmdstan_version_from_archive_name(
-      "https://github.com/stan-dev/cmdstan/releases/tag/v2.36.0"
+      "https://github.com/stan-dev/cmdstan/releases/tag/v2.37.0"
     )
   )
 })
@@ -234,10 +234,10 @@ test_that("Download failures return error message", {
 test_that("Install from release file works", {
   dir <- tempdir(check = TRUE)
 
-  destfile <- file.path(dir, "cmdstan-2.36.0.tar.gz")
+  destfile <- file.path(dir, "cmdstan-2.37.0.tar.gz")
 
   download_with_retries(
-    "https://github.com/stan-dev/cmdstan/releases/download/v2.36.0/cmdstan-2.36.0.tar.gz",
+    "https://github.com/stan-dev/cmdstan/releases/download/v2.37.0/cmdstan-2.37.0.tar.gz",
     destfile)
 
   expect_message(


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The tests needed a minor change for compatibility with Windows ARM64 - installing cmdstan versions which weren't compatible. This PR fixes the tests and adds the platform to CI

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Andrew Johnson


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
