### PR TITLE
Exclude STAN_VERSION from cpp_options()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # cmdstanr (development version)
 
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
+* `$cpp_options()` no longer includes a `STAN_VERSION` entry read from the model executable's metadata. It was never a C++ option; use `$cmdstan_version()` instead. (#1215)
 * Pathfinder fits used as initial values now use uniform weights when CmdStan already PSIS-resampled their draws, avoiding a second application of importance weights. (#1206)
 * Pathfinder fits used as initial values now correctly treat draws with different initialization parameter values as distinct even when their log weights are equal, and collapse duplicate resampled draws while retaining their selection frequency. (#1207)
 * `pathfinder()` now passes separately supplied initial values to every path instead of using only the first path's initial values. (#1206)
@@ -9,13 +10,13 @@ passing `0` to CmdStan.
 * `pathfinder()` now uses `threads` argument (`num_threads` is deprecated),
 to be consistent with other methods.
 * The `save_latent_dynamics` argument is now limited to `$sample()`, `$sample_mpi()`, and `$variational()`, matching the CmdStan algorithms that support diagnostic CSV output.
-* Informative error when exposing functions using names that are reserved 
+* Informative error when exposing functions using names that are reserved
 keywords (@VisruthSK, #1154)
-* `save_cmdstan_config` and `save_metric` default to `FALSE` but can be 
+* `save_cmdstan_config` and `save_metric` default to `FALSE` but can be
 set to `TRUE` for an entire R session via new global options. (#1159)
 * `save_metric_files()` now gives an informative error when metric files were
 not created and keeps saved metric files after the fitted model is garbage-collected. (#1021)
-* `cmdstan_model()` no longer fails when `MAKEFLAGS` enables directory-printing 
+* `cmdstan_model()` no longer fails when `MAKEFLAGS` enables directory-printing
 output while reading `STANCFLAGS` from `make`. (#1163)
 * `cmdstan_model()` now retains include paths when initialized with both a Stan file
 and a precompiled executable (#1094).
@@ -31,7 +32,7 @@ optimizer CSV now uses the filename `<output_basename>-mode-1.csv`.
 * CmdStanModel objects created using `compile_model_methods = TRUE` that are
 then saved and reloaded no longer error in model fitting methods. Model methods
 are recompiled lazily if needed. (#1158)
-  
+
 * CmdStan versions older than 2.35.0 are no longer supported. (#1144)
 * Minimum R version increased to 4.0.0. (#1144)
 * Removed legacy Windows toolchain paths for older CmdStan releases. (#1144)
@@ -55,7 +56,7 @@ are recompiled lazily if needed. (#1158)
     - `save_extra_diagnostics` (`save_latent_dynamics`)
     - `max_depth` (`max_treedepth`)
     - `stepsize` (`step_size`)
-  
+
 
 # cmdstanr 0.9.0
 

--- a/R/model.R
+++ b/R/model.R
@@ -296,7 +296,7 @@ CmdStanModel <- R6::R6Class(
       if (length(self$exe_file()) > 0 && file.exists(self$exe_file())) {
         cpp_options <- model_compile_info(self$exe_file(), self$cmdstan_version())
         for (cpp_option_name in names(cpp_options)) {
-          if (cpp_option_name != "stan_version" &&
+          if (tolower(cpp_option_name) != "stan_version" &&
               (!is.logical(cpp_options[[cpp_option_name]]) || isTRUE(cpp_options[[cpp_option_name]]))) {
             private$cpp_options_[[cpp_option_name]] <- cpp_options[[cpp_option_name]]
           }

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -572,6 +572,12 @@ test_that("cpp_options work with settings in make/local", {
   cmdstan_make_local(cpp_options = backup, append = FALSE)
 })
 
+test_that("cpp_options() excludes the Stan version reported by the executable", {
+  mod <- cmdstan_model(stan_file = stan_program)
+  expect_null(mod$cpp_options()$STAN_VERSION)
+  expect_equal(mod$cmdstan_version(), cmdstan_version())
+})
+
 test_that("cmdstan_model works with exe_file", {
   stan_file <- testing_stan_file("bernoulli")
   mod <- cmdstan_model(stan_file, dry_run = TRUE)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

model_compile_info() returns uppercase keys, so the comparison against lowercase "stan_version" never matched and the executable's Stan version was stored as if it were a C++ option. We can just use `tolower()` to fix it.  


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
