### PR TITLE
Fix include paths with spaces and resolve them at model creation

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated 
 as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
+* CmdStanModel's `$check_syntax()`, `$format()`, `$sample()`, and `$variables()` methods now work with `#include` directories whose paths contain spaces. (#820)
 * `$cpp_options()` no longer includes a `STAN_VERSION` entry read from the model 
 executable's metadata. It was never a C++ option; use `$cmdstan_version()` instead. (#1215)
 * CmdStanModel methods now use executable metadata regardless of the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,11 @@
 as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
+* `$include_paths()` now returns absolute paths, and relative include paths are
+resolved when the model object is created or `$compile()` is called rather than
+on each `stanc` call. Previously a model created from a relative path could
+resolve `#include` directives against the wrong directory if the working
+directory changed. (#1229)
 * `$cpp_options()` no longer includes a `STAN_VERSION` entry read from the model 
 executable's metadata. It was never a C++ option; use `$cmdstan_version()` instead. (#1215)
 * CmdStanModel methods now use executable metadata regardless of the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,8 @@
 
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated 
 as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
-* CmdStanModel methods now correctly handle `#include` directories with spaces in their paths. (#820)
+* CmdStanModel methods now correctly handle `#include` directories with spaces
+in their paths. (#820)
 * `$cpp_options()` no longer includes a `STAN_VERSION` entry read from the model 
 executable's metadata. It was never a C++ option; use `$cmdstan_version()` instead. (#1215)
 * CmdStanModel methods now use executable metadata regardless of the 

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,7 +2,7 @@
 
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated 
 as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
-* CmdStanModel's `$check_syntax()`, `$format()`, `$sample()`, and `$variables()` methods now work with `#include` directories whose paths contain spaces. (#820)
+* CmdStanModel methods now correctly handle `#include` directories with spaces in their paths. (#820)
 * `$cpp_options()` no longer includes a `STAN_VERSION` entry read from the model 
 executable's metadata. It was never a C++ option; use `$cmdstan_version()` instead. (#1215)
 * CmdStanModel methods now use executable metadata regardless of the 

--- a/R/model.R
+++ b/R/model.R
@@ -980,7 +980,10 @@ check_syntax <- function(pedantic = FALSE,
     stanc_options[["warn-pedantic"]] <- TRUE
   }
 
-  stancflags_val <- include_paths_stanc3_args(include_paths)
+  stancflags_val <- include_paths_stanc3_args(
+    include_paths,
+    standalone_call = TRUE
+  )
 
   if (is.null(stanc_options[["name"]])) {
     stanc_options[["name"]] <- paste0(self$model_name(), "_model")
@@ -1106,7 +1109,10 @@ format <- function(overwrite_file = FALSE,
     lower = 1, len = 1, null.ok = TRUE
   )
   stanc_options <- private$precompile_stanc_options_
-  stancflags_val <- include_paths_stanc3_args(self$include_paths())
+  stancflags_val <- include_paths_stanc3_args(
+    self$include_paths(),
+    standalone_call = TRUE
+  )
   stanc_options["auto-format"] <- TRUE
   if (!is.null(max_line_length)) {
     stanc_options["max-line-length"] <- max_line_length
@@ -2494,7 +2500,10 @@ model_variables <- function(stan_file, include_paths = NULL, allow_undefined = F
     command = stanc_cmd(),
     args = c(wsl_safe_path(stan_file),
               "--info",
-              include_paths_stanc3_args(include_paths),
+              include_paths_stanc3_args(
+                include_paths,
+                standalone_call = TRUE
+              ),
               allow_undefined_arg),
     wd = cmdstan_path(),
     echo = FALSE,

--- a/R/model.R
+++ b/R/model.R
@@ -259,7 +259,7 @@ CmdStanModel <- R6::R6Class(
       if (!is.null(stan_file)) {
         assert_file_exists(stan_file, access = "r", extension = c("stan", "stanfunctions"))
         checkmate::assert_flag(compile)
-        private$stan_file_ <- absolute_path(stan_file)
+        private$stan_file_ <- resolve_path(stan_file)
         private$stan_code_ <- readLines(stan_file)
         private$model_name_ <- gsub(" ", "_", strip_ext(basename(private$stan_file_)))
         private$precompile_cpp_options_ <- args$cpp_options %||% list()
@@ -269,20 +269,20 @@ CmdStanModel <- R6::R6Class(
           private$using_user_header_ <- TRUE
         }
         if (is.null(args$include_paths) && any(grepl("#include" , private$stan_code_))) {
-          private$precompile_include_paths_ <- dirname(stan_file)
+          private$precompile_include_paths_ <- dirname(private$stan_file_)
         } else {
-          private$precompile_include_paths_ <- args$include_paths
+          private$precompile_include_paths_ <- resolve_path(args$include_paths)
         }
       }
       if (!is.null(exe_file)) {
         ext <- if (os_is_windows() && !os_is_wsl()) "exe" else ""
-        private$exe_file_ <- repair_path(absolute_path(exe_file))
+        private$exe_file_ <- resolve_path(exe_file)
         if (is.null(stan_file)) {
           assert_file_exists(private$exe_file_, access = "r", extension = ext)
           private$model_name_ <- gsub(" ", "_", strip_ext(basename(private$exe_file_)))
         }
         private$include_paths_ <-
-          private$precompile_include_paths_ %||% args$include_paths
+          private$precompile_include_paths_ %||% resolve_path(args$include_paths)
       }
       if (!is.null(stan_file) && compile) {
         self$compile(...)
@@ -422,7 +422,7 @@ CmdStanModel <- R6::R6Class(
 #' * `$model_name()` returns the model name as a string.
 #' * `$exe_file()` returns a path as a string, or `character(0)` if no
 #'   executable path is set.
-#' * `$include_paths()` returns a character vector of paths or `NULL`.
+#' * `$include_paths()` returns a character vector of absolute paths or `NULL`.
 #' * `$cmdstan_version()` returns a CmdStan version as a string.
 #' * `$cpp_options()` returns a named list of C++ options.
 #' * `$hpp_file()` returns the path to the `.hpp` file as a string when C++ code
@@ -480,7 +480,10 @@ NULL
 #'   [`$check_syntax()`][model-method-check_syntax] method can be used instead.
 #' @param include_paths (character vector) Paths to directories where Stan
 #'   should look for files specified in `#include` directives in the Stan
-#'   program.
+#'   program. Relative paths are resolved against the working directory when
+#'   the model object is created (or when `$compile()` is called) and stored as
+#'   absolute paths, so subsequent changes to the working directory do not
+#'   affect them.
 #' @param user_header (string) The path to a C++ file (with a .hpp extension)
 #'   to compile with the Stan model.
 #' @param cpp_options (list) Any makefile options to be used when compiling the
@@ -594,7 +597,7 @@ compile <- function(quiet = TRUE,
   if (is.null(include_paths) && !is.null(private$precompile_include_paths_)) {
     include_paths <- private$precompile_include_paths_
   }
-  private$include_paths_ <- include_paths
+  private$include_paths_ <- resolve_path(include_paths)
   if (is.null(dir) && !is.null(private$dir_)) {
     dir <- absolute_path(private$dir_)
   } else if (!is.null(dir)) {

--- a/R/model.R
+++ b/R/model.R
@@ -724,7 +724,7 @@ compile <- function(quiet = TRUE,
   if (length(stancflags_local) > 0) {
     stancflags_combined <- c(stancflags_combined, stancflags_local)
   }
-  stanc_inc_paths <- include_paths_stanc3_args(include_paths, standalone_call = TRUE)
+  stanc_inc_paths <- include_paths_stanc3_args(include_paths, direct_call = TRUE)
   stancflags_standalone <- c("--standalone-functions", stanc_inc_paths, stancflags_combined)
   self$functions$hpp_code <- get_standalone_hpp(temp_stan_file, stancflags_standalone)
   private$model_methods_env_ <- new.env()
@@ -982,7 +982,7 @@ check_syntax <- function(pedantic = FALSE,
 
   stancflags_val <- include_paths_stanc3_args(
     include_paths,
-    standalone_call = TRUE
+    direct_call = TRUE
   )
 
   if (is.null(stanc_options[["name"]])) {
@@ -1111,7 +1111,7 @@ format <- function(overwrite_file = FALSE,
   stanc_options <- private$precompile_stanc_options_
   stancflags_val <- include_paths_stanc3_args(
     self$include_paths(),
-    standalone_call = TRUE
+    direct_call = TRUE
   )
   stanc_options["auto-format"] <- TRUE
   if (!is.null(max_line_length)) {
@@ -2468,19 +2468,34 @@ assert_stan_file_exists <- function(stan_file) {
   }
 }
 
-include_paths_stanc3_args <- function(include_paths = NULL, standalone_call = FALSE) {
+#' Build stanc include-path arguments
+#'
+#' Make receives include paths through `STANCFLAGS` and needs paths containing
+#' spaces to be shell-quoted within a single `--include-paths=` flag. Direct
+#' calls through processx instead need the flag and comma-separated paths as
+#' separate, unquoted arguments.
+#'
+#' @param include_paths A character vector of directories containing files used
+#'   in Stan `#include` directives, or `NULL`.
+#' @param direct_call A logical indicating whether the arguments will be passed
+#'   directly to stanc through processx instead of through Make.
+#'
+#' @return `NULL` if `include_paths` is `NULL`; otherwise, a single
+#'   `--include-paths=` argument for Make or two arguments for a direct call.
+#' @noRd
+include_paths_stanc3_args <- function(include_paths = NULL, direct_call = FALSE) {
   stancflags <- NULL
   if (!is.null(include_paths)) {
     assert_dir_exists(include_paths, access = "r")
     include_paths <- sapply(absolute_path(include_paths), wsl_safe_path)
     # Calling stanc3 directly through processx::run does not need quoting
-    if (!isTRUE(standalone_call)) {
+    if (!isTRUE(direct_call)) {
       paths_w_space <- grep(" ", include_paths)
       include_paths[paths_w_space] <- paste0("'", include_paths[paths_w_space], "'")
     }
     include_paths <- paste0(include_paths, collapse = ",")
     include_paths_flag <- "--include-paths="
-    if (isTRUE(standalone_call)) {
+    if (isTRUE(direct_call)) {
       stancflags <- c(stancflags, "--include-paths", include_paths)
     } else {
       stancflags <- paste0(stancflags, include_paths_flag, include_paths)
@@ -2502,7 +2517,7 @@ model_variables <- function(stan_file, include_paths = NULL, allow_undefined = F
               "--info",
               include_paths_stanc3_args(
                 include_paths,
-                standalone_call = TRUE
+                direct_call = TRUE
               ),
               allow_undefined_arg),
     wd = cmdstan_path(),

--- a/R/utils.R
+++ b/R/utils.R
@@ -194,6 +194,17 @@ strip_ext <- function(file) {
 }
 absolute_path <- Vectorize(.absolute_path, USE.NAMES = FALSE)
 
+# Resolve paths when they are stored on a model object rather than when they are
+# used, so that later use doesn't depend on the working directory. Empty input
+# becomes NULL, the value callers treat as "not set" (absolute_path() would
+# otherwise return list()).
+resolve_path <- function(path) {
+  if (!length(path)) {
+    return(NULL)
+  }
+  repair_path(absolute_path(path))
+}
+
 # read, write, and copy files --------------------------------------------
 
 #' Copy temporary files (e.g., output, data) to a different location

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -37,7 +37,10 @@ without compiling it or for a model that is already compiled the
 
 \item{include_paths}{(character vector) Paths to directories where Stan
 should look for files specified in \verb{#include} directives in the Stan
-program.}
+program. Relative paths are resolved against the working directory when
+the model object is created (or when \verb{$compile()} is called) and stored as
+absolute paths, so subsequent changes to the working directory do not
+affect them.}
 
 \item{user_header}{(string) The path to a C++ file (with a .hpp extension)
 to compile with the Stan model.}

--- a/man/model-method-model-info.Rd
+++ b/man/model-method-model-info.Rd
@@ -26,7 +26,7 @@ code, or \code{NULL} if the model was created without a Stan file.
 \item \verb{$model_name()} returns the model name as a string.
 \item \verb{$exe_file()} returns a path as a string, or \code{character(0)} if no
 executable path is set.
-\item \verb{$include_paths()} returns a character vector of paths or \code{NULL}.
+\item \verb{$include_paths()} returns a character vector of absolute paths or \code{NULL}.
 \item \verb{$cmdstan_version()} returns a CmdStan version as a string.
 \item \verb{$cpp_options()} returns a named list of C++ options.
 \item \verb{$hpp_file()} returns the path to the \code{.hpp} file as a string when C++ code

--- a/tests/testthat/helper-models.R
+++ b/tests/testthat/helper-models.R
@@ -9,6 +9,24 @@ testing_stan_file <- function(name) {
   test_path("resources", "stan", paste0(name, ".stan"))
 }
 
+local_include_model_with_spaces <- function(.local_envir = parent.frame()) {
+  model_dir <- withr::local_tempdir(
+    pattern = "include path",
+    .local_envir = .local_envir
+  )
+  source_files <- c(
+    testing_stan_file("bernoulli_include"),
+    testing_stan_file("divide_real_by_two")
+  )
+  if (!all(file.copy(source_files, model_dir))) {
+    stop("Failed to copy Stan include test fixtures.", call. = FALSE)
+  }
+  list(
+    stan_file = file.path(model_dir, "bernoulli_include.stan"),
+    include_paths = model_dir
+  )
+}
+
 cmdstan_example_file <- function() {
   # stan program in different directory from the others
   file.path(cmdstan_path(), "examples", "bernoulli", "bernoulli.stan")

--- a/tests/testthat/test-fit-shared.R
+++ b/tests/testthat/test-fit-shared.R
@@ -480,15 +480,19 @@ test_that("draws are returned for model with spaces", {
   expect_equal(dim(fit$draws()), c(1000, 1, 1))
 })
 
-test_that("sampling with inits works with include_paths", {
-  stan_program_w_include <- testing_stan_file("bernoulli_include")
-  exe <- cmdstan_ext(strip_ext(stan_program_w_include))
-  if (file.exists(exe)) {
-    file.remove(exe)
-  }
+test_that("sampling works with inferred include paths containing spaces", {
+  model_dir <- withr::local_tempdir(pattern = "include path")
+  file.copy(
+    c(
+      testing_stan_file("bernoulli_include"),
+      testing_stan_file("divide_real_by_two")
+    ),
+    model_dir
+  )
+  stan_program_w_include <- file.path(model_dir, "bernoulli_include.stan")
 
-  mod_w_include <- cmdstan_model(stan_file = stan_program_w_include,
-                                 include_paths = test_path("resources", "stan"))
+  mod_w_include <- cmdstan_model(stan_file = stan_program_w_include)
+  expect_equal(mod_w_include$include_paths(), model_dir)
 
   data_list <- list(N = 10, y = c(0,1,0,0,0,0,0,0,0,1))
   expect_no_error(utils::capture.output(

--- a/tests/testthat/test-fit-shared.R
+++ b/tests/testthat/test-fit-shared.R
@@ -484,7 +484,10 @@ test_that("sampling works with explicit and inferred include paths containing sp
   include_model <- local_include_model_with_spaces()
 
   mod_inferred <- cmdstan_model(stan_file = include_model$stan_file)
-  expect_equal(mod_inferred$include_paths(), include_model$include_paths)
+  expect_equal(
+    repair_path(mod_inferred$include_paths()),
+    repair_path(include_model$include_paths)
+  )
 
   data_list <- list(N = 10, y = c(0,1,0,0,0,0,0,0,0,1))
   expect_no_error(utils::capture.output(
@@ -507,7 +510,10 @@ test_that("sampling works with explicit and inferred include paths containing sp
     include_paths = include_model$include_paths,
     compile = FALSE
   )
-  expect_equal(mod_explicit$include_paths(), include_model$include_paths)
+  expect_equal(
+    repair_path(mod_explicit$include_paths()),
+    repair_path(include_model$include_paths)
+  )
   expect_no_error(utils::capture.output(
     mod_explicit$sample(
       data = data_list,

--- a/tests/testthat/test-fit-shared.R
+++ b/tests/testthat/test-fit-shared.R
@@ -480,23 +480,15 @@ test_that("draws are returned for model with spaces", {
   expect_equal(dim(fit$draws()), c(1000, 1, 1))
 })
 
-test_that("sampling works with inferred include paths containing spaces", {
-  model_dir <- withr::local_tempdir(pattern = "include path")
-  file.copy(
-    c(
-      testing_stan_file("bernoulli_include"),
-      testing_stan_file("divide_real_by_two")
-    ),
-    model_dir
-  )
-  stan_program_w_include <- file.path(model_dir, "bernoulli_include.stan")
+test_that("sampling works with explicit and inferred include paths containing spaces", {
+  include_model <- local_include_model_with_spaces()
 
-  mod_w_include <- cmdstan_model(stan_file = stan_program_w_include)
-  expect_equal(mod_w_include$include_paths(), model_dir)
+  mod_inferred <- cmdstan_model(stan_file = include_model$stan_file)
+  expect_equal(mod_inferred$include_paths(), include_model$include_paths)
 
   data_list <- list(N = 10, y = c(0,1,0,0,0,0,0,0,0,1))
   expect_no_error(utils::capture.output(
-    fit <- mod_w_include$sample(
+    fit <- mod_inferred$sample(
       data = data_list,
       seed = 123,
       chains = 4,
@@ -506,6 +498,23 @@ test_that("sampling works with inferred include paths containing spaces", {
                   list(theta = 0.25),
                   list(theta = 0.25),
                   list(theta = 0.25))
+    )
+  ))
+
+  mod_explicit <- cmdstan_model(
+    stan_file = include_model$stan_file,
+    exe_file = mod_inferred$exe_file(),
+    include_paths = include_model$include_paths,
+    compile = FALSE
+  )
+  expect_equal(mod_explicit$include_paths(), include_model$include_paths)
+  expect_no_error(utils::capture.output(
+    mod_explicit$sample(
+      data = data_list,
+      seed = 123,
+      chains = 1,
+      refresh = 500,
+      init = list(list(theta = 0.25))
     )
   ))
 })

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -181,6 +181,40 @@ test_that("include paths are resolved when the model is created", {
   expect_true(mod$check_syntax(quiet = TRUE))
 })
 
+test_that("relative include_paths are resolved when the model is created", {
+  model_dir <- withr::local_tempdir()
+  include_dir <- file.path(model_dir, "includes")
+  dir.create(include_dir)
+  file.copy(testing_stan_file("bernoulli_include"), model_dir)
+  file.copy(testing_stan_file("divide_real_by_two"), include_dir)
+
+  mod <- withr::with_dir(
+    model_dir,
+    cmdstan_model(
+      "bernoulli_include.stan",
+      include_paths = "includes",
+      compile = FALSE
+    )
+  )
+  # "includes" no longer resolves relative to the working directory
+  expect_true(mod$check_syntax(quiet = TRUE))
+})
+
+test_that("relative include_paths given to $compile() are resolved when it is called", {
+  model_dir <- withr::local_tempdir()
+  include_dir <- file.path(model_dir, "includes")
+  dir.create(include_dir)
+  file.copy(testing_stan_file("bernoulli_include"), model_dir)
+  file.copy(testing_stan_file("divide_real_by_two"), include_dir)
+
+  mod <- withr::with_dir(model_dir, {
+    mod <- cmdstan_model("bernoulli_include.stan", compile = FALSE)
+    mod$compile(include_paths = "includes", quiet = TRUE)
+    mod
+  })
+  expect_true(mod$check_syntax(quiet = TRUE))
+})
+
 test_that("name in STANCFLAGS is set correctly", {
   local_reproducible_output()
   out <- utils::capture.output(mod$compile(quiet = FALSE, force_recompile = TRUE))

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -443,10 +443,21 @@ test_that("check_syntax() works with pedantic=TRUE", {
 })
 
 test_that("check_syntax() works with include_paths", {
-  stan_program_w_include <- testing_stan_file("bernoulli_include")
+  model_dir <- withr::local_tempdir(pattern = "include path")
+  file.copy(
+    c(
+      testing_stan_file("bernoulli_include"),
+      testing_stan_file("divide_real_by_two")
+    ),
+    model_dir
+  )
+  stan_program_w_include <- file.path(model_dir, "bernoulli_include.stan")
 
-  mod_w_include <- cmdstan_model(stan_file = stan_program_w_include, compile=FALSE,
-                                   include_paths = test_path("resources", "stan"))
+  mod_w_include <- cmdstan_model(
+    stan_file = stan_program_w_include,
+    compile = FALSE,
+    include_paths = model_dir
+  )
   expect_true(mod_w_include$check_syntax())
 
 })
@@ -528,20 +539,31 @@ test_that("include_paths_stanc3_args() works", {
   }
   path_1 <- repair_path(path_1)
   path_1_compare <- ifelse(os_is_wsl(), wsl_safe_path(path_1), path_1)
+  path_1_make <- if (grepl(" ", path_1_compare, fixed = TRUE)) {
+    paste0("'", path_1_compare, "'")
+  } else {
+    path_1_compare
+  }
   expect_equal(
     include_paths_stanc3_args(path_1),
-    paste0("--include-paths=", path_1_compare))
-  path_2 <- file.path(tempdir(), "folder2")
+    paste0("--include-paths=", path_1_make))
+  path_2 <- file.path(tempdir(), "folder 2")
   if (!dir.exists(path_2)) {
     dir.create(path_2)
   }
   path_2 <- repair_path(path_2)
   path_2_compare <- ifelse(os_is_wsl(), wsl_safe_path(path_2), path_2)
+  path_2_make <- paste0("'", path_2_compare, "'")
   expect_equal(
     include_paths_stanc3_args(c(path_1, path_2)),
-    c(
-      paste0("--include-paths=", path_1_compare, ",", path_2_compare)
-    )
+    paste0("--include-paths=", path_1_make, ",", path_2_make)
+  )
+  expect_equal(
+    include_paths_stanc3_args(
+      c(path_1, path_2),
+      standalone_call = TRUE
+    ),
+    c("--include-paths", paste0(path_1_compare, ",", path_2_compare))
   )
 })
 
@@ -793,10 +815,21 @@ test_that("format() works", {
 })
 
 test_that("format() works with include_paths", {
-  stan_program_w_include <- testing_stan_file("bernoulli_include")
+  model_dir <- withr::local_tempdir(pattern = "include path")
+  file.copy(
+    c(
+      testing_stan_file("bernoulli_include"),
+      testing_stan_file("divide_real_by_two")
+    ),
+    model_dir
+  )
+  stan_program_w_include <- file.path(model_dir, "bernoulli_include.stan")
 
-  mod_w_include <- cmdstan_model(stan_file = stan_program_w_include, compile=FALSE,
-                                   include_paths = test_path("resources", "stan"))
+  mod_w_include <- cmdstan_model(
+    stan_file = stan_program_w_include,
+    compile = FALSE,
+    include_paths = model_dir
+  )
   expect_output(
     mod_w_include$format(),
     "#include ",
@@ -888,7 +921,7 @@ test_that("dirname of stan_file is used as include path if no other paths suppli
     y ~ std_normal();
   }
   "
-  tmpdir <- tempdir()
+  tmpdir <- withr::local_tempdir(pattern = "include path")
   stan_data_file <- write_stan_file(data_code, basename = "separate_file.stan", dir = tmpdir)
   stan_file <- write_stan_file(model_code, dir = tmpdir)
 

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -155,7 +155,7 @@ test_that("precompiled models retain include paths", {
     compile = FALSE,
     include_paths = model_dir
   )
-  expect_equal(model_with_explicit_path$include_paths(), model_dir)
+  expect_equal(model_with_explicit_path$include_paths(), repair_path(model_dir))
   expect_no_error(model_with_explicit_path$variables())
 
   model_with_automatic_path <- cmdstan_model(
@@ -163,8 +163,22 @@ test_that("precompiled models retain include paths", {
     exe_file = compiled_model$exe_file(),
     compile = FALSE
   )
-  expect_equal(model_with_automatic_path$include_paths(), dirname(stan_file))
+  expect_equal(model_with_automatic_path$include_paths(), repair_path(dirname(stan_file)))
   expect_no_error(model_with_automatic_path$variables())
+})
+
+test_that("include paths are resolved when the model is created", {
+  model_dir <- withr::local_tempdir()
+  file.copy(
+    c(testing_stan_file("bernoulli_include"), testing_stan_file("divide_real_by_two")),
+    model_dir
+  )
+  mod <- withr::with_dir(
+    model_dir,
+    cmdstan_model("bernoulli_include.stan", compile = FALSE)
+  )
+  # the working directory no longer contains the included file
+  expect_true(mod$check_syntax(quiet = TRUE))
 })
 
 test_that("name in STANCFLAGS is set correctly", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -443,20 +443,12 @@ test_that("check_syntax() works with pedantic=TRUE", {
 })
 
 test_that("check_syntax() works with include_paths", {
-  model_dir <- withr::local_tempdir(pattern = "include path")
-  file.copy(
-    c(
-      testing_stan_file("bernoulli_include"),
-      testing_stan_file("divide_real_by_two")
-    ),
-    model_dir
-  )
-  stan_program_w_include <- file.path(model_dir, "bernoulli_include.stan")
+  include_model <- local_include_model_with_spaces()
 
   mod_w_include <- cmdstan_model(
-    stan_file = stan_program_w_include,
+    stan_file = include_model$stan_file,
     compile = FALSE,
-    include_paths = model_dir
+    include_paths = include_model$include_paths
   )
   expect_true(mod_w_include$check_syntax())
 
@@ -561,7 +553,7 @@ test_that("include_paths_stanc3_args() works", {
   expect_equal(
     include_paths_stanc3_args(
       c(path_1, path_2),
-      standalone_call = TRUE
+      direct_call = TRUE
     ),
     c("--include-paths", paste0(path_1_compare, ",", path_2_compare))
   )
@@ -815,20 +807,12 @@ test_that("format() works", {
 })
 
 test_that("format() works with include_paths", {
-  model_dir <- withr::local_tempdir(pattern = "include path")
-  file.copy(
-    c(
-      testing_stan_file("bernoulli_include"),
-      testing_stan_file("divide_real_by_two")
-    ),
-    model_dir
-  )
-  stan_program_w_include <- file.path(model_dir, "bernoulli_include.stan")
+  include_model <- local_include_model_with_spaces()
 
   mod_w_include <- cmdstan_model(
-    stan_file = stan_program_w_include,
+    stan_file = include_model$stan_file,
     compile = FALSE,
-    include_paths = model_dir
+    include_paths = include_model$include_paths
   )
   expect_output(
     mod_w_include$format(),

--- a/tests/testthat/test-model-variables.R
+++ b/tests/testthat/test-model-variables.R
@@ -125,10 +125,20 @@ test_that("$variables() works with #includes, both pre and post compilation.", {
 
   vars_pre <- mod_explicit$variables()
   mod_explicit$compile()
-  vars_post <- mod_explicit$variables()
+  mod_explicit_post <- cmdstan_model(
+    stan_file = model_file,
+    exe_file = mod_explicit$exe_file(),
+    include_paths = model_dir,
+    compile = FALSE
+  )
+  vars_post <- mod_explicit_post$variables()
 
   expect_equal(vars_pre, vars_post)
 
-  mod_automatic <- cmdstan_model(stan_file = model_file, compile = FALSE)
+  mod_automatic <- cmdstan_model(
+    stan_file = model_file,
+    exe_file = mod_explicit$exe_file(),
+    compile = FALSE
+  )
   expect_equal(mod_automatic$variables(), vars_pre)
 })

--- a/tests/testthat/test-model-variables.R
+++ b/tests/testthat/test-model-variables.R
@@ -102,7 +102,7 @@ test_that("$variables() works with #includes, both pre and post compilation.", {
     }
   "
   model_code <- "
-    #include data.stan
+    #include includes/data.stan
     parameters {
       vector[N] y;
     }
@@ -111,18 +111,24 @@ test_that("$variables() works with #includes, both pre and post compilation.", {
     }
   "
 
-  model_file <- write_stan_file(code = model_code)
-  data_file <- write_stan_file(code = data_code, basename = "data.stan")
+  model_dir <- withr::local_tempdir(pattern = "include path")
+  include_dir <- file.path(model_dir, "includes")
+  dir.create(include_dir, recursive = TRUE)
+  model_file <- write_stan_file(code = model_code, dir = model_dir)
+  write_stan_file(code = data_code, basename = "data.stan", dir = include_dir)
 
-  mod <- cmdstan_model(
+  mod_explicit <- cmdstan_model(
     stan_file = model_file,
-    include_paths = dirname(data_file),
+    include_paths = model_dir,
     compile = FALSE
   )
 
-  vars_pre <- mod$variables()
-  mod$compile()
-  vars_post <- mod$variables()
+  vars_pre <- mod_explicit$variables()
+  mod_explicit$compile()
+  vars_post <- mod_explicit$variables()
 
   expect_equal(vars_pre, vars_post)
+
+  mod_automatic <- cmdstan_model(stan_file = model_file, compile = FALSE)
+  expect_equal(mod_automatic$variables(), vars_pre)
 })

--- a/tests/testthat/test-model-variables.R
+++ b/tests/testthat/test-model-variables.R
@@ -135,10 +135,6 @@ test_that("$variables() works with #includes, both pre and post compilation.", {
 
   expect_equal(vars_pre, vars_post)
 
-  mod_automatic <- cmdstan_model(
-    stan_file = model_file,
-    exe_file = mod_explicit$exe_file(),
-    compile = FALSE
-  )
+  mod_automatic <- cmdstan_model(stan_file = model_file, compile = FALSE)
   expect_equal(mod_automatic$variables(), vars_pre)
 })


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #820: include directories containing spaces
Fixes #1229: Paths are now resolved where they are stored, via a shared `resolve_path()` helper that is also used for `stan_file_` and `exe_file_`, which were already stored absolute.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
