### PR TITLE
Various fixes to processing initial values

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # cmdstanr (development version)
 
+* Pathfinder fits used as initial values now use uniform weights when CmdStan already PSIS-resampled their draws, avoiding a second application of importance weights.
+* `pathfinder()` now passes separately supplied initial values to every path instead of using only the first path's initial values.
 * `pathfinder()` now respects `save_single_paths = TRUE` instead of always
 passing `0` to CmdStan.
 * `pathfinder()` now uses `threads` argument (`num_threads` is deprecated),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # cmdstanr (development version)
 
-* Pathfinder fits used as initial values now use uniform weights when CmdStan already PSIS-resampled their draws, avoiding a second application of importance weights.
-* `pathfinder()` now passes separately supplied initial values to every path instead of using only the first path's initial values.
+* Pathfinder fits used as initial values now use uniform weights when CmdStan already PSIS-resampled their draws, avoiding a second application of importance weights. (#1206)
+* `pathfinder()` now passes separately supplied initial values to every path instead of using only the first path's initial values. (#1206)
 * `pathfinder()` now respects `save_single_paths = TRUE` instead of always
 passing `0` to CmdStan.
 * `pathfinder()` now uses `threads` argument (`num_threads` is deprecated),

--- a/R/args.R
+++ b/R/args.R
@@ -1491,8 +1491,8 @@ validate_init <- function(init, num_procs) {
          call. = FALSE)
   } else if (is.character(init)) {
     if (length(init) != 1 && length(init) != num_procs) {
-      stop("If 'init' is specified as a character vector it must have ",
-           "length 1 or number of chains.",
+      stop("If 'init' is specified as a character vector, its length must be ",
+           "1 or equal to the number of chains or Pathfinder paths.",
            call. = FALSE)
     }
     assert_file_exists(init, access = "r")

--- a/R/args.R
+++ b/R/args.R
@@ -155,7 +155,14 @@ CmdStanArgs <- R6::R6Class(
       }
 
       if (!is.null(self$init)) {
-        args$init <- paste0("init=", wsl_safe_path(self$init[idx]))
+        # CmdStan runs all Pathfinder paths in one process. When there is one
+        # init file per path, CmdStan expects one comma-separated argument.
+        init <- if (inherits(self$method_args, "PathfinderArgs")) {
+          self$init
+        } else {
+          self$init[idx]
+        }
+        args$init <- paste0("init=", paste(wsl_safe_path(init), collapse = ","))
       }
 
       if (!is.null(self$data_file)) {

--- a/R/args.R
+++ b/R/args.R
@@ -1306,6 +1306,13 @@ process_init_approx <- function(init, num_procs, model_variables = NULL,
   validate_fit_init(init, model_variables)
   # Convert from data.table to data.frame
   draws_df <- init$draws(format = "df")
+  pathfinder_resampled <- FALSE
+  if (inherits(init, "CmdStanPathfinder")) {
+    metadata <- init$metadata()
+    pathfinder_resampled <- metadata$num_paths > 1 &&
+      metadata$psis_resample &&
+      metadata$calculate_lp
+  }
   draws_df$lw <- draws_df$lp__ - draws_df$lp_approx__
   # Replace NaN and Inf with -Inf
   draws_df$lw[!is.finite(draws_df$lw)] <- -Inf
@@ -1331,6 +1338,10 @@ process_init_approx <- function(init, num_procs, model_variables = NULL,
   if (unique_draws < (0.95 * nrow(draws_df))) {
     temp_df <- stats::aggregate(.draw ~ lw, data = draws_df, FUN = min)
     draws_df <- posterior::as_draws_df(merge(temp_df, draws_df, by = 'lw'))
+  }
+  if (pathfinder_resampled) {
+    draws_df$weight <- rep(1.0, nrow(draws_df))
+  } else if (unique_draws < (0.95 * nrow(draws_df))) {
     draws_df$weight <- exp(draws_df$lw - max(draws_df$lw))
   } else {
       draws_df$weight <- posterior::pareto_smooth(

--- a/R/args.R
+++ b/R/args.R
@@ -1323,9 +1323,11 @@ process_init_approx <- function(init, num_procs, model_variables = NULL,
   draws_df$lw <- draws_df$lp__ - draws_df$lp_approx__
   # Replace NaN and Inf with -Inf
   draws_df$lw[!is.finite(draws_df$lw)] <- -Inf
-  # Calculate unique draws based on 'lw' using base R functions
-  unique_draws <- length(unique(draws_df$lw))
-  if (num_procs > unique_draws) {
+  # We've been using distinct log weights as a proxy for distinct parameter
+  # vectors, but this isn't perfect. Comparing parameter values directly would
+  # be more accurate.
+  num_unique_log_weights <- length(unique(draws_df$lw))
+  if (num_procs > num_unique_log_weights) {
     if (inherits(init, "CmdStanPathfinder")) {
       algo_name <- " Pathfinder "
       extra_msg <- " Try running Pathfinder with psis_resample=FALSE."
@@ -1340,28 +1342,31 @@ process_init_approx <- function(init, num_procs, model_variables = NULL,
       extra_msg <- ""
     }
     stop(paste0("Not enough distinct draws (", num_procs, ") in", algo_name ,
-      "fit to create inits.", extra_msg))
+                "fit to create inits.", extra_msg))
   }
-  if (unique_draws < (0.95 * nrow(draws_df))) {
+  if (num_unique_log_weights < (0.95 * nrow(draws_df))) {
     temp_df <- stats::aggregate(.draw ~ lw, data = draws_df, FUN = min)
     draws_df <- posterior::as_draws_df(merge(temp_df, draws_df, by = 'lw'))
   }
   if (pathfinder_resampled) {
     draws_df$weight <- rep(1.0, nrow(draws_df))
-  } else if (unique_draws < (0.95 * nrow(draws_df))) {
+  } else if (num_unique_log_weights < (0.95 * nrow(draws_df))) {
     draws_df$weight <- exp(draws_df$lw - max(draws_df$lw))
   } else {
-      draws_df$weight <- posterior::pareto_smooth(
-        exp(draws_df$lw - max(draws_df$lw)), tail = "right", r_eff=1, return_k=FALSE)
+    draws_df$weight <- posterior::pareto_smooth(
+      exp(draws_df$lw - max(draws_df$lw)), tail = "right", r_eff=1, return_k=FALSE)
   }
-    init_draws_df <- posterior::resample_draws(draws_df, ndraws = num_procs,
-                                              weights = draws_df$weight, method = "simple_no_replace")
-    init_draws_df <- posterior::subset_draws(init_draws_df,
-      variable = setdiff(posterior::variables(init_draws_df), c("lw", "weight")))
-    init_draws_lst <- process_init(init_draws_df,
-                                  num_procs = num_procs, model_variables = model_variables, warn_partial)
-    return(init_draws_lst)
-  }
+  init_draws_df <- posterior::resample_draws(draws_df, ndraws = num_procs,
+                                             weights = draws_df$weight, method = "simple_no_replace")
+  init_draws_df <- posterior::subset_draws(init_draws_df,
+                                           variable = setdiff(posterior::variables(init_draws_df), c("lw", "weight")))
+  process_init(
+    init_draws_df,
+    num_procs = num_procs,
+    model_variables = model_variables,
+    warn_partial
+  )
+}
 
 #' Write initial values to files if provided as a `CmdStanPathfinder` class
 #' @noRd

--- a/R/csv.R
+++ b/R/csv.R
@@ -871,6 +871,13 @@ read_csv_metadata <- function(csv_file) {
   csv_file_info$diagnostic_file <- NULL
   csv_file_info$metric_file <- NULL
   csv_file_info$num_threads <- NULL
+  # CmdStan records multi-path Pathfinder inits as one comma-separated value.
+  # Split it so metadata and fit$init() retain one file per path.
+  if (identical(csv_file_info$method, "pathfinder") &&
+      is.character(csv_file_info$init) &&
+      isTRUE(csv_file_info$num_paths > 1)) {
+    csv_file_info$init <- strsplit(csv_file_info$init, ",", fixed = TRUE)[[1]]
+  }
   if (length(gradients) > 0) {
     csv_file_info$gradients <- gradients
   }

--- a/R/csv.R
+++ b/R/csv.R
@@ -871,8 +871,9 @@ read_csv_metadata <- function(csv_file) {
   csv_file_info$diagnostic_file <- NULL
   csv_file_info$metric_file <- NULL
   csv_file_info$num_threads <- NULL
-  # CmdStan records multi-path Pathfinder inits as one comma-separated value.
-  # Split it so metadata and fit$init() retain one file per path.
+
+  # cmdstan records multi-path Pathfinder inits as one comma-separated value,
+  # so we split it so metadata and fit$init() have one file per path
   if (identical(csv_file_info$method, "pathfinder") &&
       is.character(csv_file_info$init) &&
       isTRUE(csv_file_info$num_paths > 1)) {
@@ -882,7 +883,7 @@ read_csv_metadata <- function(csv_file) {
     csv_file_info$gradients <- gradients
   }
 
-  # Revert any WSL-updated paths before returning the metadata
+  # revert any WSL-updated paths before returning the metadata
   if (os_is_wsl()) {
     csv_file_info$init <- wsl_safe_path(csv_file_info$init, revert = TRUE)
     csv_file_info$profile_file <- wsl_safe_path(csv_file_info$profile_file,

--- a/R/utils.R
+++ b/R/utils.R
@@ -496,6 +496,16 @@ wsl_safe_path <- function(path = NULL, revert = FALSE) {
   if (!is.character(path) || is.null(path) || !os_is_wsl()) {
     return(path)
   }
+  # Apply the existing scalar conversion to each path, forwarding `revert`.
+  if (length(path) != 1L) {
+    return(vapply(
+      path,
+      wsl_safe_path,
+      character(1),
+      revert = revert,
+      USE.NAMES = FALSE
+    ))
+  }
   if (revert) {
     if (!grepl("^/mnt/", path)) {
       return(path)

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -28,21 +28,23 @@
 #'  * A real number `x>0`. This initializes _all_ parameters randomly between
 #'  `[-x,x]` on the _unconstrained_ parameter space.
 #'  * The number `0`. This initializes _all_ parameters to `0`.
-#'  * A character vector of paths (one per chain) to JSON or Rdump files
-#'  containing initial values for all or some parameters. See
-#'  [write_stan_json()] to write \R objects to JSON files compatible with
+#'  * A character vector of paths to JSON or Rdump files containing initial
+#'  values for all or some parameters. A single path is used for all chains or
+#'  Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
+#'  See [write_stan_json()] to write \R objects to JSON files compatible with
 #'  CmdStan.
 #'  * A list of lists containing initial values for all or some parameters. For
-#'  MCMC the list should contain a sublist for each chain. For other model
-#'  fitting methods there should be just one sublist. The sublists should have
-#'  named elements corresponding to the parameters for which you are specifying
-#'  initial values. See **Examples**.
+#'  MCMC the list should contain a sublist for each chain, and for Pathfinder it
+#'  should contain a sublist for each path. For other model fitting methods
+#'  there should be just one sublist. The sublists should have named elements
+#'  corresponding to the parameters for which you are specifying initial
+#'  values. See **Examples**.
 #'  * A function that returns a single list with names corresponding to the
 #'  parameters for which you are specifying initial values. The function can
-#'  take no arguments or a single argument `chain_id`. For MCMC, if the function
-#'  has argument `chain_id` it will be supplied with the chain id (from 1 to
-#'  number of chains) when called to generate the initial values. See
-#'  **Examples**.
+#'  take no arguments or a single argument `chain_id`. For MCMC and Pathfinder,
+#'  the function is called once for each chain or path. If the function has the
+#'  `chain_id` argument, it receives the chain or path number, starting at 1.
+#'  See **Examples**.
 #'  * A [`CmdStanMCMC`], [`CmdStanMLE`], [`CmdStanVB`], [`CmdStanPathfinder`],
 #'  or [`CmdStanLaplace`] fit object. If the fit object's parameters are only a
 #'  subset of the model parameters then the other parameters will be drawn by

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -65,10 +65,11 @@
 #'  importance weights cannot be calculated. PSIS resampling is used to select
 #'  the draws for [`CmdStanVB`], and [`CmdStanLaplace`] fit objects.
 #'  * A type inheriting from `posterior::draws`. If the draws object has fewer
-#'  draws than the number of requested chains/paths then the inits will be
-#'  drawn using sampling with replacement. Otherwise sampling without
-#'  replacement will be used. If the draws object's parameters are only a subset
-#'  of the model parameters then the other parameters will be drawn by Stan's
+#'  draws than the number of requested chains/paths, the draws are reused in
+#'  their existing order until each chain/path has an initialization. If there
+#'  are more draws than requested chains/paths, draws are selected uniformly
+#'  without replacement. If the draws object's parameters are only a subset of
+#'  the model parameters then the other parameters will be drawn by Stan's
 #'  default initialization. The fit object must have at least some parameters
 #'  that are the same name and dimensions as the current Stan model.
 #'

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -29,9 +29,9 @@
 #'  `[-x,x]` on the _unconstrained_ parameter space.
 #'  * The number `0`. This initializes _all_ parameters to `0`.
 #'  * A character vector of paths to JSON or Rdump files containing initial
-#'  values for all or some parameters. A single path is used for all chains or
-#'  Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
-#'  See [write_stan_json()] to write \R objects to JSON files compatible with
+#'  values for all or some parameters. For MCMC and Pathfinder, if only a single
+#'  file is provided it will be reused for all chains and paths. See
+#'  [write_stan_json()] to write \R objects to JSON files compatible with
 #'  CmdStan.
 #'  * A list of lists containing initial values for all or some parameters. For
 #'  MCMC the list should contain a sublist for each chain, and for Pathfinder it

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -52,12 +52,16 @@
 #'  than the requested number of chains/paths then the inits will be drawn using
 #'  sampling with replacement. Otherwise sampling without replacement will be
 #'  used. When a [`CmdStanPathfinder`] fit object is used as the init, if
-#'  `psis_resample` was set to `FALSE` and `calculate_lp` was set to `TRUE`
-#'  (default), then resampling without replacement with Pareto smoothed weights
-#'  will be used. If `psis_resample` was set to `TRUE` or `calculate_lp` was set
-#'  to `FALSE` then sampling without replacement with uniform weights will be
-#'  used to select the draws. PSIS resampling is used to select the draws for
-#'  [`CmdStanVB`], and [`CmdStanLaplace`] fit objects.
+#'  CmdStan actually performed PSIS resampling (which requires `num_paths > 1`,
+#'  `psis_resample = TRUE`, and `calculate_lp = TRUE`), CmdStanR selects from
+#'  the returned draws using uniform weights to avoid applying importance
+#'  weights again. If CmdStan did not PSIS-resample the output and
+#'  `calculate_lp = TRUE`, CmdStanR selects draws using Pareto-smoothed
+#'  importance weights. This includes single-path fits with
+#'  `psis_resample = TRUE`, because CmdStan does not PSIS-resample single-path
+#'  output. If `calculate_lp = FALSE`, uniform weights are used because
+#'  importance weights cannot be calculated. PSIS resampling is used to select
+#'  the draws for [`CmdStanVB`], and [`CmdStanLaplace`] fit objects.
 #'  * A type inheriting from `posterior::draws`. If the draws object has fewer
 #'  draws than the number of requested chains/paths then the inits will be
 #'  drawn using sampling with replacement. Otherwise sampling without

--- a/man-roxygen/model-common-args.R
+++ b/man-roxygen/model-common-args.R
@@ -50,10 +50,13 @@
 #'  subset of the model parameters then the other parameters will be drawn by
 #'  Stan's default initialization. The fit object must have at least some
 #'  parameters that are the same name and dimensions as the current Stan model.
-#'  For the `sample` and `pathfinder` method, if the fit object has fewer draws
-#'  than the requested number of chains/paths then the inits will be drawn using
-#'  sampling with replacement. Otherwise sampling without replacement will be
-#'  used. When a [`CmdStanPathfinder`] fit object is used as the init, if
+#'  For the `sample` and `pathfinder` methods, which need one initialization per
+#'  chain or path, the inits are drawn from the fit object without replacement,
+#'  so it must contain at least as many draws as the number of chains/paths. For
+#'  [`CmdStanVB`], [`CmdStanLaplace`], and [`CmdStanPathfinder`] fit objects the
+#'  draws must additionally be _distinct_. A [`CmdStanMLE`] fit object is the
+#'  exception: its single draw (the mode) is used to initialize every chain or
+#'  path. When a [`CmdStanPathfinder`] fit object is used as the init, if
 #'  CmdStan actually performed PSIS resampling (which requires `num_paths > 1`,
 #'  `psis_resample = TRUE`, and `calculate_lp = TRUE`), CmdStanR selects from
 #'  the returned draws using uniform weights to avoid applying importance

--- a/man/model-method-diagnose.Rd
+++ b/man/model-method-diagnose.Rd
@@ -69,12 +69,16 @@ For the \code{sample} and \code{pathfinder} method, if the fit object has fewer 
 than the requested number of chains/paths then the inits will be drawn using
 sampling with replacement. Otherwise sampling without replacement will be
 used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
-(default), then resampling without replacement with Pareto smoothed weights
-will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
-to \code{FALSE} then sampling without replacement with uniform weights will be
-used to select the draws. PSIS resampling is used to select the draws for
-\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
+\code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
+the returned draws using uniform weights to avoid applying importance
+weights again. If CmdStan did not PSIS-resample the output and
+\code{calculate_lp = TRUE}, CmdStanR selects draws using Pareto-smoothed
+importance weights. This includes single-path fits with
+\code{psis_resample = TRUE}, because CmdStan does not PSIS-resample single-path
+output. If \code{calculate_lp = FALSE}, uniform weights are used because
+importance weights cannot be calculated. PSIS resampling is used to select
+the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
 draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without

--- a/man/model-method-diagnose.Rd
+++ b/man/model-method-diagnose.Rd
@@ -67,10 +67,13 @@ or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are o
 subset of the model parameters then the other parameters will be drawn by
 Stan's default initialization. The fit object must have at least some
 parameters that are the same name and dimensions as the current Stan model.
-For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
-than the requested number of chains/paths then the inits will be drawn using
-sampling with replacement. Otherwise sampling without replacement will be
-used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+For the \code{sample} and \code{pathfinder} methods, which need one initialization per
+chain or path, the inits are drawn from the fit object without replacement,
+so it must contain at least as many draws as the number of chains/paths. For
+\code{\link{CmdStanVB}}, \code{\link{CmdStanLaplace}}, and \code{\link{CmdStanPathfinder}} fit objects the
+draws must additionally be \emph{distinct}. A \code{\link{CmdStanMLE}} fit object is the
+exception: its single draw (the mode) is used to initialize every chain or
+path. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
 CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
 \code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
 the returned draws using uniform weights to avoid applying importance

--- a/man/model-method-diagnose.Rd
+++ b/man/model-method-diagnose.Rd
@@ -82,10 +82,11 @@ output. If \code{calculate_lp = FALSE}, uniform weights are used because
 importance weights cannot be calculated. PSIS resampling is used to select
 the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
-draws than the number of requested chains/paths then the inits will be
-drawn using sampling with replacement. Otherwise sampling without
-replacement will be used. If the draws object's parameters are only a subset
-of the model parameters then the other parameters will be drawn by Stan's
+draws than the number of requested chains/paths, the draws are reused in
+their existing order until each chain/path has an initialization. If there
+are more draws than requested chains/paths, draws are selected uniformly
+without replacement. If the draws object's parameters are only a subset of
+the model parameters then the other parameters will be drawn by Stan's
 default initialization. The fit object must have at least some parameters
 that are the same name and dimensions as the current Stan model.
 }}

--- a/man/model-method-diagnose.Rd
+++ b/man/model-method-diagnose.Rd
@@ -45,21 +45,23 @@ following:
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
-\item A character vector of paths (one per chain) to JSON or Rdump files
-containing initial values for all or some parameters. See
-\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+\item A character vector of paths to JSON or Rdump files containing initial
+values for all or some parameters. A single path is used for all chains or
+Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
+See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
-MCMC the list should contain a sublist for each chain. For other model
-fitting methods there should be just one sublist. The sublists should have
-named elements corresponding to the parameters for which you are specifying
-initial values. See \strong{Examples}.
+MCMC the list should contain a sublist for each chain, and for Pathfinder it
+should contain a sublist for each path. For other model fitting methods
+there should be just one sublist. The sublists should have named elements
+corresponding to the parameters for which you are specifying initial
+values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the function
-has argument \code{chain_id} it will be supplied with the chain id (from 1 to
-number of chains) when called to generate the initial values. See
-\strong{Examples}.
+take no arguments or a single argument \code{chain_id}. For MCMC and Pathfinder,
+the function is called once for each chain or path. If the function has the
+\code{chain_id} argument, it receives the chain or path number, starting at 1.
+See \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
 or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
 subset of the model parameters then the other parameters will be drawn by

--- a/man/model-method-diagnose.Rd
+++ b/man/model-method-diagnose.Rd
@@ -46,9 +46,9 @@ following:
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths to JSON or Rdump files containing initial
-values for all or some parameters. A single path is used for all chains or
-Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
-See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+values for all or some parameters. For MCMC and Pathfinder, if only a single
+file is provided it will be reused for all chains and paths. See
+\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
 MCMC the list should contain a sublist for each chain, and for Pathfinder it

--- a/man/model-method-laplace.Rd
+++ b/man/model-method-laplace.Rd
@@ -83,12 +83,16 @@ For the \code{sample} and \code{pathfinder} method, if the fit object has fewer 
 than the requested number of chains/paths then the inits will be drawn using
 sampling with replacement. Otherwise sampling without replacement will be
 used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
-(default), then resampling without replacement with Pareto smoothed weights
-will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
-to \code{FALSE} then sampling without replacement with uniform weights will be
-used to select the draws. PSIS resampling is used to select the draws for
-\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
+\code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
+the returned draws using uniform weights to avoid applying importance
+weights again. If CmdStan did not PSIS-resample the output and
+\code{calculate_lp = TRUE}, CmdStanR selects draws using Pareto-smoothed
+importance weights. This includes single-path fits with
+\code{psis_resample = TRUE}, because CmdStan does not PSIS-resample single-path
+output. If \code{calculate_lp = FALSE}, uniform weights are used because
+importance weights cannot be calculated. PSIS resampling is used to select
+the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
 draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without

--- a/man/model-method-laplace.Rd
+++ b/man/model-method-laplace.Rd
@@ -81,10 +81,13 @@ or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are o
 subset of the model parameters then the other parameters will be drawn by
 Stan's default initialization. The fit object must have at least some
 parameters that are the same name and dimensions as the current Stan model.
-For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
-than the requested number of chains/paths then the inits will be drawn using
-sampling with replacement. Otherwise sampling without replacement will be
-used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+For the \code{sample} and \code{pathfinder} methods, which need one initialization per
+chain or path, the inits are drawn from the fit object without replacement,
+so it must contain at least as many draws as the number of chains/paths. For
+\code{\link{CmdStanVB}}, \code{\link{CmdStanLaplace}}, and \code{\link{CmdStanPathfinder}} fit objects the
+draws must additionally be \emph{distinct}. A \code{\link{CmdStanMLE}} fit object is the
+exception: its single draw (the mode) is used to initialize every chain or
+path. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
 CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
 \code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
 the returned draws using uniform weights to avoid applying importance

--- a/man/model-method-laplace.Rd
+++ b/man/model-method-laplace.Rd
@@ -60,9 +60,9 @@ following:
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths to JSON or Rdump files containing initial
-values for all or some parameters. A single path is used for all chains or
-Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
-See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+values for all or some parameters. For MCMC and Pathfinder, if only a single
+file is provided it will be reused for all chains and paths. See
+\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
 MCMC the list should contain a sublist for each chain, and for Pathfinder it

--- a/man/model-method-laplace.Rd
+++ b/man/model-method-laplace.Rd
@@ -59,21 +59,23 @@ following:
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
-\item A character vector of paths (one per chain) to JSON or Rdump files
-containing initial values for all or some parameters. See
-\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+\item A character vector of paths to JSON or Rdump files containing initial
+values for all or some parameters. A single path is used for all chains or
+Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
+See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
-MCMC the list should contain a sublist for each chain. For other model
-fitting methods there should be just one sublist. The sublists should have
-named elements corresponding to the parameters for which you are specifying
-initial values. See \strong{Examples}.
+MCMC the list should contain a sublist for each chain, and for Pathfinder it
+should contain a sublist for each path. For other model fitting methods
+there should be just one sublist. The sublists should have named elements
+corresponding to the parameters for which you are specifying initial
+values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the function
-has argument \code{chain_id} it will be supplied with the chain id (from 1 to
-number of chains) when called to generate the initial values. See
-\strong{Examples}.
+take no arguments or a single argument \code{chain_id}. For MCMC and Pathfinder,
+the function is called once for each chain or path. If the function has the
+\code{chain_id} argument, it receives the chain or path number, starting at 1.
+See \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
 or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
 subset of the model parameters then the other parameters will be drawn by

--- a/man/model-method-laplace.Rd
+++ b/man/model-method-laplace.Rd
@@ -96,10 +96,11 @@ output. If \code{calculate_lp = FALSE}, uniform weights are used because
 importance weights cannot be calculated. PSIS resampling is used to select
 the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
-draws than the number of requested chains/paths then the inits will be
-drawn using sampling with replacement. Otherwise sampling without
-replacement will be used. If the draws object's parameters are only a subset
-of the model parameters then the other parameters will be drawn by Stan's
+draws than the number of requested chains/paths, the draws are reused in
+their existing order until each chain/path has an initialization. If there
+are more draws than requested chains/paths, draws are selected uniformly
+without replacement. If the draws object's parameters are only a subset of
+the model parameters then the other parameters will be drawn by Stan's
 default initialization. The fit object must have at least some parameters
 that are the same name and dimensions as the current Stan model.
 }}

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -87,10 +87,13 @@ or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are o
 subset of the model parameters then the other parameters will be drawn by
 Stan's default initialization. The fit object must have at least some
 parameters that are the same name and dimensions as the current Stan model.
-For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
-than the requested number of chains/paths then the inits will be drawn using
-sampling with replacement. Otherwise sampling without replacement will be
-used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+For the \code{sample} and \code{pathfinder} methods, which need one initialization per
+chain or path, the inits are drawn from the fit object without replacement,
+so it must contain at least as many draws as the number of chains/paths. For
+\code{\link{CmdStanVB}}, \code{\link{CmdStanLaplace}}, and \code{\link{CmdStanPathfinder}} fit objects the
+draws must additionally be \emph{distinct}. A \code{\link{CmdStanMLE}} fit object is the
+exception: its single draw (the mode) is used to initialize every chain or
+path. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
 CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
 \code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
 the returned draws using uniform weights to avoid applying importance

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -89,12 +89,16 @@ For the \code{sample} and \code{pathfinder} method, if the fit object has fewer 
 than the requested number of chains/paths then the inits will be drawn using
 sampling with replacement. Otherwise sampling without replacement will be
 used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
-(default), then resampling without replacement with Pareto smoothed weights
-will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
-to \code{FALSE} then sampling without replacement with uniform weights will be
-used to select the draws. PSIS resampling is used to select the draws for
-\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
+\code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
+the returned draws using uniform weights to avoid applying importance
+weights again. If CmdStan did not PSIS-resample the output and
+\code{calculate_lp = TRUE}, CmdStanR selects draws using Pareto-smoothed
+importance weights. This includes single-path fits with
+\code{psis_resample = TRUE}, because CmdStan does not PSIS-resample single-path
+output. If \code{calculate_lp = FALSE}, uniform weights are used because
+importance weights cannot be calculated. PSIS resampling is used to select
+the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
 draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -65,21 +65,23 @@ following:
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
-\item A character vector of paths (one per chain) to JSON or Rdump files
-containing initial values for all or some parameters. See
-\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+\item A character vector of paths to JSON or Rdump files containing initial
+values for all or some parameters. A single path is used for all chains or
+Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
+See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
-MCMC the list should contain a sublist for each chain. For other model
-fitting methods there should be just one sublist. The sublists should have
-named elements corresponding to the parameters for which you are specifying
-initial values. See \strong{Examples}.
+MCMC the list should contain a sublist for each chain, and for Pathfinder it
+should contain a sublist for each path. For other model fitting methods
+there should be just one sublist. The sublists should have named elements
+corresponding to the parameters for which you are specifying initial
+values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the function
-has argument \code{chain_id} it will be supplied with the chain id (from 1 to
-number of chains) when called to generate the initial values. See
-\strong{Examples}.
+take no arguments or a single argument \code{chain_id}. For MCMC and Pathfinder,
+the function is called once for each chain or path. If the function has the
+\code{chain_id} argument, it receives the chain or path number, starting at 1.
+See \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
 or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
 subset of the model parameters then the other parameters will be drawn by

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -66,9 +66,9 @@ following:
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths to JSON or Rdump files containing initial
-values for all or some parameters. A single path is used for all chains or
-Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
-See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+values for all or some parameters. For MCMC and Pathfinder, if only a single
+file is provided it will be reused for all chains and paths. See
+\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
 MCMC the list should contain a sublist for each chain, and for Pathfinder it

--- a/man/model-method-optimize.Rd
+++ b/man/model-method-optimize.Rd
@@ -102,10 +102,11 @@ output. If \code{calculate_lp = FALSE}, uniform weights are used because
 importance weights cannot be calculated. PSIS resampling is used to select
 the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
-draws than the number of requested chains/paths then the inits will be
-drawn using sampling with replacement. Otherwise sampling without
-replacement will be used. If the draws object's parameters are only a subset
-of the model parameters then the other parameters will be drawn by Stan's
+draws than the number of requested chains/paths, the draws are reused in
+their existing order until each chain/path has an initialization. If there
+are more draws than requested chains/paths, draws are selected uniformly
+without replacement. If the draws object's parameters are only a subset of
+the model parameters then the other parameters will be drawn by Stan's
 default initialization. The fit object must have at least some parameters
 that are the same name and dimensions as the current Stan model.
 }}

--- a/man/model-method-pathfinder.Rd
+++ b/man/model-method-pathfinder.Rd
@@ -93,10 +93,13 @@ or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are o
 subset of the model parameters then the other parameters will be drawn by
 Stan's default initialization. The fit object must have at least some
 parameters that are the same name and dimensions as the current Stan model.
-For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
-than the requested number of chains/paths then the inits will be drawn using
-sampling with replacement. Otherwise sampling without replacement will be
-used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+For the \code{sample} and \code{pathfinder} methods, which need one initialization per
+chain or path, the inits are drawn from the fit object without replacement,
+so it must contain at least as many draws as the number of chains/paths. For
+\code{\link{CmdStanVB}}, \code{\link{CmdStanLaplace}}, and \code{\link{CmdStanPathfinder}} fit objects the
+draws must additionally be \emph{distinct}. A \code{\link{CmdStanMLE}} fit object is the
+exception: its single draw (the mode) is used to initialize every chain or
+path. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
 CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
 \code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
 the returned draws using uniform weights to avoid applying importance

--- a/man/model-method-pathfinder.Rd
+++ b/man/model-method-pathfinder.Rd
@@ -108,10 +108,11 @@ output. If \code{calculate_lp = FALSE}, uniform weights are used because
 importance weights cannot be calculated. PSIS resampling is used to select
 the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
-draws than the number of requested chains/paths then the inits will be
-drawn using sampling with replacement. Otherwise sampling without
-replacement will be used. If the draws object's parameters are only a subset
-of the model parameters then the other parameters will be drawn by Stan's
+draws than the number of requested chains/paths, the draws are reused in
+their existing order until each chain/path has an initialization. If there
+are more draws than requested chains/paths, draws are selected uniformly
+without replacement. If the draws object's parameters are only a subset of
+the model parameters then the other parameters will be drawn by Stan's
 default initialization. The fit object must have at least some parameters
 that are the same name and dimensions as the current Stan model.
 }}

--- a/man/model-method-pathfinder.Rd
+++ b/man/model-method-pathfinder.Rd
@@ -71,21 +71,23 @@ following:
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
-\item A character vector of paths (one per chain) to JSON or Rdump files
-containing initial values for all or some parameters. See
-\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+\item A character vector of paths to JSON or Rdump files containing initial
+values for all or some parameters. A single path is used for all chains or
+Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
+See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
-MCMC the list should contain a sublist for each chain. For other model
-fitting methods there should be just one sublist. The sublists should have
-named elements corresponding to the parameters for which you are specifying
-initial values. See \strong{Examples}.
+MCMC the list should contain a sublist for each chain, and for Pathfinder it
+should contain a sublist for each path. For other model fitting methods
+there should be just one sublist. The sublists should have named elements
+corresponding to the parameters for which you are specifying initial
+values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the function
-has argument \code{chain_id} it will be supplied with the chain id (from 1 to
-number of chains) when called to generate the initial values. See
-\strong{Examples}.
+take no arguments or a single argument \code{chain_id}. For MCMC and Pathfinder,
+the function is called once for each chain or path. If the function has the
+\code{chain_id} argument, it receives the chain or path number, starting at 1.
+See \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
 or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
 subset of the model parameters then the other parameters will be drawn by

--- a/man/model-method-pathfinder.Rd
+++ b/man/model-method-pathfinder.Rd
@@ -95,12 +95,16 @@ For the \code{sample} and \code{pathfinder} method, if the fit object has fewer 
 than the requested number of chains/paths then the inits will be drawn using
 sampling with replacement. Otherwise sampling without replacement will be
 used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
-(default), then resampling without replacement with Pareto smoothed weights
-will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
-to \code{FALSE} then sampling without replacement with uniform weights will be
-used to select the draws. PSIS resampling is used to select the draws for
-\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
+\code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
+the returned draws using uniform weights to avoid applying importance
+weights again. If CmdStan did not PSIS-resample the output and
+\code{calculate_lp = TRUE}, CmdStanR selects draws using Pareto-smoothed
+importance weights. This includes single-path fits with
+\code{psis_resample = TRUE}, because CmdStan does not PSIS-resample single-path
+output. If \code{calculate_lp = FALSE}, uniform weights are used because
+importance weights cannot be calculated. PSIS resampling is used to select
+the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
 draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without

--- a/man/model-method-pathfinder.Rd
+++ b/man/model-method-pathfinder.Rd
@@ -72,9 +72,9 @@ following:
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths to JSON or Rdump files containing initial
-values for all or some parameters. A single path is used for all chains or
-Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
-See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+values for all or some parameters. For MCMC and Pathfinder, if only a single
+file is provided it will be reused for all chains and paths. See
+\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
 MCMC the list should contain a sublist for each chain, and for Pathfinder it

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -75,21 +75,23 @@ following:
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
-\item A character vector of paths (one per chain) to JSON or Rdump files
-containing initial values for all or some parameters. See
-\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+\item A character vector of paths to JSON or Rdump files containing initial
+values for all or some parameters. A single path is used for all chains or
+Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
+See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
-MCMC the list should contain a sublist for each chain. For other model
-fitting methods there should be just one sublist. The sublists should have
-named elements corresponding to the parameters for which you are specifying
-initial values. See \strong{Examples}.
+MCMC the list should contain a sublist for each chain, and for Pathfinder it
+should contain a sublist for each path. For other model fitting methods
+there should be just one sublist. The sublists should have named elements
+corresponding to the parameters for which you are specifying initial
+values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the function
-has argument \code{chain_id} it will be supplied with the chain id (from 1 to
-number of chains) when called to generate the initial values. See
-\strong{Examples}.
+take no arguments or a single argument \code{chain_id}. For MCMC and Pathfinder,
+the function is called once for each chain or path. If the function has the
+\code{chain_id} argument, it receives the chain or path number, starting at 1.
+See \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
 or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
 subset of the model parameters then the other parameters will be drawn by

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -112,10 +112,11 @@ output. If \code{calculate_lp = FALSE}, uniform weights are used because
 importance weights cannot be calculated. PSIS resampling is used to select
 the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
-draws than the number of requested chains/paths then the inits will be
-drawn using sampling with replacement. Otherwise sampling without
-replacement will be used. If the draws object's parameters are only a subset
-of the model parameters then the other parameters will be drawn by Stan's
+draws than the number of requested chains/paths, the draws are reused in
+their existing order until each chain/path has an initialization. If there
+are more draws than requested chains/paths, draws are selected uniformly
+without replacement. If the draws object's parameters are only a subset of
+the model parameters then the other parameters will be drawn by Stan's
 default initialization. The fit object must have at least some parameters
 that are the same name and dimensions as the current Stan model.
 }}

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -99,12 +99,16 @@ For the \code{sample} and \code{pathfinder} method, if the fit object has fewer 
 than the requested number of chains/paths then the inits will be drawn using
 sampling with replacement. Otherwise sampling without replacement will be
 used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
-(default), then resampling without replacement with Pareto smoothed weights
-will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
-to \code{FALSE} then sampling without replacement with uniform weights will be
-used to select the draws. PSIS resampling is used to select the draws for
-\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
+\code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
+the returned draws using uniform weights to avoid applying importance
+weights again. If CmdStan did not PSIS-resample the output and
+\code{calculate_lp = TRUE}, CmdStanR selects draws using Pareto-smoothed
+importance weights. This includes single-path fits with
+\code{psis_resample = TRUE}, because CmdStan does not PSIS-resample single-path
+output. If \code{calculate_lp = FALSE}, uniform weights are used because
+importance weights cannot be calculated. PSIS resampling is used to select
+the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
 draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -97,10 +97,13 @@ or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are o
 subset of the model parameters then the other parameters will be drawn by
 Stan's default initialization. The fit object must have at least some
 parameters that are the same name and dimensions as the current Stan model.
-For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
-than the requested number of chains/paths then the inits will be drawn using
-sampling with replacement. Otherwise sampling without replacement will be
-used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+For the \code{sample} and \code{pathfinder} methods, which need one initialization per
+chain or path, the inits are drawn from the fit object without replacement,
+so it must contain at least as many draws as the number of chains/paths. For
+\code{\link{CmdStanVB}}, \code{\link{CmdStanLaplace}}, and \code{\link{CmdStanPathfinder}} fit objects the
+draws must additionally be \emph{distinct}. A \code{\link{CmdStanMLE}} fit object is the
+exception: its single draw (the mode) is used to initialize every chain or
+path. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
 CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
 \code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
 the returned draws using uniform weights to avoid applying importance

--- a/man/model-method-sample.Rd
+++ b/man/model-method-sample.Rd
@@ -76,9 +76,9 @@ following:
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths to JSON or Rdump files containing initial
-values for all or some parameters. A single path is used for all chains or
-Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
-See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+values for all or some parameters. For MCMC and Pathfinder, if only a single
+file is provided it will be reused for all chains and paths. See
+\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
 MCMC the list should contain a sublist for each chain, and for Pathfinder it

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -82,9 +82,9 @@ following:
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths to JSON or Rdump files containing initial
-values for all or some parameters. A single path is used for all chains or
-Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
-See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+values for all or some parameters. For MCMC and Pathfinder, if only a single
+file is provided it will be reused for all chains and paths. See
+\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
 MCMC the list should contain a sublist for each chain, and for Pathfinder it

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -118,10 +118,11 @@ output. If \code{calculate_lp = FALSE}, uniform weights are used because
 importance weights cannot be calculated. PSIS resampling is used to select
 the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
-draws than the number of requested chains/paths then the inits will be
-drawn using sampling with replacement. Otherwise sampling without
-replacement will be used. If the draws object's parameters are only a subset
-of the model parameters then the other parameters will be drawn by Stan's
+draws than the number of requested chains/paths, the draws are reused in
+their existing order until each chain/path has an initialization. If there
+are more draws than requested chains/paths, draws are selected uniformly
+without replacement. If the draws object's parameters are only a subset of
+the model parameters then the other parameters will be drawn by Stan's
 default initialization. The fit object must have at least some parameters
 that are the same name and dimensions as the current Stan model.
 }}

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -81,21 +81,23 @@ following:
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
-\item A character vector of paths (one per chain) to JSON or Rdump files
-containing initial values for all or some parameters. See
-\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+\item A character vector of paths to JSON or Rdump files containing initial
+values for all or some parameters. A single path is used for all chains or
+Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
+See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
-MCMC the list should contain a sublist for each chain. For other model
-fitting methods there should be just one sublist. The sublists should have
-named elements corresponding to the parameters for which you are specifying
-initial values. See \strong{Examples}.
+MCMC the list should contain a sublist for each chain, and for Pathfinder it
+should contain a sublist for each path. For other model fitting methods
+there should be just one sublist. The sublists should have named elements
+corresponding to the parameters for which you are specifying initial
+values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the function
-has argument \code{chain_id} it will be supplied with the chain id (from 1 to
-number of chains) when called to generate the initial values. See
-\strong{Examples}.
+take no arguments or a single argument \code{chain_id}. For MCMC and Pathfinder,
+the function is called once for each chain or path. If the function has the
+\code{chain_id} argument, it receives the chain or path number, starting at 1.
+See \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
 or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
 subset of the model parameters then the other parameters will be drawn by

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -105,12 +105,16 @@ For the \code{sample} and \code{pathfinder} method, if the fit object has fewer 
 than the requested number of chains/paths then the inits will be drawn using
 sampling with replacement. Otherwise sampling without replacement will be
 used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
-(default), then resampling without replacement with Pareto smoothed weights
-will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
-to \code{FALSE} then sampling without replacement with uniform weights will be
-used to select the draws. PSIS resampling is used to select the draws for
-\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
+\code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
+the returned draws using uniform weights to avoid applying importance
+weights again. If CmdStan did not PSIS-resample the output and
+\code{calculate_lp = TRUE}, CmdStanR selects draws using Pareto-smoothed
+importance weights. This includes single-path fits with
+\code{psis_resample = TRUE}, because CmdStan does not PSIS-resample single-path
+output. If \code{calculate_lp = FALSE}, uniform weights are used because
+importance weights cannot be calculated. PSIS resampling is used to select
+the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
 draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -103,10 +103,13 @@ or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are o
 subset of the model parameters then the other parameters will be drawn by
 Stan's default initialization. The fit object must have at least some
 parameters that are the same name and dimensions as the current Stan model.
-For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
-than the requested number of chains/paths then the inits will be drawn using
-sampling with replacement. Otherwise sampling without replacement will be
-used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+For the \code{sample} and \code{pathfinder} methods, which need one initialization per
+chain or path, the inits are drawn from the fit object without replacement,
+so it must contain at least as many draws as the number of chains/paths. For
+\code{\link{CmdStanVB}}, \code{\link{CmdStanLaplace}}, and \code{\link{CmdStanPathfinder}} fit objects the
+draws must additionally be \emph{distinct}. A \code{\link{CmdStanMLE}} fit object is the
+exception: its single draw (the mode) is used to initialize every chain or
+path. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
 CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
 \code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
 the returned draws using uniform weights to avoid applying importance

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -87,10 +87,13 @@ or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are o
 subset of the model parameters then the other parameters will be drawn by
 Stan's default initialization. The fit object must have at least some
 parameters that are the same name and dimensions as the current Stan model.
-For the \code{sample} and \code{pathfinder} method, if the fit object has fewer draws
-than the requested number of chains/paths then the inits will be drawn using
-sampling with replacement. Otherwise sampling without replacement will be
-used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
+For the \code{sample} and \code{pathfinder} methods, which need one initialization per
+chain or path, the inits are drawn from the fit object without replacement,
+so it must contain at least as many draws as the number of chains/paths. For
+\code{\link{CmdStanVB}}, \code{\link{CmdStanLaplace}}, and \code{\link{CmdStanPathfinder}} fit objects the
+draws must additionally be \emph{distinct}. A \code{\link{CmdStanMLE}} fit object is the
+exception: its single draw (the mode) is used to initialize every chain or
+path. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
 CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
 \code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
 the returned draws using uniform weights to avoid applying importance

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -89,12 +89,16 @@ For the \code{sample} and \code{pathfinder} method, if the fit object has fewer 
 than the requested number of chains/paths then the inits will be drawn using
 sampling with replacement. Otherwise sampling without replacement will be
 used. When a \code{\link{CmdStanPathfinder}} fit object is used as the init, if
-\code{psis_resample} was set to \code{FALSE} and \code{calculate_lp} was set to \code{TRUE}
-(default), then resampling without replacement with Pareto smoothed weights
-will be used. If \code{psis_resample} was set to \code{TRUE} or \code{calculate_lp} was set
-to \code{FALSE} then sampling without replacement with uniform weights will be
-used to select the draws. PSIS resampling is used to select the draws for
-\code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
+CmdStan actually performed PSIS resampling (which requires \code{num_paths > 1},
+\code{psis_resample = TRUE}, and \code{calculate_lp = TRUE}), CmdStanR selects from
+the returned draws using uniform weights to avoid applying importance
+weights again. If CmdStan did not PSIS-resample the output and
+\code{calculate_lp = TRUE}, CmdStanR selects draws using Pareto-smoothed
+importance weights. This includes single-path fits with
+\code{psis_resample = TRUE}, because CmdStan does not PSIS-resample single-path
+output. If \code{calculate_lp = FALSE}, uniform weights are used because
+importance weights cannot be calculated. PSIS resampling is used to select
+the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
 draws than the number of requested chains/paths then the inits will be
 drawn using sampling with replacement. Otherwise sampling without

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -65,21 +65,23 @@ following:
 \item A real number \code{x>0}. This initializes \emph{all} parameters randomly between
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
-\item A character vector of paths (one per chain) to JSON or Rdump files
-containing initial values for all or some parameters. See
-\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+\item A character vector of paths to JSON or Rdump files containing initial
+values for all or some parameters. A single path is used for all chains or
+Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
+See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
-MCMC the list should contain a sublist for each chain. For other model
-fitting methods there should be just one sublist. The sublists should have
-named elements corresponding to the parameters for which you are specifying
-initial values. See \strong{Examples}.
+MCMC the list should contain a sublist for each chain, and for Pathfinder it
+should contain a sublist for each path. For other model fitting methods
+there should be just one sublist. The sublists should have named elements
+corresponding to the parameters for which you are specifying initial
+values. See \strong{Examples}.
 \item A function that returns a single list with names corresponding to the
 parameters for which you are specifying initial values. The function can
-take no arguments or a single argument \code{chain_id}. For MCMC, if the function
-has argument \code{chain_id} it will be supplied with the chain id (from 1 to
-number of chains) when called to generate the initial values. See
-\strong{Examples}.
+take no arguments or a single argument \code{chain_id}. For MCMC and Pathfinder,
+the function is called once for each chain or path. If the function has the
+\code{chain_id} argument, it receives the chain or path number, starting at 1.
+See \strong{Examples}.
 \item A \code{\link{CmdStanMCMC}}, \code{\link{CmdStanMLE}}, \code{\link{CmdStanVB}}, \code{\link{CmdStanPathfinder}},
 or \code{\link{CmdStanLaplace}} fit object. If the fit object's parameters are only a
 subset of the model parameters then the other parameters will be drawn by

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -66,9 +66,9 @@ following:
 \verb{[-x,x]} on the \emph{unconstrained} parameter space.
 \item The number \code{0}. This initializes \emph{all} parameters to \code{0}.
 \item A character vector of paths to JSON or Rdump files containing initial
-values for all or some parameters. A single path is used for all chains or
-Pathfinder paths. Otherwise, supply one path per chain or Pathfinder path.
-See \code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
+values for all or some parameters. For MCMC and Pathfinder, if only a single
+file is provided it will be reused for all chains and paths. See
+\code{\link[=write_stan_json]{write_stan_json()}} to write \R objects to JSON files compatible with
 CmdStan.
 \item A list of lists containing initial values for all or some parameters. For
 MCMC the list should contain a sublist for each chain, and for Pathfinder it

--- a/man/model-method-variational.Rd
+++ b/man/model-method-variational.Rd
@@ -102,10 +102,11 @@ output. If \code{calculate_lp = FALSE}, uniform weights are used because
 importance weights cannot be calculated. PSIS resampling is used to select
 the draws for \code{\link{CmdStanVB}}, and \code{\link{CmdStanLaplace}} fit objects.
 \item A type inheriting from \code{posterior::draws}. If the draws object has fewer
-draws than the number of requested chains/paths then the inits will be
-drawn using sampling with replacement. Otherwise sampling without
-replacement will be used. If the draws object's parameters are only a subset
-of the model parameters then the other parameters will be drawn by Stan's
+draws than the number of requested chains/paths, the draws are reused in
+their existing order until each chain/path has an initialization. If there
+are more draws than requested chains/paths, draws are selected uniformly
+without replacement. If the draws object's parameters are only a subset of
+the model parameters then the other parameters will be drawn by Stan's
 default initialization. The fit object must have at least some parameters
 that are the same name and dimensions as the current Stan model.
 }}

--- a/tests/testthat/test-fit-init.R
+++ b/tests/testthat/test-fit-init.R
@@ -147,9 +147,9 @@ test_that("Pathfinder fit initializations use the intended weights", {
   expect_equal(pareto_smooth_calls, 2L)
 })
 
-test_that("Pathfinder init weighting preserves distinct-draw safeguards", {
-  # These draws contain only two different importance weights, as can happen
-  # when CmdStan's PSIS resampling returns duplicate draws.
+test_that("Pathfinder init weighting preserves unique-log-weight safeguard", {
+  # The existing safeguard treats these two log weights as a proxy for two
+  # distinct parameter vectors.
   draws <- posterior::as_draws_df(data.frame(
     theta = c(1, 1, 2, 2),
     lp__ = c(1, 1, 2, 2),
@@ -186,8 +186,8 @@ test_that("Pathfinder init weighting preserves distinct-draw safeguards", {
 
   expect_equal(unique(weights_seen), 1)
   expect_equal(method_seen, "simple_no_replace")
-  # There are only two distinct draws, so asking for three initial values should
-  # produce the existing error and suggest disabling PSIS resampling.
+  # The existing proxy finds only two distinct log weights, so requesting three
+  # initial values produces the existing error and Pathfinder guidance.
   error_message <- tryCatch(
     process_init.CmdStanPathfinder(pathfinder_fit, 3),
     error = function(cnd) conditionMessage(cnd)

--- a/tests/testthat/test-fit-init.R
+++ b/tests/testthat/test-fit-init.R
@@ -95,6 +95,112 @@ test_that("Multi Pathfinder method with calculate_lp as false works as init", {
   expect_no_error(test_inits(mod_logistic, fit_path_init, data_list_logistic))
 })
 
+test_that("Pathfinder fit initializations use the intended weights", {
+  # These draws have four different importance weights, so this test can focus
+  # on whether uniform or Pareto-smoothed weights are used.
+  draws <- posterior::as_draws_df(data.frame(
+    theta = 1:4,
+    lp__ = c(1, 2, 4, 8),
+    lp_approx__ = 0
+  ))
+  # This fake Pathfinder fit supplies draws and metadata without running CmdStan.
+  pathfinder_fit <- function(num_paths, psis_resample, calculate_lp) {
+    structure(
+      list(
+        draws = function(format) draws,
+        metadata = function() list(
+          num_paths = num_paths,
+          psis_resample = psis_resample,
+          calculate_lp = calculate_lp
+        ),
+        return_codes = function() 0
+      ),
+      class = "CmdStanPathfinder"
+    )
+  }
+
+  weights_seen <- list()
+  pareto_smooth_calls <- 0L
+  # Return known Pareto-smoothed weights and record which weights are used to
+  # select the initialization draws.
+  local_mocked_bindings(
+    pareto_smooth = function(x, ...) {
+      pareto_smooth_calls <<- pareto_smooth_calls + 1L
+      seq_along(x)
+    },
+    resample_draws = function(x, ndraws, weights = NULL, ...) {
+      weights_seen[[length(weights_seen) + 1L]] <<- weights
+      x[seq_len(ndraws), , drop = FALSE]
+    },
+    .package = "posterior"
+  )
+  local_mocked_bindings(process_init = function(init, ...) init)
+
+  # Test, in order: output resampled by CmdStan, output not resampled, a
+  # single-path fit, and a fit without calculated log densities.
+  process_init.CmdStanPathfinder(pathfinder_fit(4, TRUE, TRUE), 2)
+  process_init.CmdStanPathfinder(pathfinder_fit(4, FALSE, TRUE), 2)
+  process_init.CmdStanPathfinder(pathfinder_fit(1, TRUE, TRUE), 2)
+  process_init.CmdStanPathfinder(pathfinder_fit(4, TRUE, FALSE), 2)
+
+  expect_equal(weights_seen, list(rep(1, 4), 1:4, 1:4, rep(1, 4)))
+  expect_equal(pareto_smooth_calls, 2L)
+})
+
+test_that("Pathfinder init weighting preserves distinct-draw safeguards", {
+  # These draws contain only two different importance weights, as can happen
+  # when CmdStan's PSIS resampling returns duplicate draws.
+  draws <- posterior::as_draws_df(data.frame(
+    theta = c(1, 1, 2, 2),
+    lp__ = c(1, 1, 2, 2),
+    lp_approx__ = 0
+  ))
+  pathfinder_fit <- structure(
+    list(
+      draws = function(format) draws,
+      metadata = function() list(
+        num_paths = 4,
+        psis_resample = TRUE,
+        calculate_lp = TRUE
+      ),
+      return_codes = function() 0
+    ),
+    class = "CmdStanPathfinder"
+  )
+
+  weights_seen <- NULL
+  method_seen <- NULL
+  # Fail if Pareto smoothing is called, and record how draws are selected.
+  local_mocked_bindings(
+    pareto_smooth = function(...) stop("Pareto smoothing should not be used"),
+    resample_draws = function(x, ndraws, weights = NULL, method, ...) {
+      weights_seen <<- weights
+      method_seen <<- method
+      x[seq_len(ndraws), , drop = FALSE]
+    },
+    .package = "posterior"
+  )
+  local_mocked_bindings(process_init = function(init, ...) init)
+
+  process_init.CmdStanPathfinder(pathfinder_fit, 2)
+
+  expect_equal(unique(weights_seen), 1)
+  expect_equal(method_seen, "simple_no_replace")
+  # There are only two distinct draws, so asking for three initial values should
+  # produce the existing error and suggest disabling PSIS resampling.
+  error_message <- tryCatch(
+    process_init.CmdStanPathfinder(pathfinder_fit, 3),
+    error = function(cnd) conditionMessage(cnd)
+  )
+  expect_equal(
+    error_message,
+    paste0(
+      "Not enough distinct draws (3) in Pathfinder fit to create inits.",
+      " Try running Pathfinder with psis_resample=FALSE."
+    )
+  )
+})
+
 test_that("Variational method works as init", {
   mod_logistic <- testing_model("logistic")
   utils::capture.output(fit_vb_init <- mod_logistic$variational(

--- a/tests/testthat/test-fit-init.R
+++ b/tests/testthat/test-fit-init.R
@@ -201,6 +201,27 @@ test_that("Pathfinder init weighting preserves distinct-draw safeguards", {
   )
 })
 
+test_that("draws inits are recycled in order when too few are supplied", {
+  draws <- posterior::as_draws_df(data.frame(theta = c(10, 20)))
+  model_variables <- list(
+    parameters = list(theta = list(dimensions = 0L))
+  )
+  # Return the prepared init lists instead of writing them to JSON files so the
+  # test can inspect which draw is assigned to each chain or path.
+  local_mocked_bindings(process_init = function(init, ...) init)
+
+  inits <- process_init.draws(
+    draws,
+    num_procs = 5,
+    model_variables = model_variables
+  )
+
+  expect_equal(
+    vapply(inits, `[[`, numeric(1), "theta"),
+    c(10, 20, 10, 20, 10)
+  )
+})
+
 test_that("Variational method works as init", {
   mod_logistic <- testing_model("logistic")
   utils::capture.output(fit_vb_init <- mod_logistic$variational(

--- a/tests/testthat/test-model-init.R
+++ b/tests/testthat/test-model-init.R
@@ -47,7 +47,7 @@ test_that("sample method works with valid numeric init values", {
   )
 })
 
-test_that("sample method throws error for invalid init argument", {
+test_that("fitting methods throw errors for invalid init arguments", {
   expect_error(
     mod$sample(data = data_list, chains = 2, init = -10, seed = 123),
     "If 'init' is numeric it must be a single real number >= 0",
@@ -72,7 +72,16 @@ test_that("sample method throws error for invalid init argument", {
 
   expect_error(
     mod$sample(data = data_list, chains = 3, init = c(init_json_1, init_json_2)),
-    "length 1 or number of chains"
+    "number of chains or Pathfinder paths"
+  )
+
+  expect_error(
+    mod$pathfinder(
+      data = data_list,
+      num_paths = 3,
+      init = c(init_json_1, init_json_2)
+    ),
+    "number of chains or Pathfinder paths"
   )
 })
 

--- a/tests/testthat/test-model-pathfinder.R
+++ b/tests/testthat/test-model-pathfinder.R
@@ -130,9 +130,21 @@ test_that("pathfinder() method works with init file", {
   expect_pathfinder_output(mod$pathfinder(data = data_file_r, init = init_file))
 })
 
-test_that("pathfinder() method works with init function and default paths", {
-  init_function <- function() { list(theta = 0.5) }
-  expect_pathfinder_output(mod$pathfinder(data = data_file_r, init = init_function))
+test_that("pathfinder() method passes one init to each path", {
+  init_function <- function(chain_id) {
+    list(theta = chain_id / 5)
+  }
+  expect_pathfinder_output(
+    fit <- mod$pathfinder(
+      data = data_file_r,
+      init = init_function,
+      refresh = 0,
+      seed = 123
+    )
+  )
+
+  # The function returns a different value for each of the four default paths.
+  expect_equal(vapply(fit$init(), `[[`, numeric(1), "theta"), (1:4) / 5)
 })
 
 test_that("pathfinder() method runs when all arguments specified", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -154,6 +154,39 @@ test_that("repair_path works with multiple paths", {
   expect_equal(repair_path(c("a//b\\c/", "d\\e//f")), c("a/b/c", "d/e/f"))
 })
 
+test_that("wsl_safe_path() works with multiple paths", {
+  with_mocked_bindings(
+    {
+      expect_equal(
+        wsl_safe_path(
+          c(
+            "/mnt/c/project/init-1.json",
+            "/mnt/d/project/init-2.json",
+            "relative/init-3.json"
+          ),
+          revert = TRUE
+        ),
+        c(
+          "C:/project/init-1.json",
+          "D:/project/init-2.json",
+          "relative/init-3.json"
+        )
+      )
+      expect_equal(
+        wsl_safe_path(
+          c(
+            "//wsl$/Ubuntu/tmp/init-1.json",
+            "//wsl$/Ubuntu/tmp/init-2.json"
+          )
+        ),
+        c("/tmp/init-1.json", "/tmp/init-2.json")
+      )
+    },
+    os_is_wsl = function() TRUE,
+    wsl_dir_prefix = function(...) "//wsl$/Ubuntu"
+  )
+})
+
 test_that("list_to_array works with empty list", {
   expect_equal(list_to_array(list()), NULL)
 })


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

There were a few mistakes in the original code that was added to do initialization using pathfinder. This PR fixes them and makes a few other doc edits.  

  - Pass separately supplied initialization values to every Pathfinder path and preserve the per-path files in fit metadata.
  - Avoid applying importance weights twice when CmdStan has already PSIS-resampled Pathfinder draws.
  - Use uniform weights when log densities are unavailable.
  - Document that insufficient `posterior::draws` initializations are recycled deterministically rather than sampled with
  replacement.
  - Clarify initialization-length errors for Pathfinder paths.

This PR was AI assisted in the following ways: 
  - Some of the summary above was generated by Codex
  -  Claude and Codex both helped write the tests for this PR. I checked all the test code and understand it. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
