### PR TITLE
cleanly handle compiling with threads in compile doc

### DIFF
--- a/R/model.R
+++ b/R/model.R
@@ -533,17 +533,23 @@ NULL
 #'
 #' @examples
 #' \dontrun{
-#' file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.stan")
+#' stan_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.stan")
 #'
 #' # by default compilation happens when cmdstan_model() is called.
 #' # to delay compilation until calling the $compile() method set compile=FALSE
-#' mod <- cmdstan_model(file, compile = FALSE)
+#' mod <- cmdstan_model(stan_file, compile = FALSE)
 #' mod$compile()
 #' mod$exe_file()
 #'
-#' # turn on threading support (for using functions that support within-chain parallelization)
-#' mod$compile(force_recompile = TRUE, cpp_options = list(stan_threads = TRUE))
-#' mod$exe_file()
+#' # turn on threading support for using functions that support within-chain
+#' # parallelization or running multiple pathfinder paths in parallel
+#' # (here we compile a copy of the model in a temporary directory so that the
+#' # executable compiled without threading above is not overwritten)
+#' stan_file_threads <- file.path(tempdir(), "bernoulli.stan")
+#' file.copy(stan_file, stan_file_threads)
+#' mod_threads <- cmdstan_model(stan_file_threads, compile = FALSE)
+#' mod_threads$compile(cpp_options = list(stan_threads = TRUE))
+#' mod_threads$cpp_options()
 #'
 #' # turn on pedantic mode
 #' file_pedantic <- write_stan_file("
@@ -554,8 +560,9 @@ NULL
 #'   sigma ~ exponential(1);
 #' }
 #' ")
-#' mod <- cmdstan_model(file_pedantic, pedantic = TRUE)
-#'
+#' mod <- cmdstan_model(file_pedantic, compile = FALSE)
+#' mod$compile(pedantic = TRUE)
+#' # same as mod <- cmdstan_model(file_pedantic, pedantic = TRUE)
 #' }
 #'
 compile <- function(quiet = TRUE,

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -114,17 +114,23 @@ location use
 }
 \examples{
 \dontrun{
-file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.stan")
+stan_file <- file.path(cmdstan_path(), "examples/bernoulli/bernoulli.stan")
 
 # by default compilation happens when cmdstan_model() is called.
 # to delay compilation until calling the $compile() method set compile=FALSE
-mod <- cmdstan_model(file, compile = FALSE)
+mod <- cmdstan_model(stan_file, compile = FALSE)
 mod$compile()
 mod$exe_file()
 
-# turn on threading support (for using functions that support within-chain parallelization)
-mod$compile(force_recompile = TRUE, cpp_options = list(stan_threads = TRUE))
-mod$exe_file()
+# turn on threading support for using functions that support within-chain
+# parallelization or running multiple pathfinder paths in parallel
+# (here we compile a copy of the model in a temporary directory so that the
+# executable compiled without threading above is not overwritten)
+stan_file_threads <- file.path(tempdir(), "bernoulli.stan")
+file.copy(stan_file, stan_file_threads)
+mod_threads <- cmdstan_model(stan_file_threads, compile = FALSE)
+mod_threads$compile(cpp_options = list(stan_threads = TRUE))
+mod_threads$cpp_options()
 
 # turn on pedantic mode
 file_pedantic <- write_stan_file("
@@ -135,8 +141,9 @@ model {
   sigma ~ exponential(1);
 }
 ")
-mod <- cmdstan_model(file_pedantic, pedantic = TRUE)
-
+mod <- cmdstan_model(file_pedantic, compile = FALSE)
+mod$compile(pedantic = TRUE)
+# same as mod <- cmdstan_model(file_pedantic, pedantic = TRUE)
 }
 
 }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

The $compile() example recompiles the CmdStan example model with stan_threads = TRUE. Because pkgdown before building vignettes, the cmdstanr.Rmd vignette then reused that threaded executable and errored when trying to run sampling.

This was always happening, but before #1212 the threading metadata went undetected due to the case-sensitivity bug.


#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
