### PR TITLE
recognize thread and OpenCL support regardless of the capitalization

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # cmdstanr (development version)
 
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
+* CmdStanModel methods now recognize thread and OpenCL support in precompiled executables regardless of the capitalization of C++ option names. (#765, #1100)
 * Pathfinder fits used as initial values now use uniform weights when CmdStan already PSIS-resampled their draws, avoiding a second application of importance weights. (#1206)
 * Pathfinder fits used as initial values now correctly treat draws with different initialization parameter values as distinct even when their log weights are equal, and collapse duplicate resampled draws while retaining their selection frequency. (#1207)
 * `pathfinder()` now passes separately supplied initial values to every path instead of using only the first path's initial values. (#1206)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,15 +1,24 @@
 # cmdstanr (development version)
 
-* The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
-* CmdStanModel methods now recognize thread and OpenCL support in precompiled executables regardless of the capitalization of C++ option names. Precompiled models detected as threaded now require the corresponding `threads` or `threads_per_chain` argument, matching existing behavior for models compiled through CmdStanR. (#765, #1100)
-* Pathfinder fits used as initial values now use uniform weights when CmdStan already PSIS-resampled their draws, avoiding a second application of importance weights. (#1206)
-* Pathfinder fits used as initial values now correctly treat draws with different initialization parameter values as distinct even when their log weights are equal, and collapse duplicate resampled draws while retaining their selection frequency. (#1207)
-* `pathfinder()` now passes separately supplied initial values to every path instead of using only the first path's initial values. (#1206)
+* The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated 
+as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
+* CmdStanModel methods now use executable metadata regardless of the 
+capitalization of C++ option names. Any executable reporting threading enabled 
+requires the corresponding `threads` or `threads_per_chain` argument. (#765, #1100)
+* Pathfinder fits used as initial values now use uniform weights when CmdStan 
+already PSIS-resampled their draws, avoiding a second application of importance weights. (#1206)
+* Pathfinder fits used as initial values now correctly treat draws with different 
+initialization parameter values as distinct even when their log weights are equal, 
+and collapse duplicate resampled draws while retaining their selection frequency. (#1207)
+* `pathfinder()` now passes separately supplied initial values to every path 
+instead of using only the first path's initial values. (#1206)
 * `pathfinder()` now respects `save_single_paths = TRUE` instead of always
 passing `0` to CmdStan.
 * `pathfinder()` now uses `threads` argument (`num_threads` is deprecated),
 to be consistent with other methods.
-* The `save_latent_dynamics` argument is now limited to `$sample()`, `$sample_mpi()`, and `$variational()`, matching the CmdStan algorithms that support diagnostic CSV output.
+* The `save_latent_dynamics` argument is now limited to `$sample()`, 
+`$sample_mpi()`, and `$variational()`, matching the CmdStan algorithms 
+that support diagnostic CSV output.
 * Informative error when exposing functions using names that are reserved 
 keywords (@VisruthSK, #1154)
 * `save_cmdstan_config` and `save_metric` default to `FALSE` but can be 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # cmdstanr (development version)
 
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
-* CmdStanModel methods now recognize thread and OpenCL support in precompiled executables regardless of the capitalization of C++ option names. (#765, #1100)
+* CmdStanModel methods now recognize thread and OpenCL support in precompiled executables regardless of the capitalization of C++ option names. Precompiled models detected as threaded now require the corresponding `threads` or `threads_per_chain` argument, matching existing behavior for models compiled through CmdStanR. (#765, #1100)
 * Pathfinder fits used as initial values now use uniform weights when CmdStan already PSIS-resampled their draws, avoiding a second application of importance weights. (#1206)
 * Pathfinder fits used as initial values now correctly treat draws with different initialization parameter values as distinct even when their log weights are equal, and collapse duplicate resampled draws while retaining their selection frequency. (#1207)
 * `pathfinder()` now passes separately supplied initial values to every path instead of using only the first path's initial values. (#1206)

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -132,7 +132,8 @@ validate_cpp_options <- function(cpp_options) {
 # check specific options for validity ---------------------------------
 cpp_option_value <- function(cpp_options, option) {
   # CmdStanR input and executable metadata can use different casing. Prefer
-  # the last match because later executable metadata best describes the binary.
+  # the final match, even when it is NULL, because later executable metadata
+  # best describes the binary.
   matches <- which(tolower(names(cpp_options)) == tolower(option))
   if (length(matches) == 0) {
     return(NULL)
@@ -171,8 +172,8 @@ assert_valid_threads <- function(threads, cpp_options, multiple_chains = FALSE) 
     }
   } else if (isTRUE(stan_threads) && is.null(threads)) {
     stop(
-      "The model was compiled with 'cpp_options = list(stan_threads = TRUE)' ",
-      "but '", threads_arg, "' was not set!",
+      "The model executable was built with threading enabled but '",
+      threads_arg, "' was not set!",
       call. = FALSE
     )
   }

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -130,12 +130,21 @@ validate_cpp_options <- function(cpp_options) {
 }
 
 # check specific options for validity ---------------------------------
+cpp_option_value <- function(cpp_options, option) {
+  # CmdStanR input and executable metadata can use different casing. Prefer
+  # the last match because later executable metadata best describes the binary.
+  matches <- which(tolower(names(cpp_options)) == tolower(option))
+  if (length(matches) == 0) {
+    return(NULL)
+  }
+  cpp_options[[matches[[length(matches)]]]]
+}
+
 # no type checking for opencl_ids
 # cpp_options must be a list
 # opencl_ids returned unchanged
 assert_valid_opencl <- function(opencl_ids, cpp_options) {
-  names(cpp_options) <- tolower(names(cpp_options))
-  if (is.null(cpp_options[["stan_opencl"]])
+  if (is.null(cpp_option_value(cpp_options, "stan_opencl"))
       && !is.null(opencl_ids)) {
     stop("'opencl_ids' is set but the model was not compiled for use with OpenCL.",
          "\nRecompile the model with 'cpp_options = list(stan_opencl = TRUE)'",
@@ -146,11 +155,11 @@ assert_valid_opencl <- function(opencl_ids, cpp_options) {
 
 # cpp_options must be a list
 assert_valid_threads <- function(threads, cpp_options, multiple_chains = FALSE) {
-  names(cpp_options) <- tolower(names(cpp_options))
   threads_arg <- if (multiple_chains) "threads_per_chain" else "threads"
   checkmate::assert_integerish(threads, .var.name = threads_arg,
                                null.ok = TRUE, lower = 1, len = 1)
-  if (is.null(cpp_options[["stan_threads"]]) || !isTRUE(cpp_options[["stan_threads"]])) {
+  stan_threads <- cpp_option_value(cpp_options, "stan_threads")
+  if (is.null(stan_threads) || !isTRUE(stan_threads)) {
     if (!is.null(threads)) {
       warning(
         "'", threads_arg, "' is set but the model was not compiled with ",
@@ -160,7 +169,7 @@ assert_valid_threads <- function(threads, cpp_options, multiple_chains = FALSE) 
       )
       threads <- NULL
     }
-  } else if (isTRUE(cpp_options[["stan_threads"]]) && is.null(threads)) {
+  } else if (isTRUE(stan_threads) && is.null(threads)) {
     stop(
       "The model was compiled with 'cpp_options = list(stan_threads = TRUE)' ",
       "but '", threads_arg, "' was not set!",

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -134,6 +134,7 @@ validate_cpp_options <- function(cpp_options) {
 # cpp_options must be a list
 # opencl_ids returned unchanged
 assert_valid_opencl <- function(opencl_ids, cpp_options) {
+  names(cpp_options) <- tolower(names(cpp_options))
   if (is.null(cpp_options[["stan_opencl"]])
       && !is.null(opencl_ids)) {
     stop("'opencl_ids' is set but the model was not compiled for use with OpenCL.",
@@ -145,6 +146,7 @@ assert_valid_opencl <- function(opencl_ids, cpp_options) {
 
 # cpp_options must be a list
 assert_valid_threads <- function(threads, cpp_options, multiple_chains = FALSE) {
+  names(cpp_options) <- tolower(names(cpp_options))
   threads_arg <- if (multiple_chains) "threads_per_chain" else "threads"
   checkmate::assert_integerish(threads, .var.name = threads_arg,
                                null.ok = TRUE, lower = 1, len = 1)

--- a/R/model.R
+++ b/R/model.R
@@ -603,7 +603,7 @@ compile <- function(quiet = TRUE,
     stanc_options[["warn-pedantic"]] <- TRUE
   }
 
-  if (isTRUE(cpp_options$stan_opencl)) {
+  if (isTRUE(cpp_option_value(cpp_options, "stan_opencl"))) {
     stanc_options[["use-opencl"]] <- TRUE
   }
 

--- a/R/model.R
+++ b/R/model.R
@@ -484,7 +484,7 @@ NULL
 #' @param user_header (string) The path to a C++ file (with a .hpp extension)
 #'   to compile with the Stan model.
 #' @param cpp_options (list) Any makefile options to be used when compiling the
-#'   model (`STAN_THREADS`, `STAN_MPI`, `STAN_OPENCL`, etc.). Anything you would
+#'   model (`stan_threads`, `stan_mpi`, `stan_opencl`, etc.). Anything you would
 #'   otherwise write in the `make/local` file. For an example of using threading
 #'   see the Stan case study
 #'   [Reduce Sum: A Minimal Example](https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html).
@@ -1312,12 +1312,12 @@ CmdStanModel$set("public", name = "sample", value = sample)
 #'
 #'   An example of compiling with MPI:
 #'   ```
-#'   mpi_options = list(STAN_MPI=TRUE, CXX="mpicxx", TBB_CXX_TYPE="gcc")
+#'   mpi_options = list(stan_mpi = TRUE, CXX = "mpicxx", TBB_CXX_TYPE = "gcc")
 #'   mod = cmdstan_model("model.stan", cpp_options = mpi_options)
 #'   ```
 #'   The C++ options that must be supplied to the
 #'   [compile][model-method-compile] call are:
-#'   - `STAN_MPI`: Enables the use of MPI with Stan if `TRUE`.
+#'   - `stan_mpi`: Enables the use of MPI with Stan if `TRUE`.
 #'   - `CXX`: The name of the MPI C++ compiler wrapper. Typically `"mpicxx"`.
 #'   - `TBB_CXX_TYPE`: The C++ compiler the MPI wrapper wraps. Typically `"gcc"`
 #'   on Linux and `"clang"` on macOS.
@@ -1357,7 +1357,7 @@ CmdStanModel$set("public", name = "sample", value = sample)
 #'
 #' @examples
 #' \dontrun{
-#' # mpi_options <- list(STAN_MPI=TRUE, CXX="mpicxx", TBB_CXX_TYPE="gcc")
+#' # mpi_options <- list(stan_mpi = TRUE, CXX = "mpicxx", TBB_CXX_TYPE = "gcc")
 #' # mod <- cmdstan_model("model.stan", cpp_options = mpi_options)
 #' # fit <- mod$sample_mpi(..., mpi_args = list("n" = 4))
 #' }

--- a/R/model.R
+++ b/R/model.R
@@ -486,8 +486,13 @@ NULL
 #' @param cpp_options (list) Any makefile options to be used when compiling the
 #'   model (`stan_threads`, `stan_mpi`, `stan_opencl`, etc.). Anything you would
 #'   otherwise write in the `make/local` file. For an example of using threading
-#'   see the Stan case study
-#'   [Reduce Sum: A Minimal Example](https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html).
+#'   see the Stan case study [Reduce Sum: A Minimal
+#'   Example](https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html).
+#'   **Note:** For historical reasons, CmdStan treats some options as enabled
+#'   whenever their `Make` variable is non-empty. In particular, setting
+#'   `stan_threads` to `FALSE` passes `STAN_THREADS=FALSE` to `Make`, which
+#'   still enables threading! To leave threading disabled, simply omit
+#'   `stan_threads` entirely or set it to `NULL`.
 #' @param stanc_options (list) Any Stan-to-C++ transpiler options to be used
 #'   when compiling the model. See the **Examples** section below as well as the
 #'   [`stanc` chapter of the CmdStan User's

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -45,8 +45,12 @@ to compile with the Stan model.}
 \item{cpp_options}{(list) Any makefile options to be used when compiling the
 model (\code{stan_threads}, \code{stan_mpi}, \code{stan_opencl}, etc.). Anything you would
 otherwise write in the \code{make/local} file. For an example of using threading
-see the Stan case study
-\href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.}
+see the Stan case study \href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.
+\strong{Note:} For historical reasons, CmdStan treats some options as enabled
+whenever their \code{Make} variable is non-empty. In particular, setting
+\code{stan_threads} to \code{FALSE} passes \code{STAN_THREADS=FALSE} to \code{Make}, which
+still enables threading! To leave threading disabled, simply omit
+\code{stan_threads} entirely or set it to \code{NULL}.}
 
 \item{stanc_options}{(list) Any Stan-to-C++ transpiler options to be used
 when compiling the model. See the \strong{Examples} section below as well as the

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -43,7 +43,7 @@ program.}
 to compile with the Stan model.}
 
 \item{cpp_options}{(list) Any makefile options to be used when compiling the
-model (\code{STAN_THREADS}, \code{STAN_MPI}, \code{STAN_OPENCL}, etc.). Anything you would
+model (\code{stan_threads}, \code{stan_mpi}, \code{stan_opencl}, etc.). Anything you would
 otherwise write in the \code{make/local} file. For an example of using threading
 see the Stan case study
 \href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.}

--- a/man/model-method-sample_mpi.Rd
+++ b/man/model-method-sample_mpi.Rd
@@ -304,14 +304,14 @@ MPICH and OpenMPI. The implementations provide an MPI C++ compiler wrapper
 
 An example of compiling with MPI:
 
-\if{html}{\out{<div class="sourceCode">}}\preformatted{mpi_options = list(STAN_MPI=TRUE, CXX="mpicxx", TBB_CXX_TYPE="gcc")
+\if{html}{\out{<div class="sourceCode">}}\preformatted{mpi_options = list(stan_mpi = TRUE, CXX = "mpicxx", TBB_CXX_TYPE = "gcc")
 mod = cmdstan_model("model.stan", cpp_options = mpi_options)
 }\if{html}{\out{</div>}}
 
 The C++ options that must be supplied to the
 \link[=model-method-compile]{compile} call are:
 \itemize{
-\item \code{STAN_MPI}: Enables the use of MPI with Stan if \code{TRUE}.
+\item \code{stan_mpi}: Enables the use of MPI with Stan if \code{TRUE}.
 \item \code{CXX}: The name of the MPI C++ compiler wrapper. Typically \code{"mpicxx"}.
 \item \code{TBB_CXX_TYPE}: The C++ compiler the MPI wrapper wraps. Typically \code{"gcc"}
 on Linux and \code{"clang"} on macOS.
@@ -325,7 +325,7 @@ only define the number of processes. To use \code{n_procs} processes specify
 }
 \examples{
 \dontrun{
-# mpi_options <- list(STAN_MPI=TRUE, CXX="mpicxx", TBB_CXX_TYPE="gcc")
+# mpi_options <- list(stan_mpi = TRUE, CXX = "mpicxx", TBB_CXX_TYPE = "gcc")
 # mod <- cmdstan_model("model.stan", cpp_options = mpi_options)
 # fit <- mod$sample_mpi(..., mpi_args = list("n" = 4))
 }

--- a/tests/testthat/_snaps/cpp_opts.md
+++ b/tests/testthat/_snaps/cpp_opts.md
@@ -17,7 +17,7 @@
       assert_valid_threads(NULL, list(STAN_THREADS = TRUE))
     Condition
       Error:
-      ! The model was compiled with 'cpp_options = list(stan_threads = TRUE)' but 'threads' was not set!
+      ! The model executable was built with threading enabled but 'threads' was not set!
 
 # cpp option checks do not use partial matching
 

--- a/tests/testthat/_snaps/cpp_opts.md
+++ b/tests/testthat/_snaps/cpp_opts.md
@@ -1,0 +1,30 @@
+# lowercase stan_threads behavior remains unchanged
+
+    Code
+      assert_valid_threads(2L, list(stan_threads = FALSE))
+    Condition
+      Warning:
+      'threads' is set but the model was not compiled with 'cpp_options = list(stan_threads = TRUE)' so 'threads' will have no effect!
+    Code
+      assert_valid_threads(2L, list(stan_threads = "dummy string"))
+    Condition
+      Warning:
+      'threads' is set but the model was not compiled with 'cpp_options = list(stan_threads = TRUE)' so 'threads' will have no effect!
+
+# uppercase stan_threads requires a thread count
+
+    Code
+      assert_valid_threads(NULL, list(STAN_THREADS = TRUE))
+    Condition
+      Error:
+      ! The model was compiled with 'cpp_options = list(stan_threads = TRUE)' but 'threads' was not set!
+
+# cpp option checks do not use partial matching
+
+    Code
+      assert_valid_opencl(c(0L, 0L), list(stan_opencl_x = TRUE))
+    Condition
+      Error:
+      ! 'opencl_ids' is set but the model was not compiled for use with OpenCL.
+      Recompile the model with 'cpp_options = list(stan_opencl = TRUE)'
+

--- a/tests/testthat/_snaps/threads.md
+++ b/tests/testthat/_snaps/threads.md
@@ -6,3 +6,11 @@
       Warning:
       'num_threads' is deprecated as of CmdStanR 1.0.0 and will be removed in a future release. Please use 'threads' instead.
 
+# executable metadata takes precedence over compile options
+
+    Code
+      mod$sample(data = data_file_json, chains = 1)
+    Condition
+      Error:
+      ! The model executable was built with threading enabled but 'threads_per_chain' was not set!
+

--- a/tests/testthat/test-cpp_opts.R
+++ b/tests/testthat/test-cpp_opts.R
@@ -37,14 +37,84 @@ test_that("validate_cpp_options works", {
   expect_warning(validate_cpp_options(list(STAN_OPENCL = FALSE)))
 })
 
+test_that("cpp option lookup is exact and case-insensitive", {
+  cpp_options <- list(STAN_THREADS = TRUE)
+  expect_identical(cpp_option_value(cpp_options, "stan_threads"), TRUE)
+  expect_named(cpp_options, "STAN_THREADS")
+
+  expect_identical(
+    cpp_option_value(
+      list(stan_threads = FALSE, STAN_THREADS = TRUE),
+      "stan_threads"
+    ),
+    TRUE
+  )
+  expect_identical(
+    cpp_option_value(
+      list(STAN_THREADS = TRUE, stan_threads = FALSE),
+      "stan_threads"
+    ),
+    FALSE
+  )
+  expect_null(cpp_option_value(list(stan_opencl_x = TRUE), "stan_opencl"))
+})
+
 test_that("cpp option checks are case-insensitive", {
   expect_identical(
     assert_valid_threads(2L, list(STAN_THREADS = TRUE)),
     2L
   )
   expect_identical(
+    assert_valid_threads(2L, list(stan_threads = TRUE)),
+    2L
+  )
+  expect_identical(
     assert_valid_opencl(c(0L, 0L), list(STAN_OPENCL = TRUE)),
     c(0L, 0L)
+  )
+  expect_identical(
+    assert_valid_opencl(c(0L, 0L), list(stan_opencl = TRUE)),
+    c(0L, 0L)
+  )
+})
+
+test_that("lowercase stan_threads behavior remains unchanged", {
+  expect_null(assert_valid_threads(NULL, list(stan_threads = FALSE)))
+  expect_null(assert_valid_threads(NULL, list(stan_threads = "dummy string")))
+  expect_snapshot({
+    assert_valid_threads(2L, list(stan_threads = FALSE))
+    assert_valid_threads(2L, list(stan_threads = "dummy string"))
+  })
+})
+
+test_that("cpp option checks prefer the last case-insensitive match", {
+  expect_identical(
+    assert_valid_threads(
+      2L,
+      list(stan_threads = FALSE, STAN_THREADS = TRUE)
+    ),
+    2L
+  )
+  expect_identical(
+    assert_valid_opencl(
+      c(0L, 0L),
+      list(stan_opencl = NULL, STAN_OPENCL = TRUE)
+    ),
+    c(0L, 0L)
+  )
+})
+
+test_that("uppercase stan_threads requires a thread count", {
+  expect_snapshot(
+    error = TRUE,
+    assert_valid_threads(NULL, list(STAN_THREADS = TRUE))
+  )
+})
+
+test_that("cpp option checks do not use partial matching", {
+  expect_snapshot(
+    error = TRUE,
+    assert_valid_opencl(c(0L, 0L), list(stan_opencl_x = TRUE))
   )
 })
 

--- a/tests/testthat/test-cpp_opts.R
+++ b/tests/testthat/test-cpp_opts.R
@@ -56,6 +56,12 @@ test_that("cpp option lookup is exact and case-insensitive", {
     ),
     FALSE
   )
+  expect_null(
+    cpp_option_value(
+      list(STAN_OPENCL = TRUE, stan_opencl = NULL),
+      "stan_opencl"
+    )
+  )
   expect_null(cpp_option_value(list(stan_opencl_x = TRUE), "stan_opencl"))
 })
 

--- a/tests/testthat/test-cpp_opts.R
+++ b/tests/testthat/test-cpp_opts.R
@@ -37,6 +37,16 @@ test_that("validate_cpp_options works", {
   expect_warning(validate_cpp_options(list(STAN_OPENCL = FALSE)))
 })
 
+test_that("cpp option checks are case-insensitive", {
+  expect_identical(
+    assert_valid_threads(2L, list(STAN_THREADS = TRUE)),
+    2L
+  )
+  expect_identical(
+    assert_valid_opencl(c(0L, 0L), list(STAN_OPENCL = TRUE)),
+    c(0L, 0L)
+  )
+})
 
 test_that("exe_info cpp_options comparison works", {
   exe_info_all_flags_off <- exe_info_style_cpp_options(list())

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -913,6 +913,40 @@ test_that("STANCFLAGS from get_cmdstan_flags() are included in compile output", 
   expect_output(print(out), out_w_flags)
 })
 
+test_that("compile() detects stan_opencl without case or partial matching", {
+  stan_file <- testing_stan_file("bernoulli")
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  received_stancflags <- list()
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
+  )
+
+  model$compile(
+    cpp_options = list(STAN_OPENCL = TRUE),
+    force_recompile = TRUE,
+    dry_run = TRUE
+  )
+  expect_equal(
+    vapply(received_stancflags, \(x) "--use-opencl" %in% x, logical(1)),
+    rep(TRUE, 2)
+  )
+
+  received_stancflags <- list()
+  model$compile(
+    cpp_options = list(stan_opencl_x = TRUE),
+    force_recompile = TRUE,
+    dry_run = TRUE
+  )
+  expect_equal(
+    vapply(received_stancflags, \(x) "--use-opencl" %in% x, logical(1)),
+    rep(FALSE, 2)
+  )
+})
+
 test_that("compile() ignores directory chatter from MAKEFLAGS when reading STANCFLAGS", {
   withr::local_envvar(MAKEFLAGS = "-w -j 4")
   expect_compilation(mod, quiet = TRUE, force_recompile = TRUE)

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -930,9 +930,14 @@ test_that("compile() detects stan_opencl without case or partial matching", {
     force_recompile = TRUE,
     dry_run = TRUE
   )
+  expect_length(received_stancflags, 2)
   expect_equal(
-    vapply(received_stancflags, \(x) "--use-opencl" %in% x, logical(1)),
-    rep(TRUE, 2)
+    vapply(
+      received_stancflags,
+      function(x) "--use-opencl" %in% x,
+      logical(1)
+    ),
+    rep(TRUE, length(received_stancflags))
   )
 
   received_stancflags <- list()
@@ -941,9 +946,14 @@ test_that("compile() detects stan_opencl without case or partial matching", {
     force_recompile = TRUE,
     dry_run = TRUE
   )
+  expect_length(received_stancflags, 2)
   expect_equal(
-    vapply(received_stancflags, \(x) "--use-opencl" %in% x, logical(1)),
-    rep(FALSE, 2)
+    vapply(
+      received_stancflags,
+      function(x) "--use-opencl" %in% x,
+      logical(1)
+    ),
+    rep(FALSE, length(received_stancflags))
   )
 })
 

--- a/tests/testthat/test-threads.R
+++ b/tests/testthat/test-threads.R
@@ -22,7 +22,7 @@ test_that("threading works with sample()", {
 
   expect_error(
     mod$sample(data = data_file_json),
-    "The model was compiled with 'cpp_options = list(stan_threads = TRUE)' but 'threads_per_chain' was not set!",
+    "The model executable was built with threading enabled but 'threads_per_chain' was not set!",
     fixed = TRUE
   )
 
@@ -55,7 +55,7 @@ test_that("threading works with optimize()", {
 
   expect_error(
     mod$optimize(data = data_file_json),
-    "The model was compiled with 'cpp_options = list(stan_threads = TRUE)' but 'threads' was not set!",
+    "The model executable was built with threading enabled but 'threads' was not set!",
     fixed = TRUE
   )
 
@@ -89,7 +89,7 @@ test_that("threading works with variational()", {
 
   expect_error(
     mod$variational(data = data_file_json),
-    "The model was compiled with 'cpp_options = list(stan_threads = TRUE)' but 'threads' was not set!",
+    "The model executable was built with threading enabled but 'threads' was not set!",
     fixed = TRUE
   )
 
@@ -134,7 +134,7 @@ test_that("threading works with pathfinder()", {
 
   expect_error(
     do.call(mod$pathfinder, pathfinder_args),
-    "The model was compiled with 'cpp_options = list(stan_threads = TRUE)' but 'threads' was not set!",
+    "The model executable was built with threading enabled but 'threads' was not set!",
     fixed = TRUE
   )
 
@@ -169,7 +169,7 @@ test_that("threading works with generate_quantities()", {
   )
   expect_error(
     mod_gq$generate_quantities(fitted_params = f, data = data_file_json),
-    "The model was compiled with 'cpp_options = list(stan_threads = TRUE)' but 'threads_per_chain' was not set!",
+    "The model executable was built with threading enabled but 'threads_per_chain' was not set!",
     fixed = TRUE
   )
   expect_output(
@@ -202,6 +202,10 @@ test_that("executable metadata takes precedence over compile options", {
     stan_program,
     cpp_options = list(stan_threads = FALSE),
     force_recompile = TRUE
+  )
+  expect_snapshot(
+    error = TRUE,
+    mod$sample(data = data_file_json, chains = 1)
   )
   expect_output(
     fit <- mod$sample(

--- a/tests/testthat/test-threads.R
+++ b/tests/testthat/test-threads.R
@@ -197,27 +197,20 @@ test_that("threading works with generate_quantities()", {
   expect_equal(f_gq$metadata()$threads_per_chain, 4)
 })
 
-test_that("correct output when stan_threads not TRUE", {
-  mod <- cmdstan_model(stan_program, cpp_options = list(stan_threads = FALSE), force_recompile = TRUE)
-  expect_output(
-    mod$sample(data = data_file_json),
-    "Running MCMC with 4 sequential chains",
-    fixed = TRUE
+test_that("executable metadata takes precedence over compile options", {
+  mod <- cmdstan_model(
+    stan_program,
+    cpp_options = list(stan_threads = FALSE),
+    force_recompile = TRUE
   )
-  mod <- cmdstan_model(stan_program, cpp_options = list(stan_threads = "dummy string"), force_recompile = TRUE)
   expect_output(
-    mod$sample(data = data_file_json),
-    "Running MCMC with 4 sequential chains",
-    fixed = TRUE
-  )
-  mod <- cmdstan_model(stan_program, cpp_options = list(stan_threads = FALSE), force_recompile = TRUE)
-  expect_output(
-    expect_warning(
-      mod$sample(data = data_file_json, threads_per_chain = 4),
-      "'threads_per_chain' is set but the model was not compiled with 'cpp_options = list(stan_threads = TRUE)' so 'threads_per_chain' will have no effect!",
-      fixed = TRUE
+    fit <- mod$sample(
+      data = data_file_json,
+      chains = 1,
+      threads_per_chain = 2
     ),
-    "Running MCMC with 4 sequential chains",
+    "with 2 thread(s) per chain",
     fixed = TRUE
   )
+  expect_equal(fit$metadata()$threads_per_chain, 2)
 })

--- a/vignettes/articles-online-only/opencl.Rmd
+++ b/vignettes/articles-online-only/opencl.Rmd
@@ -116,7 +116,7 @@ To build the model with OpenCL support, add
 `cpp_options = list(stan_opencl = TRUE)` at the compilation step.
 
 ```{r compile-opencl, message=FALSE, results='hide'}
-# Compile the model with STAN_OPENCL=TRUE
+# Compile the model with stan_opencl = TRUE
 mod_cl <- cmdstan_model("opencl-files/bernoulli_logit_glm.stan",
                         cpp_options = list(stan_opencl = TRUE),
                         force_recompile = TRUE)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary


Respect `STAN_THREADS` and `STAN_OPENCL` regardless of capitalization and be more consistent in documentation of cpp options

- fixes #1100 
- fixes wlandau/instantiate#30 and https://github.com/wlandau/instantiate/discussions/31
- advances #765 (by recognizing mixed-case executable metadata for precompiled models. But metadata can still be lost after a later `$compile()` call, so leaving #765 open).

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
**Jonah Gabry**


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
