### PR TITLE
Don't permanently modify user's make/local in test suite

### DIFF
--- a/tests/testthat/helper-envvars-and-paths.R
+++ b/tests/testthat/helper-envvars-and-paths.R
@@ -23,3 +23,26 @@ delete_extensions <- function() {
     c("", ".o",".hpp")
   }
 }
+
+# Write cpp_options to the make/local of the current CmdStan installation and
+# restore its original contents (or absence) when `envir` exits. Called at the
+# top level of a test file, the restore runs after all tests in that file.
+local_cmdstan_make_local <- function(cpp_options, envir = parent.frame()) {
+  make_local_path <- file.path(cmdstan_path(), "make", "local")
+  make_local_orig <- if (file.exists(make_local_path)) {
+    readLines(make_local_path, warn = FALSE)
+  } else {
+    NULL
+  }
+  withr::defer(
+    {
+      if (is.null(make_local_orig)) {
+        unlink(make_local_path)
+      } else {
+        writeLines(make_local_orig, make_local_path)
+      }
+    },
+    envir = envir
+  )
+  cmdstan_make_local(cpp_options = cpp_options)
+}

--- a/tests/testthat/helper-envvars-and-paths.R
+++ b/tests/testthat/helper-envvars-and-paths.R
@@ -30,7 +30,7 @@ delete_extensions <- function() {
 local_cmdstan_make_local <- function(cpp_options, envir = parent.frame()) {
   make_local_path <- file.path(cmdstan_path(), "make", "local")
   make_local_orig <- if (file.exists(make_local_path)) {
-    readLines(make_local_path, warn = FALSE)
+    readBin(make_local_path, "raw", file.size(make_local_path))
   } else {
     NULL
   }
@@ -39,7 +39,7 @@ local_cmdstan_make_local <- function(cpp_options, envir = parent.frame()) {
       if (is.null(make_local_orig)) {
         unlink(make_local_path)
       } else {
-        writeLines(make_local_orig, make_local_path)
+        writeBin(make_local_orig, make_local_path)
       }
     },
     envir = envir

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -6,12 +6,7 @@ w_path <- function(f) {
   x
 }
 
-make_local_orig <- cmdstan_make_local()
-cmdstan_make_local(cpp_options = list("PRECOMPILED_HEADERS" = "false"))
-
-withr::defer(
-  cmdstan_make_local(cpp_options = make_local_orig, append = FALSE)
-)
+local_cmdstan_make_local(cpp_options = list("PRECOMPILED_HEADERS" = "false"))
 
 hpp <- "
 #include <stan/math.hpp>

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -1,7 +1,7 @@
 set_cmdstan_path()
 stan_program <- cmdstan_example_file()
 mod <- cmdstan_model(stan_file = stan_program, compile = FALSE)
-cmdstan_make_local(cpp_options = list("PRECOMPILED_HEADERS"="false"))
+local_cmdstan_make_local(cpp_options = list("PRECOMPILED_HEADERS"="false"))
 
 test_that("object initialized correctly", {
   expect_equal(mod$stan_file(), stan_program)


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

test-model-compile.R added PRECOMPILED_HEADERS=false to make/local on every test run and never removed it.

This PR adds a local_cmdstan_make_local() test helper that writes cpp_options to make/local and restores its original contents (or absence) at the end of the test file. 

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
