### PR TITLE
Global option to turn off spinner

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -28,6 +28,10 @@ that support diagnostic CSV output.
 keywords (@VisruthSK, #1154)
 * `save_cmdstan_config` and `save_metric` default to `FALSE` but can be
 set to `TRUE` for an entire R session via new global options. (#1159)
+* The compilation spinner can now be disabled for an entire R session by setting
+the new `cmdstanr_spinner` global option to `FALSE`. The spinner shown while
+installing or rebuilding CmdStan and while checking syntax also respects this
+option, and is no longer shown when knitting. (#486)
 * `save_metric_files()` now gives an informative error when metric files were
 not created and keeps saved metric files after the fitted model is garbage-collected. (#1021)
 * `cmdstan_model()` no longer fails when `MAKEFLAGS` enables directory-printing

--- a/R/install.R
+++ b/R/install.R
@@ -490,7 +490,7 @@ build_cmdstan <- function(dir,
         wd = dir,
         echo_cmd = is_verbose_mode(),
         echo = !quiet || is_verbose_mode(),
-        spinner = quiet,
+        spinner = quiet && use_spinner(),
         error_on_status = FALSE,
         stderr_callback = function(x, p) { if (quiet) message(x) },
         timeout = timeout
@@ -515,7 +515,7 @@ clean_cmdstan <- function(dir = cmdstan_path(),
         wd = dir,
         echo_cmd = is_verbose_mode(),
         echo = !quiet || is_verbose_mode(),
-        spinner = quiet,
+        spinner = quiet && use_spinner(),
         error_on_status = FALSE,
         stderr_callback = function(x, p) { if (quiet) message(x) }
       )
@@ -538,7 +538,7 @@ build_example <- function(dir, cores, quiet, timeout) {
         wd = dir,
         echo_cmd = is_verbose_mode(),
         echo = !quiet || is_verbose_mode(),
-        spinner = quiet,
+        spinner = quiet && use_spinner(),
         error_on_status = FALSE,
         stderr_callback = function(x, p) { if (quiet) message(x) },
         timeout = timeout

--- a/R/model.R
+++ b/R/model.R
@@ -755,7 +755,7 @@ compile <- function(quiet = TRUE,
           wd = cmdstan_path(),
           echo = !quiet || is_verbose_mode(),
           echo_cmd = is_verbose_mode(),
-          spinner = quiet && rlang::is_interactive() && !identical(Sys.getenv("IN_PKGDOWN"), "true"),
+          spinner = quiet && use_spinner(),
           stderr_callback = function(x, p) {
             if (!startsWith(x, paste0(make_cmd(), ": *** No rule to make target"))) {
               message(x)
@@ -1008,7 +1008,7 @@ check_syntax <- function(pedantic = FALSE,
       wd = cmdstan_path(),
       echo = is_verbose_mode(),
       echo_cmd = is_verbose_mode(),
-      spinner = quiet && rlang::is_interactive(),
+      spinner = quiet && use_spinner(),
       stderr_callback = function(x, p) {
         message(x)
       },

--- a/R/options.R
+++ b/R/options.R
@@ -31,6 +31,11 @@
 #' a temporary directory are removed as part of \R garbage collection, while
 #' files in an explicitly defined directory are not automatically deleted.
 #'
+#' * `cmdstanr_spinner`: Should a spinner be shown while CmdStan compiles a
+#' model, checks syntax, or is installed or rebuilt? The default is `TRUE`. The
+#' spinner is only ever shown in interactive sessions, so setting this to
+#' `FALSE` is only necessary to suppress it in an interactive session.
+#'
 #' * `cmdstanr_verbose`: Should more information be printed
 #' when compiling or running models, including showing how CmdStan was called
 #' internally? The default is `FALSE`.

--- a/R/utils.R
+++ b/R/utils.R
@@ -11,6 +11,15 @@ is_verbose_mode <- function() {
   getOption("cmdstanr_verbose", default = FALSE)
 }
 
+# Should a spinner be shown while an external process runs? Only in genuinely
+# interactive use, so that the spinner characters don't end up in knitr/pkgdown
+# output or in redirected output (#486).
+use_spinner <- function() {
+  getOption("cmdstanr_spinner", default = TRUE) &&
+    rlang::is_interactive() &&
+    !identical(Sys.getenv("IN_PKGDOWN"), "true")
+}
+
 # Famous helper for switching on `NULL` or zero length
 `%||%` <- function(x, y) {
   if (is.null(x) || length(x) == 0) y else x

--- a/man/cmdstanr_global_options.Rd
+++ b/man/cmdstanr_global_options.Rd
@@ -27,6 +27,10 @@ Configure the option or environment variable before attaching the package.
 CSV files when fitting models. The default is a temporary directory. Files in
 a temporary directory are removed as part of \R garbage collection, while
 files in an explicitly defined directory are not automatically deleted.
+\item \code{cmdstanr_spinner}: Should a spinner be shown while CmdStan compiles a
+model, checks syntax, or is installed or rebuilt? The default is \code{TRUE}. The
+spinner is only ever shown in interactive sessions, so setting this to
+\code{FALSE} is only necessary to suppress it in an interactive session.
 \item \code{cmdstanr_verbose}: Should more information be printed
 when compiling or running models, including showing how CmdStan was called
 internally? The default is \code{FALSE}.

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -327,14 +327,20 @@ test_that("require_suggested_package() works", {
 })
 
 test_that("use_spinner() respects the cmdstanr_spinner option", {
-  # rlang::is_interactive() is FALSE while testing, so simulate both cases
-  withr::local_options(rlang_interactive = TRUE)
+  # rlang::is_interactive() is FALSE while testing, so simulate an interactive
+  # session. The option and env var are cleared so that the tests don't inherit
+  # them from the session running the tests.
+  withr::local_options(list(rlang_interactive = TRUE, cmdstanr_spinner = NULL))
+  withr::local_envvar(IN_PKGDOWN = NA)
   expect_true(use_spinner())
   withr::with_options(list(cmdstanr_spinner = FALSE), expect_false(use_spinner()))
   withr::with_options(list(cmdstanr_spinner = TRUE), expect_true(use_spinner()))
 })
 
 test_that("use_spinner() is FALSE unless interactive", {
+  withr::local_options(list(cmdstanr_spinner = NULL))
+  withr::local_envvar(IN_PKGDOWN = NA)
+
   withr::local_options(rlang_interactive = FALSE)
   expect_false(use_spinner())
   withr::with_options(list(cmdstanr_spinner = TRUE), expect_false(use_spinner()))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -326,6 +326,24 @@ test_that("require_suggested_package() works", {
   )
 })
 
+test_that("use_spinner() respects the cmdstanr_spinner option", {
+  # rlang::is_interactive() is FALSE while testing, so simulate both cases
+  withr::local_options(rlang_interactive = TRUE)
+  expect_true(use_spinner())
+  withr::with_options(list(cmdstanr_spinner = FALSE), expect_false(use_spinner()))
+  withr::with_options(list(cmdstanr_spinner = TRUE), expect_true(use_spinner()))
+})
+
+test_that("use_spinner() is FALSE unless interactive", {
+  withr::local_options(rlang_interactive = FALSE)
+  expect_false(use_spinner())
+  withr::with_options(list(cmdstanr_spinner = TRUE), expect_false(use_spinner()))
+
+  withr::local_options(rlang_interactive = TRUE)
+  withr::local_envvar(IN_PKGDOWN = "true")
+  expect_false(use_spinner())
+})
+
 test_that("as_mcmc.list() works", {
   x <- as_mcmc.list(fit_mcmc)
   expect_length(x, fit_mcmc$num_chains())


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

fixes #486

Adds global option to turn off spinner during compilation and installation

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
