### PR TITLE
maintain separate direct and Make-quoted stanc options

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,15 @@ variables are, instead of erroring. (#1225)
 which previously errored. (#1225)
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated 
 as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
-* `CmdStanModel$compile()` now compiles models with named `stanc_options` values such as `canonicalize`, automatically enables `allow-undefined` for user headers supplied through `cpp_options`, and reports `stanc` failures immediately with their stderr and exit status instead of failing later while writing the generated C++ header. (#1227)
+* `$compile()` now works with named `stanc_options` values such as
+`canonicalize`. The values were shell-quoted for Make and the same quoted
+strings were also passed to `stanc` directly, which rejected them. (#1227)
+* `$compile()` now enables `allow-undefined` for user headers supplied through
+`cpp_options`, not just through the `user_header` argument. (#1227)
+* `stanc` failures during `$compile()` are now reported immediately, with the
+`stanc` error message. Previously they surfaced several steps later. (#1227)
+* Errors for include paths that do not exist now report the resolved absolute 
+path. (#1227)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ variables are, instead of erroring. (#1225)
 which previously errored. (#1225)
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated 
 as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
-* `CmdStanModel$compile()` now compiles models with named `stanc_options` values such as `canonicalize` and reports `stanc` failures immediately with their stderr and exit status instead of failing later while writing the generated C++ header. (#1227)
+* `CmdStanModel$compile()` now compiles models with named `stanc_options` values such as `canonicalize`, automatically enables `allow-undefined` for user headers supplied through `cpp_options`, and reports `stanc` failures immediately with their stderr and exit status instead of failing later while writing the generated C++ header. (#1227)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -22,8 +22,10 @@ strings were also passed to `stanc` directly, which rejected them. (#1227)
 `cpp_options`, not just through the `user_header` argument. (#1227)
 * `stanc` failures during `$compile()` are now reported immediately, with the
 `stanc` error message. Previously they surfaced several steps later. (#1227)
-* Errors for include paths that do not exist now report the resolved absolute 
+* Errors for include paths that do not exist now report the resolved absolute
 path. (#1227)
+* Numeric `stanc_options` values such as `list("max-line-length" = 78)` are no
+longer dropped. (#1233)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -15,7 +15,7 @@ variables are, instead of erroring. (#1225)
 which previously errored. (#1225)
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated 
 as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
-* `CmdStanModel$compile()` now compiles models with named `stanc_options` values such as `canonicalize`. (#1227)
+* `CmdStanModel$compile()` now compiles models with named `stanc_options` values such as `canonicalize` and reports `stanc` failures immediately with their stderr and exit status instead of failing later while writing the generated C++ header. (#1227)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,7 @@
 
 * The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated 
 as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
+* `CmdStanModel$compile()` now compiles models with named `stanc_options` values such as `canonicalize`. (#1227)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/R/model.R
+++ b/R/model.R
@@ -710,28 +710,37 @@ compile <- function(quiet = TRUE,
     stanc_options[["name"]] <- paste0(self$model_name(), "_model")
   }
   stanc_built_options <- c()
+  stanc_direct_options <- c()
   for (i in seq_len(length(stanc_options))) {
     option_name <- names(stanc_options)[i]
     if (isTRUE(as.logical(stanc_options[[i]]))) {
-      stanc_built_options <- c(stanc_built_options, paste0("--", option_name))
+      stanc_direct_option <- paste0("--", option_name)
+      stanc_built_option <- stanc_direct_option
     } else if (is.null(option_name) || !nzchar(option_name)) {
-      stanc_built_options <- c(stanc_built_options, paste0("--", stanc_options[[i]]))
+      stanc_direct_option <- paste0("--", stanc_options[[i]])
+      stanc_built_option <- stanc_direct_option
     } else if (option_name == "name") { # Quoting model name mangles generated namespace
-      stanc_built_options <- c(stanc_built_options, paste0("--", option_name, "=", stanc_options[[i]]))
-    }  else {
-      stanc_built_options <- c(stanc_built_options, paste0("--", option_name, "=", "'", stanc_options[[i]], "'"))
+      stanc_direct_option <- paste0("--", option_name, "=", stanc_options[[i]])
+      stanc_built_option <- stanc_direct_option
+    } else {
+      stanc_direct_option <- paste0("--", option_name, "=", stanc_options[[i]])
+      stanc_built_option <- paste0("--", option_name, "=", "'", stanc_options[[i]], "'")
     }
+    stanc_direct_options <- c(stanc_direct_options, stanc_direct_option)
+    stanc_built_options <- c(stanc_built_options, stanc_built_option)
   }
   stancflags_combined <- stanc_built_options
+  stancflags_direct <- stanc_direct_options
   stancflags_local <- get_cmdstan_flags("STANCFLAGS")
   if (length(stancflags_local) > 0) {
     stancflags_combined <- c(stancflags_combined, stancflags_local)
+    stancflags_direct <- c(stancflags_direct, stancflags_local)
   }
   stanc_inc_paths <- include_paths_stanc3_args(include_paths, direct_call = TRUE)
-  stancflags_standalone <- c("--standalone-functions", stanc_inc_paths, stancflags_combined)
+  stancflags_standalone <- c("--standalone-functions", stanc_inc_paths, stancflags_direct)
   self$functions$hpp_code <- get_standalone_hpp(temp_stan_file, stancflags_standalone)
   private$model_methods_env_ <- new.env()
-  private$model_methods_env_$hpp_code_ <- get_standalone_hpp(temp_stan_file, c(stanc_inc_paths, stancflags_combined))
+  private$model_methods_env_$hpp_code_ <- get_standalone_hpp(temp_stan_file, c(stanc_inc_paths, stancflags_direct))
   self$functions$external <- !is.null(user_header)
   self$functions$existing_exe <- FALSE
 

--- a/R/model.R
+++ b/R/model.R
@@ -598,6 +598,7 @@ compile <- function(quiet = TRUE,
     include_paths <- private$precompile_include_paths_
   }
   private$include_paths_ <- resolve_path(include_paths)
+  include_paths <- private$include_paths_
   if (is.null(dir) && !is.null(private$dir_)) {
     dir <- absolute_path(private$dir_)
   } else if (!is.null(dir)) {
@@ -806,10 +807,6 @@ compile <- function(quiet = TRUE,
     )
     if (is.na(run_log$status) || run_log$status != 0) {
       err_msg <- "An error occured during compilation! See the message above for more information."
-      if (grepl("auto-format flag to stanc", run_log$stderr)) {
-        format_msg <- "\nTo fix deprecated or removed syntax please see ?cmdstanr::format for an example."
-        err_msg <- paste(err_msg, format_msg)
-      }
       stop(err_msg, call. = FALSE)
     }
     if (file.exists(exe)) {

--- a/R/model.R
+++ b/R/model.R
@@ -631,7 +631,6 @@ compile <- function(quiet = TRUE,
     }
 
     cpp_options[["USER_HEADER"]] <- wsl_safe_path(absolute_path(user_header))
-    stanc_options[["allow-undefined"]] <- TRUE
     private$using_user_header_ <- TRUE
   } else if (!is.null(cpp_options[["USER_HEADER"]])) {
     if (!is.null(cpp_options[["user_header"]])) {
@@ -649,6 +648,7 @@ compile <- function(quiet = TRUE,
 
 
   if (!is.null(user_header)) {
+    stanc_options[["allow-undefined"]] <- TRUE
     user_header <- absolute_path(user_header) # As mentioned above, just absolute, not wsl_safe_path()
     if (!file.exists(user_header)) {
       stop(paste0("User header file '", user_header, "' does not exist."), call. = FALSE)

--- a/R/model.R
+++ b/R/model.R
@@ -1087,9 +1087,6 @@ format <- function(overwrite_file = FALSE,
     max_line_length,
     lower = 1, len = 1, null.ok = TRUE
   )
-  # Assign with [[ into a list so values keep their types. Using [ on a NULL or
-  # atomic vector coerces every element to a common type, which turned the
-  # logical TRUE for auto-format into the string "TRUE".
   stanc_options <- as.list(private$precompile_stanc_options_)
   stancflags_val <- include_paths_stanc3_args(
     self$include_paths(),

--- a/R/model.R
+++ b/R/model.R
@@ -806,8 +806,8 @@ compile <- function(quiet = TRUE,
       )
     )
     if (is.na(run_log$status) || run_log$status != 0) {
-      err_msg <- "An error occured during compilation! See the message above for more information."
-      stop(err_msg, call. = FALSE)
+      stop("An error occurred during compilation! See the message above for more information.",
+           call. = FALSE)
     }
     if (file.exists(exe)) {
       file.remove(exe)

--- a/R/model.R
+++ b/R/model.R
@@ -710,28 +710,8 @@ compile <- function(quiet = TRUE,
   if (is.null(stanc_options[["name"]])) {
     stanc_options[["name"]] <- paste0(self$model_name(), "_model")
   }
-  stanc_built_options <- c()
-  stanc_direct_options <- c()
-  for (i in seq_len(length(stanc_options))) {
-    option_name <- names(stanc_options)[i]
-    if (isTRUE(as.logical(stanc_options[[i]]))) {
-      stanc_direct_option <- paste0("--", option_name)
-      stanc_built_option <- stanc_direct_option
-    } else if (is.null(option_name) || !nzchar(option_name)) {
-      stanc_direct_option <- paste0("--", stanc_options[[i]])
-      stanc_built_option <- stanc_direct_option
-    } else if (option_name == "name") { # Quoting model name mangles generated namespace
-      stanc_direct_option <- paste0("--", option_name, "=", stanc_options[[i]])
-      stanc_built_option <- stanc_direct_option
-    } else {
-      stanc_direct_option <- paste0("--", option_name, "=", stanc_options[[i]])
-      stanc_built_option <- paste0("--", option_name, "=", "'", stanc_options[[i]], "'")
-    }
-    stanc_direct_options <- c(stanc_direct_options, stanc_direct_option)
-    stanc_built_options <- c(stanc_built_options, stanc_built_option)
-  }
-  stancflags_combined <- stanc_built_options
-  stancflags_direct <- stanc_direct_options
+  stancflags_combined <- stanc_options_to_args(stanc_options, quote_values = TRUE)
+  stancflags_direct <- stanc_options_to_args(stanc_options)
   stancflags_local <- get_cmdstan_flags("STANCFLAGS")
   if (length(stancflags_local) > 0) {
     stancflags_combined <- c(stancflags_combined, stancflags_local)
@@ -997,17 +977,7 @@ check_syntax <- function(pedantic = FALSE,
   if (is.null(stanc_options[["name"]])) {
     stanc_options[["name"]] <- paste0(self$model_name(), "_model")
   }
-  stanc_built_options <- c()
-  for (i in seq_len(length(stanc_options))) {
-    option_name <- names(stanc_options)[i]
-    if (isTRUE(as.logical(stanc_options[[i]]))) {
-      stanc_built_options <- c(stanc_built_options, paste0("--", option_name))
-    } else if (is.null(option_name) || !nzchar(option_name)) {
-      stanc_built_options <- c(stanc_built_options, paste0("--", stanc_options[[i]]))
-    } else {
-      stanc_built_options <- c(stanc_built_options, paste0("--", option_name, "=", stanc_options[[i]]))
-    }
-  }
+  stanc_built_options <- stanc_options_to_args(stanc_options)
 
   withr::with_path(
     c(
@@ -1117,37 +1087,24 @@ format <- function(overwrite_file = FALSE,
     max_line_length,
     lower = 1, len = 1, null.ok = TRUE
   )
-  stanc_options <- private$precompile_stanc_options_
+  # Assign with [[ into a list so values keep their types. Using [ on a NULL or
+  # atomic vector coerces every element to a common type, which turned the
+  # logical TRUE for auto-format into the string "TRUE".
+  stanc_options <- as.list(private$precompile_stanc_options_)
   stancflags_val <- include_paths_stanc3_args(
     self$include_paths(),
     direct_call = TRUE
   )
-  stanc_options["auto-format"] <- TRUE
+  stanc_options[["auto-format"]] <- TRUE
   if (!is.null(max_line_length)) {
-    stanc_options["max-line-length"] <- max_line_length
+    stanc_options[["max-line-length"]] <- max_line_length
   }
   if (isTRUE(canonicalize)) {
-    stanc_options["print-canonical"] <- TRUE
+    stanc_options[["print-canonical"]] <- TRUE
   } else if (is.list(canonicalize) && length(canonicalize) > 0){
-    stanc_options["canonicalize"] <- paste0(canonicalize, collapse = ",")
+    stanc_options[["canonicalize"]] <- paste0(canonicalize, collapse = ",")
   }
-  stanc_built_options <- c()
-  for (i in seq_len(length(stanc_options))) {
-    option_name <- names(stanc_options)[i]
-    if (isTRUE(as.logical(stanc_options[[i]])) && !is.numeric(stanc_options[[i]])) {
-      stanc_built_options <- c(stanc_built_options, paste0("--", option_name))
-    } else if (is.null(option_name) || !nzchar(option_name)) {
-      stanc_built_options <- c(
-        stanc_built_options,
-        paste0("--", stanc_options[[i]])
-      )
-    } else {
-      stanc_built_options <- c(
-        stanc_built_options,
-        paste0("--", option_name, "=", stanc_options[[i]])
-      )
-    }
-  }
+  stanc_built_options <- stanc_options_to_args(stanc_options)
   withr::with_path(
     c(
       toolchain_PATH_env_var(),
@@ -2475,6 +2432,39 @@ assert_stan_file_exists <- function(stan_file) {
   if (!file.exists(stan_file)) {
     stop("The Stan file used to create the `CmdStanModel` object does not exist.", call. = FALSE)
   }
+}
+
+#' Turn a `stanc_options` list into `stanc` command line arguments
+#'
+#' @param stanc_options (list) Named or unnamed stanc options. Logical values
+#'   mark boolean flags and any other value is passed as `--name=value`.
+#' @param quote_values (logical) Single-quote option values? Only the
+#'   `STANCFLAGS` string handed to Make needs quoting, because Make expands it
+#'   through a shell. Arguments for direct `stanc` calls are passed to processx
+#'   as separate elements and must be left unquoted (#1227).
+#' @return A character vector of arguments, one per element.
+#' @noRd
+stanc_options_to_args <- function(stanc_options, quote_values = FALSE) {
+  args <- c()
+  for (i in seq_len(length(stanc_options))) {
+    option_name <- names(stanc_options)[i]
+    option_value <- stanc_options[[i]]
+    if (is.null(option_name) || !nzchar(option_name)) {
+      # Unnamed options are already flag names, e.g. list("allow-undefined")
+      args <- c(args, paste0("--", option_value))
+    } else if (is.logical(option_value)) {
+      # TRUE emits a bare flag, FALSE leaves the flag out entirely
+      if (isTRUE(option_value)) {
+        args <- c(args, paste0("--", option_name))
+      }
+    } else if (isTRUE(quote_values) && option_name != "name") {
+      # Quoting the model name mangles the generated namespace
+      args <- c(args, paste0("--", option_name, "=", "'", option_value, "'"))
+    } else {
+      args <- c(args, paste0("--", option_name, "=", option_value))
+    }
+  }
+  args
 }
 
 #' Build stanc include-path arguments

--- a/R/utils.R
+++ b/R/utils.R
@@ -945,20 +945,23 @@ get_standalone_hpp <- function(stan_file, stancflags) {
         error_on_status = FALSE
       )
     )
-  if (is.null(status$status) || is.na(status$status) || status$status != 0) {
+  if (is.na(status$status) || status$status != 0) {
     if (length(status$stderr) > 0 && nzchar(status$stderr)) {
       message(status$stderr)
     }
-    status_code <- if (is.null(status$status) || is.na(status$status)) {
-      "missing"
-    } else {
-      status$status
-    }
-    stop(
-      "stanc exited with status ", status_code, ".\n",
-      "Failed to generate the model C++ header.",
-      call. = FALSE
+    err_msg <- paste0(
+      "stanc exited with status ", status$status, ".\n",
+      "Failed to generate the model C++ header."
     )
+    if (length(status$stderr) > 0 &&
+        grepl("auto-format flag to stanc", status$stderr)) {
+      err_msg <- paste0(
+        err_msg,
+        "\nTo fix deprecated or removed syntax please see ",
+        "?cmdstanr::format for an example."
+      )
+    }
+    stop(err_msg, call. = FALSE)
   }
   suppressWarnings(readLines(hpp_path, warn = FALSE))
 }

--- a/R/utils.R
+++ b/R/utils.R
@@ -931,6 +931,7 @@ get_standalone_hpp <- function(stan_file, stancflags) {
   name <- strip_ext(basename(stan_file))
   path <- dirname(stan_file)
   hpp_path <- file.path(path, paste0(name, ".hpp"))
+  on.exit(unlink(hpp_path), add = TRUE)
 
   status <- withr::with_path(
       c(
@@ -944,13 +945,22 @@ get_standalone_hpp <- function(stan_file, stancflags) {
         error_on_status = FALSE
       )
     )
-  if (status$status == 0) {
-    hpp <- suppressWarnings(readLines(hpp_path, warn = FALSE))
-    unlink(hpp_path)
-    hpp
-  } else {
-    invisible(NULL)
+  if (is.null(status$status) || is.na(status$status) || status$status != 0) {
+    if (length(status$stderr) > 0 && nzchar(status$stderr)) {
+      message(status$stderr)
+    }
+    status_code <- if (is.null(status$status) || is.na(status$status)) {
+      "missing"
+    } else {
+      status$status
+    }
+    stop(
+      "stanc exited with status ", status_code, ".\n",
+      "Failed to generate the model C++ header.",
+      call. = FALSE
+    )
   }
+  suppressWarnings(readLines(hpp_path, warn = FALSE))
 }
 
 get_function_name <- function(fun_start, fun_end, model_lines) {

--- a/R/utils.R
+++ b/R/utils.R
@@ -950,8 +950,8 @@ get_standalone_hpp <- function(stan_file, stancflags) {
       message(status$stderr)
     }
     err_msg <- paste0(
-      "stanc exited with status ", status$status, ".\n",
-      "Failed to generate the model C++ header."
+      "An error occurred during compilation! See the message above for more ",
+      "information. (stanc exited with status ", status$status, ")"
     )
     if (length(status$stderr) > 0 &&
         grepl("auto-format flag to stanc", status$stderr)) {

--- a/tests/testthat/_snaps/model-compile.md
+++ b/tests/testthat/_snaps/model-compile.md
@@ -1,0 +1,9 @@
+# compile() performs stanc checks during dry runs
+
+    Code
+      model$compile(force_recompile = TRUE, dry_run = TRUE)
+    Condition
+      Error:
+      ! stanc exited with status 1.
+      Failed to generate the model C++ header.
+

--- a/tests/testthat/_snaps/model-compile.md
+++ b/tests/testthat/_snaps/model-compile.md
@@ -1,9 +1,0 @@
-# compile() performs stanc checks during dry runs
-
-    Code
-      model$compile(force_recompile = TRUE, dry_run = TRUE)
-    Condition
-      Error:
-      ! stanc exited with status 1.
-      Failed to generate the model C++ header.
-

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -6,8 +6,7 @@
       stanc: invalid canonicalize value
     Condition
       Error:
-      ! stanc exited with status 124.
-      Failed to generate the model C++ header.
+      ! An error occurred during compilation! See the message above for more information. (stanc exited with status 124)
 
 # get_standalone_hpp() suggests formatting deprecated syntax
 
@@ -17,8 +16,7 @@
       Syntax error: Use the auto-format flag to stanc
     Condition
       Error:
-      ! stanc exited with status 1.
-      Failed to generate the model C++ header.
+      ! An error occurred during compilation! See the message above for more information. (stanc exited with status 1)
       To fix deprecated or removed syntax please see ?cmdstanr::format for an example.
 
 # copy_temp_files retains sources if any copy fails

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -1,3 +1,14 @@
+# get_standalone_hpp() reports stanc failures
+
+    Code
+      get_standalone_hpp(stan_file, "--canonicalize='deprecations'")
+    Message
+      stanc: invalid canonicalize value
+    Condition
+      Error:
+      ! stanc exited with status 124.
+      Failed to generate the model C++ header.
+
 # copy_temp_files retains sources if any copy fails
 
     Code

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -9,6 +9,18 @@
       ! stanc exited with status 124.
       Failed to generate the model C++ header.
 
+# get_standalone_hpp() suggests formatting deprecated syntax
+
+    Code
+      get_standalone_hpp(stan_file, character())
+    Message
+      Syntax error: Use the auto-format flag to stanc
+    Condition
+      Error:
+      ! stanc exited with status 1.
+      Failed to generate the model C++ header.
+      To fix deprecated or removed syntax please see ?cmdstanr::format for an example.
+
 # copy_temp_files retains sources if any copy fails
 
     Code

--- a/tests/testthat/test-fit-mcmc.R
+++ b/tests/testthat/test-fit-mcmc.R
@@ -270,7 +270,7 @@ test_that("inc_warmup in draws() works", {
   expect_equal(dim(y4), NULL)
 })
 
-test_that("inc_warmup in draws() works", {
+test_that("inc_warmup in draws() works with a single chain", {
   x3 <- fit_mcmc_2$draws(inc_warmup = FALSE)
   expect_equal(dim(x3), c(10000, 1, 5))
   expect_error(fit_mcmc_2$draws(inc_warmup = TRUE),

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -1,3 +1,35 @@
+test_that("cpp_options user headers allow undefined functions", {
+  stan_file <- testing_stan_file("bernoulli_external")
+  user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  received_stancflags <- list()
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
+  )
+
+  for (option_name in c("USER_HEADER", "user_header")) {
+    model <- cmdstan_model(stan_file, compile = FALSE)
+    model$compile(
+      cpp_options = setNames(list(user_header), option_name),
+      force_recompile = TRUE,
+      dry_run = TRUE
+    )
+  }
+
+  expect_length(received_stancflags, 4)
+  expect_equal(
+    vapply(
+      received_stancflags,
+      \(x) "--allow-undefined" %in% x,
+      logical(1)
+    ),
+    rep(TRUE, 4)
+  )
+})
+
 skip_if(os_is_macos())
 
 w_path <- function(f) {

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -23,7 +23,7 @@ test_that("cpp_options user headers allow undefined functions", {
   expect_equal(
     vapply(
       received_stancflags,
-      \(x) "--allow-undefined" %in% x,
+      function(x) "--allow-undefined" %in% x,
       logical(1)
     ),
     rep(TRUE, 4)

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -1,3 +1,6 @@
+# This test is deliberately placed above the file-level skip_if(os_is_macos())
+# below: it mocks the stanc call and never compiles, so it needs no toolchain
+# and should run on every platform.
 test_that("cpp_options user headers allow undefined functions", {
   stan_file <- testing_stan_file("bernoulli_external")
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -284,7 +284,8 @@ test_that("compile errors are shown", {
   stan_file <- testing_stan_file("fail")
   expect_error(
     cmdstan_model(stan_file),
-    "An error occured during compilation! See the message above for more information."
+    "stanc exited with status 1.\nFailed to generate the model C++ header.",
+    fixed = TRUE
   )
 })
 
@@ -522,7 +523,7 @@ test_that("check_syntax() works with pedantic=TRUE", {
   mod_dep_warning <- cmdstan_model(stan_file, compile = FALSE)
   expect_error(
     mod_dep_warning$compile(),
-    "An error occured during compilation! See the message above for more information.",
+    "stanc exited with status 1.\nFailed to generate the model C++ header.",
     fixed = TRUE
   )
   expect_error(
@@ -982,6 +983,72 @@ test_that("STANCFLAGS from get_cmdstan_flags() are included in compile output", 
     out_w_flags <- "bin/stanc --name=bernoulli_model[[:space:]]+--O1[[:space:]]+--warn-pedantic[[:space:]]+--o"
   }
   expect_output(print(out), out_w_flags)
+})
+
+test_that("compile() passes unquoted named stanc options to direct calls", {
+  stan_file <- testing_stan_file("bernoulli")
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  received_stancflags <- list()
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
+  )
+
+  model$compile(
+    stanc_options = list(
+      canonicalize = "deprecations",
+      "filename-in-msg" = "model filename with spaces.stan"
+    ),
+    force_recompile = TRUE,
+    dry_run = TRUE
+  )
+
+  expected <- c(
+    "--canonicalize=deprecations",
+    "--filename-in-msg=model filename with spaces.stan"
+  )
+  direct_options <- lapply(received_stancflags, function(x) {
+    grep("^--(canonicalize|filename-in-msg)=", x, value = TRUE)
+  })
+  expect_length(received_stancflags, 2)
+  expect_equal(direct_options, rep(list(expected), 2))
+  expect_equal(
+    grep("'", unlist(received_stancflags), fixed = TRUE, value = TRUE),
+    character()
+  )
+})
+
+test_that("compile() works with named stanc option values", {
+  stan_file <- write_stan_file(
+    "
+    functions {
+      real half(real x) {
+        return x / 2;
+      }
+    }
+    parameters {
+      real y;
+    }
+    model {
+      y ~ std_normal();
+    }
+    ",
+    dir = withr::local_tempdir(),
+    basename = "issue1227.stan"
+  )
+
+  expect_call_compilation(
+    model <- cmdstan_model(
+      stan_file,
+      stanc_options = list(
+        canonicalize = "deprecations",
+        "filename-in-msg" = "model filename with spaces.stan"
+      )
+    )
+  )
 })
 
 test_that("compile() detects stan_opencl without case or partial matching", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -289,28 +289,18 @@ test_that("compile errors are shown", {
   stan_file <- testing_stan_file("fail")
   expect_error(
     cmdstan_model(stan_file),
-    "stanc exited with status 1.\nFailed to generate the model C++ header.",
+    "An error occurred during compilation! See the message above for more information. (stanc exited with status 1)",
     fixed = TRUE
   )
 })
 
 test_that("compile() performs stanc checks during dry runs", {
-  stan_file <- testing_stan_file("bernoulli")
+  stan_file <- testing_stan_file("fail")
   model <- cmdstan_model(stan_file, compile = FALSE)
-  local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
-    get_standalone_hpp = function(...) {
-      stop(
-        "stanc exited with status 1.\n",
-        "Failed to generate the model C++ header.",
-        call. = FALSE
-      )
-    }
-  )
-
-  expect_snapshot(
-    error = TRUE,
-    model$compile(force_recompile = TRUE, dry_run = TRUE)
+  expect_error(
+    model$compile(force_recompile = TRUE, dry_run = TRUE),
+    "An error occurred during compilation! See the message above for more information. (stanc exited with status 1)",
+    fixed = TRUE
   )
 })
 
@@ -537,7 +527,7 @@ test_that("check_syntax() works with include_paths on compiled model", {
 
 })
 
-test_that("check_syntax() works with pedantic=TRUE", {
+test_that("compile() and check_syntax() error on removed syntax", {
   model_code <- "
   transformed data {
     real a;
@@ -548,7 +538,7 @@ test_that("check_syntax() works with pedantic=TRUE", {
   mod_dep_warning <- cmdstan_model(stan_file, compile = FALSE)
   expect_error(
     mod_dep_warning$compile(),
-    "stanc exited with status 1.\nFailed to generate the model C++ header.",
+    "An error occurred during compilation! See the message above for more information. (stanc exited with status 1)",
     fixed = TRUE
   )
   expect_error(
@@ -558,7 +548,7 @@ test_that("check_syntax() works with pedantic=TRUE", {
   )
 })
 
-test_that("compiliation errors if folder with the model name exists", {
+test_that("compilation errors if folder with the model name exists", {
   skip_if(os_is_windows() && !os_is_wsl())
   model_code <- "
   parameters {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -88,7 +88,12 @@ test_that("compilation works with include_paths", {
   expect_error(
     cmdstan_model(stan_file = stan_program_w_include, include_paths = "NOT_A_DIR",
                   quiet = TRUE),
-    "Directory 'NOT_A_DIR' does not exist"
+    paste0(
+      "Directory '",
+      repair_path(absolute_path("NOT_A_DIR")),
+      "' does not exist"
+    ),
+    fixed = TRUE
   )
 
   expect_error(

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -294,6 +294,26 @@ test_that("compile errors are shown", {
   )
 })
 
+test_that("compile() performs stanc checks during dry runs", {
+  stan_file <- testing_stan_file("bernoulli")
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(...) {
+      stop(
+        "stanc exited with status 1.\n",
+        "Failed to generate the model C++ header.",
+        call. = FALSE
+      )
+    }
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    model$compile(force_recompile = TRUE, dry_run = TRUE)
+  )
+})
+
 test_that("dir arg works for cmdstan_model and $compile()", {
   tmp_dir <- tempdir()
   tmp_dir_2 <- tempdir()

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -742,11 +742,12 @@ test_that("cmdstan_model works with user_header", {
   ))
   file.remove(mod$exe_file())
 
+  # No stanc_options here: a user header supplied via cpp_options must enable
+  # allow-undefined on its own (#1227)
   expect_call_compilation(
     mod_2 <- cmdstan_model(
       stan_file = testing_stan_file("bernoulli_external"),
-      cpp_options=list(USER_HEADER=tmpfile),
-      stanc_options = list("allow-undefined")
+      cpp_options=list(USER_HEADER=tmpfile)
     )
   )
 
@@ -998,6 +999,44 @@ test_that("STANCFLAGS from get_cmdstan_flags() are included in compile output", 
     out_w_flags <- "bin/stanc --name=bernoulli_model[[:space:]]+--O1[[:space:]]+--warn-pedantic[[:space:]]+--o"
   }
   expect_output(print(out), out_w_flags)
+})
+
+test_that("stanc_options_to_args() builds direct and Make-quoted arguments", {
+  # Unnamed options are already flag names and are never quoted
+  expect_equal(stanc_options_to_args(list("allow-undefined")), "--allow-undefined")
+  expect_equal(
+    stanc_options_to_args(list("allow-undefined"), quote_values = TRUE),
+    "--allow-undefined"
+  )
+
+  # Logical values mark boolean flags
+  expect_equal(stanc_options_to_args(list("warn-pedantic" = TRUE)), "--warn-pedantic")
+  expect_equal(stanc_options_to_args(list("warn-pedantic" = FALSE)), NULL)
+
+  # Values are quoted only for Make (#1227)
+  expect_equal(
+    stanc_options_to_args(list(canonicalize = "deprecations")),
+    "--canonicalize=deprecations"
+  )
+  expect_equal(
+    stanc_options_to_args(list(canonicalize = "deprecations"), quote_values = TRUE),
+    "--canonicalize='deprecations'"
+  )
+
+  # Quoting the model name mangles the generated namespace
+  expect_equal(
+    stanc_options_to_args(list(name = "m_model"), quote_values = TRUE),
+    "--name=m_model"
+  )
+
+  # Numeric values are kept rather than collapsed to a bare flag (#1233)
+  expect_equal(
+    stanc_options_to_args(list("max-line-length" = 78)),
+    "--max-line-length=78"
+  )
+
+  expect_equal(stanc_options_to_args(list()), NULL)
+  expect_equal(stanc_options_to_args(NULL), NULL)
 })
 
 test_that("compile() passes unquoted named stanc options to direct calls", {

--- a/tests/testthat/test-model-variables.R
+++ b/tests/testthat/test-model-variables.R
@@ -39,7 +39,7 @@ test_that("$variables() work correctly with example models", {
   expect_equal(mod$variables()$parameters$beta$dimensions, 1)
 })
 
-test_that("$variables() work correctly with example models", {
+test_that("$variables() work correctly with multidimensional variables", {
   code <- "
   data {
     array[1,2,3,4,5,6,7,8] int y;

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -161,6 +161,25 @@ test_that("get_standalone_hpp() reports stanc failures", {
   expect_false(file.exists(hpp_file))
 })
 
+test_that("get_standalone_hpp() suggests formatting deprecated syntax", {
+  stan_file <- withr::local_tempfile(fileext = ".stan")
+  writeLines("real x; transformed parameters { x <- 1; }", stan_file)
+  local_mocked_bindings(
+    wsl_compatible_run = function(...) {
+      list(
+        status = 1L,
+        stdout = "",
+        stderr = "Syntax error: Use the auto-format flag to stanc"
+      )
+    }
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    get_standalone_hpp(stan_file, character())
+  )
+})
+
 
 # misc --------------------------------------------------------------------
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -163,7 +163,6 @@ test_that("get_standalone_hpp() reports stanc failures", {
 
 test_that("get_standalone_hpp() suggests formatting deprecated syntax", {
   stan_file <- withr::local_tempfile(fileext = ".stan")
-  writeLines("real x; transformed parameters { x <- 1; }", stan_file)
   local_mocked_bindings(
     wsl_compatible_run = function(...) {
       list(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -135,6 +135,32 @@ test_that("cmdstan_diagnose works if bin/diagnose deleted file", {
   expect_output(delete_and_run(), "Checking sampler transitions treedepth")
 })
 
+test_that("get_standalone_hpp() reports stanc failures", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "model.stan")
+  hpp_file <- file.path(model_dir, "model.hpp")
+  writeLines("parameters { real y; } model { y ~ std_normal(); }", stan_file)
+  writeLines("// partial output", hpp_file)
+  local_mocked_bindings(
+    wsl_compatible_run = function(...) {
+      list(
+        status = 124L,
+        stdout = "",
+        stderr = "stanc: invalid canonicalize value"
+      )
+    }
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    get_standalone_hpp(
+      stan_file,
+      "--canonicalize='deprecations'"
+    )
+  )
+  expect_false(file.exists(hpp_file))
+})
+
 
 # misc --------------------------------------------------------------------
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -259,6 +259,19 @@ test_that("wsl_safe_path() works with multiple paths", {
   )
 })
 
+test_that("wsl_compatible_run() preserves arguments containing spaces", {
+  skip_if_not(os_is_wsl())
+  arg <- "--filename-in-msg=model filename with spaces.stan"
+  result <- wsl_compatible_run(
+    command = "printf",
+    args = c("%s", arg),
+    wd = cmdstan_path()
+  )
+
+  expect_equal(result$status, 0L)
+  expect_equal(result$stdout, arg)
+})
+
 test_that("list_to_array works with empty list", {
   expect_equal(list_to_array(list()), NULL)
 })


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #1227 
Fixes #1233 

In addition to those issues,`stanc` errors during `$compile()` are now thrown  immediately with the `stanc` error message attached, instead of returning `NULL` and failing later

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah 


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
