### PR TITLE
Keep model state consistent with the executable, and stop dropping compile-time inputs

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -13,3 +13,4 @@
 ^vignettes/articles-online-only$
 ^release-prep\.R$
 ^\.vscode$
+^dev-notes$

--- a/NEWS.md
+++ b/NEWS.md
@@ -37,6 +37,10 @@ version of the Stan program. They must be exposed again with
 compilation when they are not supplied again. Recompiling a model that uses
 `#include` directives or a user header through the same object previously
 failed because those inputs were dropped. (#1234)
+* `$compile()` now recompiles when `include_paths` change. Previously the model
+went on using the executable built against the old paths while `$variables()`
+and `$include_paths()` described the new ones, so data and initial values were
+validated against a program that was not running. (#1235)
 * A `user_header` supplied to `cmdstan_model()` is now used by a later
 `$compile()`. Previously it was only honored when the model was compiled
 immediately. (#1234)

--- a/NEWS.md
+++ b/NEWS.md
@@ -61,7 +61,12 @@ at the C++ stage left the old executable paired with model methods generated
 from the new program. (#1235)
 * `$compile()` now warns when `cpp_options` are supplied but the existing
 executable is up to date and was not built with them, so nothing is rebuilt and
-the options have no effect. Use `force_recompile = TRUE` to rebuild. (#1235)
+the options have no effect. The check is best effort: for an executable the
+model object compiled itself the options are known exactly and any difference is
+reported, but for one adopted from an earlier session only the few `STAN_*`
+flags the binary reports about itself can be checked, and anything else passes
+unremarked. Use `force_recompile = TRUE` when a supplied option has to take
+effect. (#1235)
 * `$cpp_options()` no longer reports options the executable was not built with.
 Previously a request that did not rebuild the model was recorded as though it
 had, so `$sample()` could fail with "the model executable was built with

--- a/NEWS.md
+++ b/NEWS.md
@@ -58,9 +58,9 @@ pre-compiled Stan model" on a model that had compiled itself. (#1235)
 * A failed compilation no longer moves `$exe_file()` or replaces the generated
 C++ used by `$hpp_file()` and `fit$init_model_methods()`. Previously a failure
 at the C++ stage left the old executable paired with model methods generated
-from the new program. A `dry_run = TRUE` compilation likewise no longer moves
-`$hpp_file()`, which previously pointed at a temporary file it never wrote.
-(#1235)
+from the new program. A `dry_run = TRUE` compilation likewise no longer records
+`$cpp_options()` or moves `$hpp_file()`, which previously pointed at a temporary
+file it never wrote. (#1235)
 * `$compile()` now errors if the newly compiled executable cannot be installed,
 restoring the previous executable. Previously the replacement was unchecked, so
 a failure could silently leave the model with no executable at all. (#1235)

--- a/NEWS.md
+++ b/NEWS.md
@@ -48,24 +48,16 @@ different header was ignored if the executable was otherwise up to date. (#1235)
 `cpp_options` to the one actually used, so `$cpp_options()` no longer reports
 the ignored spelling after a successful compilation. (#1235)
 * A `$compile()` call that finds the executable up to date no longer erases
-`$cpp_options()`. Previously the recorded options were replaced with whatever
-the call supplied, so a bare `$compile()` on a model built with
-`cpp_options = list(stan_threads = TRUE)` dropped `stan_threads` and the
-executable then ran single-threaded. (#1235)
+`$cpp_options()`. (#1235)
 * `$expose_functions()` now works after a `$compile()` call that found the
-executable up to date. It previously failed with "not possible with a
-pre-compiled Stan model" on a model that had compiled itself. (#1235)
+executable up to date. (#1235)
 * A failed compilation no longer moves `$exe_file()` or replaces the generated
 C++ used by `$hpp_file()` and `fit$init_model_methods()`. Previously a failure
 at the C++ stage left the old executable paired with model methods generated
-from the new program. A `dry_run = TRUE` compilation likewise no longer records
-`$cpp_options()` or moves `$hpp_file()`, which previously pointed at a temporary
-file it never wrote. (#1235)
+from the new program. (#1235)
 * `$compile()` now warns when `cpp_options` are supplied but the existing
 executable is up to date and was not built with them, so nothing is rebuilt and
-the options have no effect. Previously they were recorded and reported as if
-they applied, so a model could print "2 thread(s) per chain" while running
-single-threaded. Use `force_recompile = TRUE` to rebuild. (#1235)
+the options have no effect. Use `force_recompile = TRUE` to rebuild. (#1235)
 * `$compile()` now errors if the newly compiled executable cannot be installed,
 restoring the previous executable. Previously the replacement was unchecked, so
 a failure could silently leave the model with no executable at all. (#1235)

--- a/NEWS.md
+++ b/NEWS.md
@@ -186,6 +186,7 @@ are recompiled lazily if needed. (#1158)
     - `stepsize` (`step_size`)
 
 
+
 # cmdstanr 0.9.0
 
 ## General Improvements/Changes

--- a/NEWS.md
+++ b/NEWS.md
@@ -91,6 +91,9 @@ An executable path that names a directory, which `$exe_file()` and
 `cmdstan_model(exe_file = )` both accept without checking, previously had that
 directory renamed aside as though it were the old executable and a file put in
 its place. (#1235)
+* `$compile()` now checks that it can record the compiled model before replacing
+the executable, so a failure at that point can no longer leave a new executable
+on disk that the model object knows nothing about. (#1235)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -58,6 +58,10 @@ from the new program. (#1235)
 * `$compile()` now warns when `cpp_options` are supplied but the existing
 executable is up to date and was not built with them, so nothing is rebuilt and
 the options have no effect. Use `force_recompile = TRUE` to rebuild. (#1235)
+* `$cpp_options()` no longer reports options the executable was not built with.
+Previously a request that did not rebuild the model was recorded as though it
+had, so `$sample()` could fail with "the model executable was built with
+threading enabled" for a binary that had no threading. (#1019, #1235)
 * `$compile()` now errors if the newly compiled executable cannot be installed,
 restoring the previous executable. Previously the replacement was unchecked, so
 a failure could silently leave the model with no executable at all. (#1235)

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,9 @@ as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
 `canonicalize`. The values were shell-quoted for Make and the same quoted
 strings were also passed to `stanc` directly, which rejected them. (#1227)
 * `$compile()` now enables `allow-undefined` for user headers supplied through
-`cpp_options`, not just through the `user_header` argument. (#1227)
+`cpp_options`, not just through the `user_header` argument. `$check_syntax()`
+and `$format()` also now correctly enable `allow-undefined` for models that use
+a user header. (#1227, #1234)
 * `stanc` failures during `$compile()` are now reported immediately, with the
 `stanc` error message. Previously they surfaced several steps later. (#1227)
 * Errors for include paths that do not exist now report the resolved absolute
@@ -38,10 +40,6 @@ failed because those inputs were dropped. (#1234)
 * A `user_header` supplied to `cmdstan_model()` is now used by a later
 `$compile()`. Previously it was only honored when the model was compiled
 immediately. (#1234)
-* `$compile(dry_run = TRUE)` no longer discards the `cpp_options`,
-`stanc_options` and `include_paths` supplied to `cmdstan_model()`. (#1234)
-* `$include_paths()` no longer returns `NULL` for a model whose executable does
-not exist, such as after `$compile(dry_run = TRUE)`. (#1234)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -13,7 +13,7 @@ variables are, instead of erroring. (#1225)
 * Supplying a factor for a variable not declared as `int` is now an error. (#1225)
 * Factors are now accepted for length-1 `int` arrays (e.g. `array[1] int x`),
 which previously errored. (#1225)
-* The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated
+* The `CMDSTANR_NO_VER_CHECK` R option and environment variable are deprecated 
 as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
 * `$compile()` now works with named `stanc_options` values such as
 `canonicalize`. The values were shell-quoted for Make and the same quoted
@@ -68,17 +68,17 @@ resolved when the model object is created or `$compile()` is called rather than
 on each `stanc` call. Previously a model created from a relative path could
 resolve `#include` directives against the wrong directory if the working
 directory changed. (#1229)
-* `$cpp_options()` no longer includes a `STAN_VERSION` entry read from the model
+* `$cpp_options()` no longer includes a `STAN_VERSION` entry read from the model 
 executable's metadata. It was never a C++ option; use `$cmdstan_version()` instead. (#1215)
-* CmdStanModel methods now use executable metadata regardless of the
-capitalization of C++ option names. Any executable reporting threading enabled
+* CmdStanModel methods now use executable metadata regardless of the 
+capitalization of C++ option names. Any executable reporting threading enabled 
 requires the corresponding `threads` or `threads_per_chain` argument. (#765, #1100)
-* Pathfinder fits used as initial values now use uniform weights when CmdStan
+* Pathfinder fits used as initial values now use uniform weights when CmdStan 
 already PSIS-resampled their draws, avoiding a second application of importance weights. (#1206)
-* Pathfinder fits used as initial values now correctly treat draws with different
-initialization parameter values as distinct even when their log weights are equal,
+* Pathfinder fits used as initial values now correctly treat draws with different 
+initialization parameter values as distinct even when their log weights are equal, 
 and collapse duplicate resampled draws while retaining their selection frequency. (#1207)
-* `pathfinder()` now passes separately supplied initial values to every path
+* `pathfinder()` now passes separately supplied initial values to every path 
 instead of using only the first path's initial values. (#1206)
 * `pathfinder()` now respects `save_single_paths = TRUE` instead of always
 passing `0` to CmdStan.
@@ -87,10 +87,10 @@ to be consistent with other methods.
 * The `num_paths` documentation for `pathfinder()` now notes that running
 multiple paths in parallel requires compiling with
 `cpp_options = list(stan_threads = TRUE)` and setting `threads`. (#896)
-* The `save_latent_dynamics` argument is now limited to `$sample()`,
-`$sample_mpi()`, and `$variational()`, matching the CmdStan algorithms
+* The `save_latent_dynamics` argument is now limited to `$sample()`, 
+`$sample_mpi()`, and `$variational()`, matching the CmdStan algorithms 
 that support diagnostic CSV output.
-* Informative error when exposing functions using names that are reserved
+* Informative error when exposing functions using names that are reserved 
 keywords (@VisruthSK, #1154)
 * `save_cmdstan_config` and `save_metric` default to `FALSE` but can be
 set to `TRUE` for an entire R session via new global options. (#1159)

--- a/NEWS.md
+++ b/NEWS.md
@@ -108,6 +108,10 @@ clears a previously configured user header instead of being ignored. It stands
 for an explicit `USER_HEADER=`, which `Make` takes as clearing anything set
 before it, so the model previously compiled with no header while continuing to
 report the old one. (#1235)
+* A `$compile()` that fails because the user header does not exist now still
+records the header. Previously the request was discarded, so `$check_syntax()`
+and `$format()` reported the model's own undefined functions as errors and a
+bare retry after creating the file compiled with no header at all. (#1235)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -82,6 +82,8 @@ effect. (#1235)
 were never passed to `$compile()`, such as those inherited from `make/local`,
 when the binary reports them. `$sample()` and friends previously refused
 `threads_per_chain` for an executable that did have threading. (#1019, #1235)
+* `cmdstan_model()` no longer runs the model executable twice to read its build
+metadata. (#1236)
 * `$cpp_options()` no longer reports options the executable was not built with.
 Previously a request that did not rebuild the model was recorded as though it
 had, so `$sample()` could fail with "the model executable was built with

--- a/NEWS.md
+++ b/NEWS.md
@@ -62,6 +62,9 @@ the options have no effect. Use `force_recompile = TRUE` to rebuild. (#1235)
 Previously a request that did not rebuild the model was recorded as though it
 had, so `$sample()` could fail with "the model executable was built with
 threading enabled" for a binary that had no threading. (#1019, #1235)
+* `$format(overwrite_file = TRUE)` now refreshes `$variables()` along with
+`$code()`, which previously kept describing the program as it was before
+formatting. (#1235)
 * `$compile()` now errors if the newly compiled executable cannot be installed,
 restoring the previous executable. Previously the replacement was unchecked, so
 a failure could silently leave the model with no executable at all. (#1235)

--- a/NEWS.md
+++ b/NEWS.md
@@ -19,7 +19,9 @@ as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
 `canonicalize`. The values were shell-quoted for Make and the same quoted
 strings were also passed to `stanc` directly, which rejected them. (#1227)
 * `$compile()` now enables `allow-undefined` for user headers supplied through
-`cpp_options`, not just through the `user_header` argument. (#1227)
+`cpp_options`, not just through the `user_header` argument. `$check_syntax()`
+and `$format()` also now correctly enable `allow-undefined` for models that use
+a user header. (#1227)
 * `stanc` failures during `$compile()` are now reported immediately, with the
 `stanc` error message. Previously they surfaced several steps later. (#1227)
 * Errors for include paths that do not exist now report the resolved absolute
@@ -38,10 +40,6 @@ failed because those inputs were dropped. (#1234)
 * A `user_header` supplied to `cmdstan_model()` is now used by a later
 `$compile()`. Previously it was only honored when the model was compiled
 immediately. (#1234)
-* `$compile(dry_run = TRUE)` no longer discards the `cpp_options`,
-`stanc_options` and `include_paths` supplied to `cmdstan_model()`. (#1234)
-* `$include_paths()` no longer returns `NULL` for a model whose executable does
-not exist, such as after `$compile(dry_run = TRUE)`. (#1234)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,9 @@ the ignored spelling after a successful compilation. (#1235)
 `$cpp_options()`. (#1235)
 * `$expose_functions()` now works after a `$compile()` call that found the
 executable up to date. (#1235)
+* `$expose_functions()` on a model with no executable, such as one created with
+`compile = FALSE` or compiled with `dry_run = TRUE`, now reports that it cannot
+expose functions instead of failing with "argument is of length zero". (#1235)
 * A failed compilation no longer moves `$exe_file()` or replaces the generated
 C++ used by `$hpp_file()` and `fit$init_model_methods()`. Previously a failure
 at the C++ stage left the old executable paired with model methods generated

--- a/NEWS.md
+++ b/NEWS.md
@@ -94,6 +94,9 @@ its place. (#1235)
 * `$compile()` now checks that it can record the compiled model before replacing
 the executable, so a failure at that point can no longer leave a new executable
 on disk that the model object knows nothing about. (#1235)
+* A duplicated `USER_HEADER` or `user_header` entry in `cpp_options` now selects
+the last one, matching what `Make` does with repeated assignments. Previously
+the first was compiled with and the rest were left in `cpp_options`. (#1235)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -26,6 +26,11 @@ strings were also passed to `stanc` directly, which rejected them. (#1227)
 path. (#1227)
 * Numeric `stanc_options` values such as `list("max-line-length" = 78)` are no
 longer dropped. (#1233)
+* `$compile()` now refreshes `$code()` and `$variables()` after a successful
+compilation. (#1228)
+* `$compile()` now discards standalone functions exposed from an earlier
+version of the Stan program. They must be exposed again with
+`$expose_functions()` after a recompilation. (#1228)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -60,13 +60,18 @@ C++ used by `$hpp_file()` and `fit$init_model_methods()`. Previously a failure
 at the C++ stage left the old executable paired with model methods generated
 from the new program. (#1235)
 * `$compile()` now warns when `cpp_options` are supplied but the existing
-executable is up to date and was not built with them, so nothing is rebuilt and
-the options have no effect. The check is best effort: for an executable the
-model object compiled itself the options are known exactly and any difference is
-reported, but for one adopted from an earlier session only the few `STAN_*`
-flags the binary reports about itself can be checked, and anything else passes
+executable is up to date, so nothing is rebuilt and the options are not applied.
+The check is best effort. For an executable the model object compiled itself it
+compares the options passed to `Make` against those requested, and treats
+anything the binary reports but was never passed as inherited from `make/local`
+and so unchanged by a rebuild. For one adopted from an earlier session only the
+few `STAN_*` flags the binary reports can be checked, and anything else passes
 unremarked. Use `force_recompile = TRUE` when a supplied option has to take
 effect. (#1235)
+* `$cpp_options()` now also reports options the executable was built with that
+were never passed to `$compile()`, such as those inherited from `make/local`,
+when the binary reports them. `$sample()` and friends previously refused
+`threads_per_chain` for an executable that did have threading. (#1019, #1235)
 * `$cpp_options()` no longer reports options the executable was not built with.
 Previously a request that did not rebuild the model was recorded as though it
 had, so `$sample()` could fail with "the model executable was built with

--- a/NEWS.md
+++ b/NEWS.md
@@ -97,6 +97,11 @@ on disk that the model object knows nothing about. (#1235)
 * A duplicated `USER_HEADER` or `user_header` entry in `cpp_options` now selects
 the last one, matching what `Make` does with repeated assignments. Previously
 the first was compiled with and the rest were left in `cpp_options`. (#1235)
+* A `USER_HEADER` or `user_header` entry in `cpp_options` set to `NULL` now
+clears a previously configured user header instead of being ignored. It stands
+for an explicit `USER_HEADER=`, which `Make` takes as clearing anything set
+before it, so the model previously compiled with no header while continuing to
+report the old one. (#1235)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -61,6 +61,11 @@ at the C++ stage left the old executable paired with model methods generated
 from the new program. A `dry_run = TRUE` compilation likewise no longer records
 `$cpp_options()` or moves `$hpp_file()`, which previously pointed at a temporary
 file it never wrote. (#1235)
+* `$compile()` now warns when `cpp_options` are supplied but the existing
+executable is up to date and was not built with them, so nothing is rebuilt and
+the options have no effect. Previously they were recorded and reported as if
+they applied, so a model could print "2 thread(s) per chain" while running
+single-threaded. Use `force_recompile = TRUE` to rebuild. (#1235)
 * `$compile()` now errors if the newly compiled executable cannot be installed,
 restoring the previous executable. Previously the replacement was unchecked, so
 a failure could silently leave the model with no executable at all. (#1235)

--- a/NEWS.md
+++ b/NEWS.md
@@ -86,6 +86,11 @@ formatting. (#1235)
 * `$compile()` now errors if the newly compiled executable cannot be installed,
 restoring the previous executable. Previously the replacement was unchecked, so
 a failure could silently leave the model with no executable at all. (#1235)
+* `$compile()` now errors instead of installing an executable over a directory.
+An executable path that names a directory, which `$exe_file()` and
+`cmdstan_model(exe_file = )` both accept without checking, previously had that
+directory renamed aside as though it were the old executable and a file put in
+its place. (#1235)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -66,7 +66,11 @@ compares the options passed to `Make` against those requested, and treats
 anything the binary reports but was never passed as inherited from `make/local`
 and so unchanged by a rebuild. For one adopted from an earlier session only the
 few `STAN_*` flags the binary reports can be checked, and anything else passes
-unremarked. Use `force_recompile = TRUE` when a supplied option has to take
+unremarked. It can also warn when nothing would in fact change: an option
+inherited from `make/local` that the binary does not report looks like a request
+the executable lacks, and one that was both passed explicitly and set in
+`make/local` looks like something a rebuild would drop when it would be
+inherited again. Use `force_recompile = TRUE` when a supplied option has to take
 effect. (#1235)
 * `$cpp_options()` now also reports options the executable was built with that
 were never passed to `$compile()`, such as those inherited from `make/local`,

--- a/NEWS.md
+++ b/NEWS.md
@@ -31,6 +31,17 @@ compilation. (#1228)
 * `$compile()` now discards standalone functions exposed from an earlier
 version of the Stan program. They must be exposed again with
 `$expose_functions()` after a recompilation. (#1228)
+* `$compile()` now reuses the include paths and the user header of the previous
+compilation when they are not supplied again. Recompiling a model that uses
+`#include` directives or a user header through the same object previously
+failed because those inputs were dropped. (#1234)
+* A `user_header` supplied to `cmdstan_model()` is now used by a later
+`$compile()`. Previously it was only honored when the model was compiled
+immediately. (#1234)
+* `$compile(dry_run = TRUE)` no longer discards the `cpp_options`,
+`stanc_options` and `include_paths` supplied to `cmdstan_model()`. (#1234)
+* `$include_paths()` no longer returns `NULL` for a model whose executable does
+not exist, such as after `$compile(dry_run = TRUE)`. (#1234)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/NEWS.md
+++ b/NEWS.md
@@ -40,6 +40,30 @@ failed because those inputs were dropped. (#1234)
 * A `user_header` supplied to `cmdstan_model()` is now used by a later
 `$compile()`. Previously it was only honored when the model was compiled
 immediately. (#1234)
+* `$compile()` now accepts `user_header = NULL` to compile without a user
+header. Previously a header, once supplied, could not be removed. (#1235)
+* `$compile()` now recompiles when the user header changes. Previously a
+different header was ignored if the executable was otherwise up to date. (#1235)
+* `$compile()` now reduces duplicate `USER_HEADER`/`user_header` entries in
+`cpp_options` to the one actually used, so `$cpp_options()` no longer reports
+the ignored spelling after a successful compilation. (#1235)
+* A `$compile()` call that finds the executable up to date no longer erases
+`$cpp_options()`. Previously the recorded options were replaced with whatever
+the call supplied, so a bare `$compile()` on a model built with
+`cpp_options = list(stan_threads = TRUE)` dropped `stan_threads` and the
+executable then ran single-threaded. (#1235)
+* `$expose_functions()` now works after a `$compile()` call that found the
+executable up to date. It previously failed with "not possible with a
+pre-compiled Stan model" on a model that had compiled itself. (#1235)
+* A failed compilation no longer moves `$exe_file()` or replaces the generated
+C++ used by `$hpp_file()` and `fit$init_model_methods()`. Previously a failure
+at the C++ stage left the old executable paired with model methods generated
+from the new program. A `dry_run = TRUE` compilation likewise no longer moves
+`$hpp_file()`, which previously pointed at a temporary file it never wrote.
+(#1235)
+* `$compile()` now errors if the newly compiled executable cannot be installed,
+restoring the previous executable. Previously the replacement was unchecked, so
+a failure could silently leave the model with no executable at all. (#1235)
 * CmdStanModel methods now correctly handle `#include` directories with spaces
 in their paths. (#820)
 * `$include_paths()` now returns absolute paths, and relative include paths are

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -73,11 +73,8 @@ model_compile_info <- function(exe_file, version) {
   info
 }
 
-# Merge the options an executable reports about itself into the options already
-# recorded for it. STAN_VERSION describes the toolchain rather than a make
-# option, and a flag the executable reports as FALSE was never set at all, so
-# recording it would pass "FLAG=FALSE" to make, which CmdStan reads as enabling
-# the flag.
+# Merge build options reported by the executable. Ignore STAN_VERSION and false
+# flags (passing FLAG=FALSE back to CmdStan can enable the flag).
 merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
   for (option_name in names(exe_info)) {
     value <- exe_info[[option_name]]
@@ -89,22 +86,9 @@ merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
   cpp_options
 }
 
-# The options a compilation would actually be run with, normalized so that a
-# request can be compared against what an executable was built with.
-#
-# Deliberately canonicalizes the output of cpp_options_to_compile_flags() rather
-# than reading the list itself: what make is handed is what decides whether two
-# builds differ, and any second reading of these lists drifts from the first.
-# Named and unnamed entries, duplicate names, vector values that expand into
-# several assignments and NULLs that expand into an empty NAME= are all already
-# resolved by the time the flags exist.
-#
-# Assignments are reduced last-wins, as a makefile does, and compared by
-# lower-cased name so that spelling is not a difference. Anything that is not an
-# assignment is opaque and keeps its order relative to the other opaque
-# arguments, though not its position among the assignments. Header entries are
-# dropped: header identity is tracked separately and forces a rebuild on its
-# own.
+# Normalize the flags sent to make. Assignment names are case-insensitive and
+# the last value wins. Nonassignments keep their order. Headers are handled
+# separately.
 parsed_cpp_options <- function(cpp_options) {
   assignments <- list()
   opaque <- character()
@@ -134,9 +118,7 @@ normalized_cpp_options <- function(cpp_options) {
   c(sort(reduced), parsed$opaque)
 }
 
-# Whether an executable built with `recorded` would differ from one built with
-# `requested`. Symmetric, because cpp_options are one-shot: a recompilation
-# carrying `requested` would drop anything `recorded` holds that it does not.
+# Omitted recorded options count as changes because cpp_options are one-shot.
 cpp_options_disagree <- function(requested, recorded) {
   !identical(
     normalized_cpp_options(requested),
@@ -200,36 +182,16 @@ validate_cpp_options <- function(cpp_options) {
 }
 
 # user headers ---------------------------------------------------------
-# Decide which user header a compilation should use and reduce cpp_options to a
-# single, unambiguous source for it.
-#
-# Precedence:
-#   1. an explicit non-NULL `user_header` argument;
-#   2. an explicit `user_header = NULL`, which clears any header carried in
-#      cpp_options as well;
-#   3. only when the argument is omitted, cpp_options -- USER_HEADER ahead of
-#      user_header whichever order they appear in -- and then `previous`, the
-#      header the model already holds.
-#
-# `supplied` is what makes (2) expressible at all: `user_header = NULL` is also
-# the default, so the value alone cannot separate "cleared" from "not
-# mentioned". `cpp_options_supplied` separates a header passed in the same call,
-# a conflict worth warning about, from one inherited from an earlier call.
-#
-# Both spellings are always dropped from cpp_options; callers reinsert the
-# selected header under `spelling`, in whatever form they store. The header is
-# returned as supplied, neither made absolute nor WSL-safe, because callers
-# differ on which they need.
+# Resolve one header and remove both header spellings from cpp_options.
+# Precedence is explicit user_header (including NULL), USER_HEADER,
+# user_header, then previous. `supplied` distinguishes NULL from omission.
+# `cpp_options_supplied` limits conflict warnings to this call.
 resolve_user_header <- function(user_header,
                                 supplied,
                                 cpp_options,
                                 cpp_options_supplied = TRUE,
                                 previous = NULL) {
-  # Positions rather than [[name]]: every duplicate reaches make and a makefile
-  # takes the last, so the last occurrence of a spelling is the one that would
-  # have been used. Reading by name takes the first, and removing by name drops
-  # only one occurrence, which would leave the others to reach make alongside
-  # the header selected here.
+  # Use positions so duplicate options follow make's last-value-wins behavior.
   upper_at <- which(names(cpp_options) == "USER_HEADER")
   lower_at <- which(names(cpp_options) == "user_header")
   last_of <- function(positions) {
@@ -239,14 +201,7 @@ resolve_user_header <- function(user_header,
       cpp_options[[positions[[length(positions)]]]]
     }
   }
-  # Presence comes from the positions, never from the value, because NULL is a
-  # value an entry can hold rather than a way of being absent. An entry whose
-  # final occurrence is NULL stands for an explicit `USER_HEADER=` -- the
-  # assignment that would reach make if the resolver did not strip it, and the
-  # one make would take as clearing anything set before it. Reading presence
-  # off the value instead treated that as "no header given" and fell back to
-  # the persisted one, so the compile ran with no header while the object went
-  # on describing the old one. Matches cpp_option_value() below.
+  # NULL is still present here because it emits an empty USER_HEADER= assignment.
   has_upper <- length(upper_at) > 0
   has_lower <- length(lower_at) > 0
   from_upper <- last_of(upper_at)
@@ -271,14 +226,11 @@ resolve_user_header <- function(user_header,
     header <- previous
   }
 
-  # Shape is checked wherever a header is accepted; whether it exists is checked
-  # only when compiling, so that a header created between construction and
-  # $compile() still works.
+  # Validate the value now and check file existence when compiling.
   if (!is.null(header)) {
     checkmate::assert_string(header, .var.name = "user_header")
   }
-  # Guarded because negative indexing by an empty vector returns nothing at all
-  # rather than everything.
+  # Guarded because x[-integer(0)] is empty.
   header_at <- c(upper_at, lower_at)
   if (length(header_at) > 0) {
     cpp_options <- cpp_options[-header_at]
@@ -379,17 +331,13 @@ exe_info_reflects_cpp_options <- function(exe_info, cpp_options) {
   }
   if (is.null(cpp_options)) return(TRUE)
 
-  # Only the assignments the binary can speak to. Anything else is left alone
-  # rather than reported as a mismatch: an adopted executable carries no record
-  # of what produced it, so an unreportable option is unverifiable, not wrong.
-  # Read through parsed_cpp_options() so that unnamed raw assignments, duplicate
-  # names and vector values mean here what they mean to make.
+  # Compare only options reported by the executable. Other options are unknown.
+  # Parse the emitted flags so duplicates and unnamed assignments match make.
   assignments <- parsed_cpp_options(cpp_options)$assignments
   reported <- intersect(names(assignments), tolower(names(exe_info)))
 
   for (option_name in reported) {
-    # CmdStan enables these whenever the make variable is non-empty, so an empty
-    # assignment is the only way to ask for one to be off.
+    # CmdStan treats any nonempty make value as enabled.
     requested <- nzchar(assignments[[option_name]])
     if (requested != isTRUE(cpp_option_value(exe_info, option_name))) {
       return(FALSE)

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -89,6 +89,41 @@ merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
   cpp_options
 }
 
+# The options a compilation would actually be run with, normalized so that a
+# request can be compared against what an executable was built with. Names are
+# lower-cased because CmdStanR input and executable metadata disagree on case;
+# header entries are dropped because header identity is tracked separately and
+# forces a rebuild on its own; NULL and FALSE are dropped because neither asks
+# make for anything; and values are compared as strings so that TRUE and "TRUE"
+# are not read as different requests.
+normalized_cpp_options <- function(cpp_options) {
+  normalized <- list()
+  for (option_name in names(cpp_options)) {
+    value <- cpp_options[[option_name]]
+    if (tolower(option_name) %in% c("user_header", "stan_version")) {
+      next
+    }
+    if (is.null(value) || isFALSE(value)) {
+      next
+    }
+    normalized[[tolower(option_name)]] <- as.character(value)
+  }
+  if (length(normalized) == 0) {
+    return(normalized)
+  }
+  normalized[order(names(normalized))]
+}
+
+# Whether an executable built with `recorded` would differ from one built with
+# `requested`. Symmetric, because cpp_options are one-shot: a recompilation
+# carrying `requested` would drop anything `recorded` holds that it does not.
+cpp_options_disagree <- function(requested, recorded) {
+  !identical(
+    normalized_cpp_options(requested),
+    normalized_cpp_options(recorded)
+  )
+}
+
 # convert to compile flags --------------------
 # from list(flag1=TRUE, flag2=FALSE) to "FLAG1=TRUE\nFLAG2=FALSE"
 cpp_options_to_compile_flags <- function(cpp_options) {

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -225,8 +225,22 @@ resolve_user_header <- function(user_header,
                                 cpp_options,
                                 cpp_options_supplied = TRUE,
                                 previous = NULL) {
-  from_upper <- cpp_options[["USER_HEADER"]]
-  from_lower <- cpp_options[["user_header"]]
+  # Positions rather than [[name]]: every duplicate reaches make and a makefile
+  # takes the last, so the last occurrence of a spelling is the one that would
+  # have been used. Reading by name takes the first, and removing by name drops
+  # only one occurrence, which would leave the others to reach make alongside
+  # the header selected here.
+  upper_at <- which(names(cpp_options) == "USER_HEADER")
+  lower_at <- which(names(cpp_options) == "user_header")
+  last_of <- function(positions) {
+    if (length(positions) == 0) {
+      NULL
+    } else {
+      cpp_options[[positions[[length(positions)]]]]
+    }
+  }
+  from_upper <- last_of(upper_at)
+  from_lower <- last_of(lower_at)
   conflict <- NULL
   spelling <- "USER_HEADER"
 
@@ -253,8 +267,12 @@ resolve_user_header <- function(user_header,
   if (!is.null(header)) {
     checkmate::assert_string(header, .var.name = "user_header")
   }
-  cpp_options[["USER_HEADER"]] <- NULL
-  cpp_options[["user_header"]] <- NULL
+  # Guarded because negative indexing by an empty vector returns nothing at all
+  # rather than everything.
+  header_at <- c(upper_at, lower_at)
+  if (length(header_at) > 0) {
+    cpp_options <- cpp_options[-header_at]
+  }
 
   list(
     user_header = header,

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -105,7 +105,7 @@ merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
 # arguments, though not its position among the assignments. Header entries are
 # dropped: header identity is tracked separately and forces a rebuild on its
 # own.
-normalized_cpp_options <- function(cpp_options) {
+parsed_cpp_options <- function(cpp_options) {
   assignments <- list()
   opaque <- character()
   for (flag in cpp_options_to_compile_flags(cpp_options)) {
@@ -119,13 +119,19 @@ normalized_cpp_options <- function(cpp_options) {
     }
     assignments[[option_name]] <- sub("^[^=]*=", "", flag)
   }
+  list(assignments = assignments, opaque = opaque)
+}
+
+normalized_cpp_options <- function(cpp_options) {
+  parsed <- parsed_cpp_options(cpp_options)
   reduced <- character()
-  if (length(assignments) > 0) {
+  if (length(parsed$assignments) > 0) {
     reduced <- paste0(
-      names(assignments), "=", unlist(assignments, use.names = FALSE)
+      names(parsed$assignments), "=",
+      unlist(parsed$assignments, use.names = FALSE)
     )
   }
-  c(sort(reduced), opaque)
+  c(sort(reduced), parsed$opaque)
 }
 
 # Whether an executable built with `recorded` would differ from one built with
@@ -345,11 +351,21 @@ exe_info_reflects_cpp_options <- function(exe_info, cpp_options) {
   }
   if (is.null(cpp_options)) return(TRUE)
 
-  cpp_options <- exe_info_style_cpp_options(cpp_options)[tolower(names(cpp_options))]
-  overlap <- names(cpp_options)[names(cpp_options) %in% names(exe_info)]
+  # Only the assignments the binary can speak to. Anything else is left alone
+  # rather than reported as a mismatch: an adopted executable carries no record
+  # of what produced it, so an unreportable option is unverifiable, not wrong.
+  # Read through parsed_cpp_options() so that unnamed raw assignments, duplicate
+  # names and vector values mean here what they mean to make.
+  assignments <- parsed_cpp_options(cpp_options)$assignments
+  reported <- intersect(names(assignments), tolower(names(exe_info)))
 
-  if (length(overlap) == 0) TRUE else all.equal(
-    exe_info[overlap],
-    cpp_options[overlap]
-  )
+  for (option_name in reported) {
+    # CmdStan enables these whenever the make variable is non-empty, so an empty
+    # assignment is the only way to ask for one to be off.
+    requested <- nzchar(assignments[[option_name]])
+    if (requested != isTRUE(cpp_option_value(exe_info, option_name))) {
+      return(FALSE)
+    }
+  }
+  TRUE
 }

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -144,6 +144,80 @@ validate_cpp_options <- function(cpp_options) {
   cpp_options
 }
 
+# user headers ---------------------------------------------------------
+# Decide which user header a compilation should use and reduce cpp_options to a
+# single, unambiguous source for it.
+#
+# Precedence:
+#   1. an explicit non-NULL `user_header` argument;
+#   2. an explicit `user_header = NULL`, which clears any header carried in
+#      cpp_options as well;
+#   3. only when the argument is omitted, cpp_options -- USER_HEADER ahead of
+#      user_header whichever order they appear in -- and then `previous`, the
+#      header the model already holds.
+#
+# `supplied` is what makes (2) expressible at all: `user_header = NULL` is also
+# the default, so the value alone cannot separate "cleared" from "not
+# mentioned". `cpp_options_supplied` separates a header passed in the same call,
+# a conflict worth warning about, from one inherited from an earlier call.
+#
+# Both spellings are always dropped from cpp_options; callers reinsert the
+# selected header under `spelling`, in whatever form they store. The header is
+# returned as supplied, neither made absolute nor WSL-safe, because callers
+# differ on which they need.
+resolve_user_header <- function(user_header,
+                                supplied,
+                                cpp_options,
+                                cpp_options_supplied = TRUE,
+                                previous = NULL) {
+  from_upper <- cpp_options[["USER_HEADER"]]
+  from_lower <- cpp_options[["user_header"]]
+  conflict <- NULL
+  spelling <- "USER_HEADER"
+
+  if (supplied) {
+    if (cpp_options_supplied && (!is.null(from_upper) || !is.null(from_lower))) {
+      conflict <- "argument"
+    }
+    header <- user_header
+  } else if (!is.null(from_upper)) {
+    if (!is.null(from_lower)) {
+      conflict <- "cpp_options"
+    }
+    header <- from_upper
+  } else if (!is.null(from_lower)) {
+    header <- from_lower
+    spelling <- "user_header"
+  } else {
+    header <- previous
+  }
+
+  # Shape is checked wherever a header is accepted; whether it exists is checked
+  # only when compiling, so that a header created between construction and
+  # $compile() still works.
+  if (!is.null(header)) {
+    checkmate::assert_string(header, .var.name = "user_header")
+  }
+  cpp_options[["USER_HEADER"]] <- NULL
+  cpp_options[["user_header"]] <- NULL
+
+  list(
+    user_header = header,
+    spelling = spelling,
+    cpp_options = cpp_options,
+    conflict = conflict
+  )
+}
+
+warn_user_header_conflict <- function(conflict) {
+  if (identical(conflict, "argument")) {
+    warning("User header specified both via user_header argument and via cpp_options arguments")
+  } else if (identical(conflict, "cpp_options")) {
+    warning('User header specified both via cpp_options[["USER_HEADER"]] and cpp_options[["user_header"]].', call. = FALSE)
+  }
+  invisible(NULL)
+}
+
 # check specific options for validity ---------------------------------
 cpp_option_value <- function(cpp_options, option) {
   # CmdStanR input and executable metadata can use different casing. Prefer

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -73,6 +73,22 @@ model_compile_info <- function(exe_file, version) {
   info
 }
 
+# Merge the options an executable reports about itself into the options already
+# recorded for it. STAN_VERSION describes the toolchain rather than a make
+# option, and a flag the executable reports as FALSE was never set at all, so
+# recording it would pass "FLAG=FALSE" to make, which CmdStan reads as enabling
+# the flag.
+merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
+  for (option_name in names(exe_info)) {
+    value <- exe_info[[option_name]]
+    if (tolower(option_name) != "stan_version" &&
+        (!is.logical(value) || isTRUE(value))) {
+      cpp_options[[option_name]] <- value
+    }
+  }
+  cpp_options
+}
+
 # convert to compile flags --------------------
 # from list(flag1=TRUE, flag2=FALSE) to "FLAG1=TRUE\nFLAG2=FALSE"
 cpp_options_to_compile_flags <- function(cpp_options) {

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -96,13 +96,15 @@ merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
 # than reading the list itself: what make is handed is what decides whether two
 # builds differ, and any second reading of these lists drifts from the first.
 # Named and unnamed entries, duplicate names, vector values that expand into
-# several assignments and NULLs that expand into none are all already resolved
-# by the time the flags exist.
+# several assignments and NULLs that expand into an empty NAME= are all already
+# resolved by the time the flags exist.
 #
 # Assignments are reduced last-wins, as a makefile does, and compared by
 # lower-cased name so that spelling is not a difference. Anything that is not an
-# assignment is opaque, so it keeps its position. Header entries are dropped:
-# header identity is tracked separately and forces a rebuild on its own.
+# assignment is opaque and keeps its order relative to the other opaque
+# arguments, though not its position among the assignments. Header entries are
+# dropped: header identity is tracked separately and forces a rebuild on its
+# own.
 normalized_cpp_options <- function(cpp_options) {
   assignments <- list()
   opaque <- character()

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -239,22 +239,32 @@ resolve_user_header <- function(user_header,
       cpp_options[[positions[[length(positions)]]]]
     }
   }
+  # Presence comes from the positions, never from the value, because NULL is a
+  # value an entry can hold rather than a way of being absent. An entry whose
+  # final occurrence is NULL stands for an explicit `USER_HEADER=` -- the
+  # assignment that would reach make if the resolver did not strip it, and the
+  # one make would take as clearing anything set before it. Reading presence
+  # off the value instead treated that as "no header given" and fell back to
+  # the persisted one, so the compile ran with no header while the object went
+  # on describing the old one. Matches cpp_option_value() below.
+  has_upper <- length(upper_at) > 0
+  has_lower <- length(lower_at) > 0
   from_upper <- last_of(upper_at)
   from_lower <- last_of(lower_at)
   conflict <- NULL
   spelling <- "USER_HEADER"
 
   if (supplied) {
-    if (cpp_options_supplied && (!is.null(from_upper) || !is.null(from_lower))) {
+    if (cpp_options_supplied && (has_upper || has_lower)) {
       conflict <- "argument"
     }
     header <- user_header
-  } else if (!is.null(from_upper)) {
-    if (!is.null(from_lower)) {
+  } else if (has_upper) {
+    if (has_lower) {
       conflict <- "cpp_options"
     }
     header <- from_upper
-  } else if (!is.null(from_lower)) {
+  } else if (has_lower) {
     header <- from_lower
     spelling <- "user_header"
   } else {

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -90,28 +90,44 @@ merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
 }
 
 # The options a compilation would actually be run with, normalized so that a
-# request can be compared against what an executable was built with. Names are
-# lower-cased because CmdStanR input and executable metadata disagree on case;
-# header entries are dropped because header identity is tracked separately and
-# forces a rebuild on its own; NULL and FALSE are dropped because neither asks
-# make for anything; and values are compared as strings so that TRUE and "TRUE"
-# are not read as different requests.
+# request can be compared against what an executable was built with. This has to
+# follow cpp_options_to_compile_flags(), because what make is given is what
+# decides whether two builds differ:
+#
+#   - names are lower-cased, since CmdStanR input and executable metadata
+#     disagree on case, and values compared as strings so TRUE and "TRUE" are
+#     not read as two different requests;
+#   - an unnamed entry is a raw make argument and is compared as written;
+#   - a later entry with the same name wins, because every duplicate reaches
+#     make and a makefile takes the last;
+#   - only NULL is omission. FALSE is *not*: it reaches make as
+#     STAN_THREADS=FALSE, and CmdStan enables some options whenever their make
+#     variable is non-empty, so requesting FALSE can change the executable;
+#   - header entries are dropped, header identity being tracked separately and
+#     forcing a rebuild on its own.
 normalized_cpp_options <- function(cpp_options) {
-  normalized <- list()
-  for (option_name in names(cpp_options)) {
-    value <- cpp_options[[option_name]]
+  named <- list()
+  raw <- character()
+  for (i in seq_along(cpp_options)) {
+    option_name <- names(cpp_options)[i]
+    value <- cpp_options[[i]]
+    if (is.null(option_name) || is.na(option_name) || !nzchar(option_name)) {
+      raw <- c(raw, as.character(value))
+      next
+    }
     if (tolower(option_name) %in% c("user_header", "stan_version")) {
       next
     }
-    if (is.null(value) || isFALSE(value)) {
+    if (is.null(value)) {
       next
     }
-    normalized[[tolower(option_name)]] <- as.character(value)
+    named[[tolower(option_name)]] <- paste(as.character(value), collapse = ",")
   }
-  if (length(normalized) == 0) {
-    return(normalized)
+  entries <- character()
+  if (length(named) > 0) {
+    entries <- paste0(names(named), "=", unlist(named, use.names = FALSE))
   }
-  normalized[order(names(normalized))]
+  sort(c(raw, entries))
 }
 
 # Whether an executable built with `recorded` would differ from one built with

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -90,44 +90,40 @@ merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
 }
 
 # The options a compilation would actually be run with, normalized so that a
-# request can be compared against what an executable was built with. This has to
-# follow cpp_options_to_compile_flags(), because what make is given is what
-# decides whether two builds differ:
+# request can be compared against what an executable was built with.
 #
-#   - names are lower-cased, since CmdStanR input and executable metadata
-#     disagree on case, and values compared as strings so TRUE and "TRUE" are
-#     not read as two different requests;
-#   - an unnamed entry is a raw make argument and is compared as written;
-#   - a later entry with the same name wins, because every duplicate reaches
-#     make and a makefile takes the last;
-#   - only NULL is omission. FALSE is *not*: it reaches make as
-#     STAN_THREADS=FALSE, and CmdStan enables some options whenever their make
-#     variable is non-empty, so requesting FALSE can change the executable;
-#   - header entries are dropped, header identity being tracked separately and
-#     forcing a rebuild on its own.
+# Deliberately canonicalizes the output of cpp_options_to_compile_flags() rather
+# than reading the list itself: what make is handed is what decides whether two
+# builds differ, and any second reading of these lists drifts from the first.
+# Named and unnamed entries, duplicate names, vector values that expand into
+# several assignments and NULLs that expand into none are all already resolved
+# by the time the flags exist.
+#
+# Assignments are reduced last-wins, as a makefile does, and compared by
+# lower-cased name so that spelling is not a difference. Anything that is not an
+# assignment is opaque, so it keeps its position. Header entries are dropped:
+# header identity is tracked separately and forces a rebuild on its own.
 normalized_cpp_options <- function(cpp_options) {
-  named <- list()
-  raw <- character()
-  for (i in seq_along(cpp_options)) {
-    option_name <- names(cpp_options)[i]
-    value <- cpp_options[[i]]
-    if (is.null(option_name) || is.na(option_name) || !nzchar(option_name)) {
-      raw <- c(raw, as.character(value))
+  assignments <- list()
+  opaque <- character()
+  for (flag in cpp_options_to_compile_flags(cpp_options)) {
+    if (!grepl("^[A-Za-z_][A-Za-z0-9_]*=", flag)) {
+      opaque <- c(opaque, flag)
       next
     }
-    if (tolower(option_name) %in% c("user_header", "stan_version")) {
+    option_name <- tolower(sub("=.*$", "", flag))
+    if (option_name %in% c("user_header", "stan_version")) {
       next
     }
-    if (is.null(value)) {
-      next
-    }
-    named[[tolower(option_name)]] <- paste(as.character(value), collapse = ",")
+    assignments[[option_name]] <- sub("^[^=]*=", "", flag)
   }
-  entries <- character()
-  if (length(named) > 0) {
-    entries <- paste0(names(named), "=", unlist(named, use.names = FALSE))
+  reduced <- character()
+  if (length(assignments) > 0) {
+    reduced <- paste0(
+      names(assignments), "=", unlist(assignments, use.names = FALSE)
+    )
   }
-  sort(c(raw, entries))
+  c(sort(reduced), opaque)
 }
 
 # Whether an executable built with `recorded` would differ from one built with

--- a/R/model.R
+++ b/R/model.R
@@ -496,10 +496,13 @@ NULL
 #'   the model object is created (or when `$compile()` is called) and stored as
 #'   absolute paths, so subsequent changes to the working directory do not
 #'   affect them. If `$compile()` is called again without `include_paths`, the
-#'   paths used for the previous compilation are reused.
+#'   most recently supplied paths are reused.
 #' @param user_header (string) The path to a C++ file (with a .hpp extension)
 #'   to compile with the Stan model. If `$compile()` is called again without
-#'   `user_header`, the header used for the previous compilation is reused.
+#'   `user_header`, the most recently supplied header is reused, and changing
+#'   it forces recompilation. Pass `user_header = NULL` to compile without one.
+#'   A header can also be supplied via `cpp_options` as `USER_HEADER` or
+#'   `user_header`; the `user_header` argument takes precedence over both.
 #' @param cpp_options (list) Any makefile options to be used when compiling the
 #'   model (`stan_threads`, `stan_mpi`, `stan_opencl`, etc.). Anything you would
 #'   otherwise write in the `make/local` file. For an example of using threading
@@ -738,6 +741,14 @@ compile <- function(quiet = TRUE,
     }
   }
 
+  # Evaluated here rather than in the tail: cmdstan_version() is not infallible
+  # despite being an accessor, because set_cmdstan_path() can leave PATH set
+  # while VERSION stays NULL, and in that state stanc and make both run but this
+  # errors. Staging it removes a failure point after the executable is already
+  # installed. It cannot be hoisted above the no-op return, which today never
+  # reaches this call at all.
+  compiled_cmdstan_version <- cmdstan_version()
+
   if (os_is_wsl() && (compile_model_methods || compile_standalone)) {
     warning("Additional model methods and standalone functions are not ",
             "currently available with WSLv1 CmdStan and will not be compiled.",
@@ -862,6 +873,7 @@ compile <- function(quiet = TRUE,
     private$user_header_dirty_ <- FALSE
     private$hpp_file_ <- hpp_file
     private$model_methods_env_ <- model_methods_env
+    private$cpp_options_ <- cpp_options
     private$precompile_cpp_options_ <- NULL
     private$precompile_stanc_options_ <- NULL
     private$precompile_include_paths_ <- NULL
@@ -871,9 +883,12 @@ compile <- function(quiet = TRUE,
     }
   } # End - if(!dry_run)
 
-  private$cmdstan_version_ <- cmdstan_version()
+  # Both are exceptions to the rule that state describing the compiled artifact
+  # is committed only above: during a dry run they are also the configured
+  # destination and the toolchain version, so they are assigned on a dry run and
+  # on success -- and, for exe_file_, on a no-op -- but never on a failure.
+  private$cmdstan_version_ <- compiled_cmdstan_version
   private$exe_file_ <- exe
-  private$cpp_options_ <- cpp_options
 
   if (!dry_run) {
     if (compile_model_methods) {

--- a/R/model.R
+++ b/R/model.R
@@ -523,8 +523,10 @@ NULL
 #'   **Note:** For historical reasons, CmdStan treats some options as enabled
 #'   whenever their `Make` variable is non-empty. In particular, setting
 #'   `stan_threads` to `FALSE` passes `STAN_THREADS=FALSE` to `Make`, which
-#'   still enables threading! To leave threading disabled, simply omit
-#'   `stan_threads` entirely or set it to `NULL`.
+#'   still enables threading! To leave threading disabled, either omit
+#'   `stan_threads` entirely, which leaves any setting in `make/local` in
+#'   place, or set it to `NULL`, which passes an empty `STAN_THREADS=` and so
+#'   overrides `make/local` too.
 #' @param stanc_options (list) Any Stan-to-C++ transpiler options to be used
 #'   when compiling the model. See the **Examples** section below as well as the
 #'   [`stanc` chapter of the CmdStan User's

--- a/R/model.R
+++ b/R/model.R
@@ -242,6 +242,7 @@ CmdStanModel <- R6::R6Class(
     cpp_options_ = list(),
     stanc_options_ = list(),
     include_paths_ = NULL,
+    user_header_ = NULL,
     using_user_header_ = FALSE,
     precompile_cpp_options_ = NULL,
     precompile_stanc_options_ = NULL,
@@ -268,6 +269,7 @@ CmdStanModel <- R6::R6Class(
             !is.null(args$cpp_options[["user_header"]])) {
           private$using_user_header_ <- TRUE
         }
+        private$user_header_ <- args$user_header
         if (is.null(args$include_paths) && any(grepl("#include" , private$stan_code_))) {
           private$precompile_include_paths_ <- dirname(private$stan_file_)
         } else {
@@ -305,11 +307,7 @@ CmdStanModel <- R6::R6Class(
       invisible(self)
     },
     include_paths = function() {
-      if (length(self$exe_file()) > 0 && file.exists(self$exe_file())) {
-        return(private$include_paths_)
-      } else {
-        return(private$precompile_include_paths_)
-      }
+      private$include_paths_ %||% private$precompile_include_paths_
     },
     code = function() {
       if (length(private$stan_code_) == 0) {
@@ -483,9 +481,11 @@ NULL
 #'   program. Relative paths are resolved against the working directory when
 #'   the model object is created (or when `$compile()` is called) and stored as
 #'   absolute paths, so subsequent changes to the working directory do not
-#'   affect them.
+#'   affect them. If `$compile()` is called again without `include_paths`, the
+#'   paths used for the previous compilation are reused.
 #' @param user_header (string) The path to a C++ file (with a .hpp extension)
-#'   to compile with the Stan model.
+#'   to compile with the Stan model. If `$compile()` is called again without
+#'   `user_header`, the header used for the previous compilation is reused.
 #' @param cpp_options (list) Any makefile options to be used when compiling the
 #'   model (`stan_threads`, `stan_mpi`, `stan_opencl`, etc.). Anything you would
 #'   otherwise write in the `make/local` file. For an example of using threading
@@ -594,8 +594,8 @@ compile <- function(quiet = TRUE,
     stanc_options <- private$precompile_stanc_options_
   }
   stanc_options <- assert_valid_stanc_options(stanc_options)
-  if (is.null(include_paths) && !is.null(private$precompile_include_paths_)) {
-    include_paths <- private$precompile_include_paths_
+  if (is.null(include_paths)) {
+    include_paths <- private$include_paths_ %||% private$precompile_include_paths_
   }
   private$include_paths_ <- resolve_path(include_paths)
   include_paths <- private$include_paths_
@@ -641,6 +641,11 @@ compile <- function(quiet = TRUE,
   } else if (!is.null(cpp_options[["user_header"]])) {
     user_header <- cpp_options[["user_header"]]
     cpp_options[["user_header"]] <- wsl_safe_path(absolute_path(cpp_options[["user_header"]]))
+  } else if (!is.null(private$user_header_)) {
+    # the header the model was last compiled with, or the one supplied to
+    # cmdstan_model() if it has not been compiled yet
+    user_header <- private$user_header_
+    cpp_options[["USER_HEADER"]] <- wsl_safe_path(absolute_path(user_header))
   }
 
 
@@ -804,6 +809,10 @@ compile <- function(quiet = TRUE,
     private$stan_code_ <- readLines(temp_stan_file)
     private$variables_ <- NULL
     private$using_user_header_ <- using_user_header
+    private$user_header_ <- user_header
+    private$precompile_cpp_options_ <- NULL
+    private$precompile_stanc_options_ <- NULL
+    private$precompile_include_paths_ <- NULL
 
     if (compile_standalone) {
       expose_stan_functions(self$functions, verbose = !quiet)
@@ -816,9 +825,6 @@ compile <- function(quiet = TRUE,
   private$cmdstan_version_ <- cmdstan_version()
   private$exe_file_ <- exe
   private$cpp_options_ <- cpp_options
-  private$precompile_cpp_options_ <- NULL
-  private$precompile_stanc_options_ <- NULL
-  private$precompile_include_paths_ <- NULL
 
   if (!dry_run) {
     if (compile_model_methods) {

--- a/R/model.R
+++ b/R/model.R
@@ -946,6 +946,15 @@ compile <- function(quiet = TRUE,
   private$exe_file_ <- exe
 
   if (!dry_run) {
+    # Learn options the executable reports that were never passed, such as ones
+    # inherited from make/local. Ahead of the exposures, which can fail.
+    exe_info <- tryCatch(
+      model_compile_info(exe, self$cmdstan_version()),
+      error = function(e) NULL
+    )
+    private$cpp_options_ <-
+      merge_exe_info_cpp_options(private$cpp_options_, exe_info)
+
     # Run optional exposure only after executable state is committed.
     if (compile_standalone) {
       expose_stan_functions(self$functions, verbose = !quiet)

--- a/R/model.R
+++ b/R/model.R
@@ -304,7 +304,8 @@ CmdStanModel <- R6::R6Class(
         private$include_paths_ <-
           private$precompile_include_paths_ %||% resolve_path(args$include_paths)
       }
-      if (!is.null(stan_file) && compile) {
+      compiled_here <- !is.null(stan_file) && compile
+      if (compiled_here) {
         self$compile(...)
       }
 
@@ -313,7 +314,9 @@ CmdStanModel <- R6::R6Class(
       # in the future, will be set only if/when we have a binary
       # as the version the model was compiled with
       private$cmdstan_version_ <- cmdstan_version()
-      if (length(self$exe_file()) > 0 && file.exists(self$exe_file())) {
+      # compile() reads the metadata itself on both of its exits.
+      if (!compiled_here &&
+          length(self$exe_file()) > 0 && file.exists(self$exe_file())) {
         private$cpp_options_ <- merge_exe_info_cpp_options(
           private$cpp_options_,
           model_compile_info(self$exe_file(), self$cmdstan_version())

--- a/R/model.R
+++ b/R/model.R
@@ -631,7 +631,6 @@ compile <- function(quiet = TRUE,
     }
 
     cpp_options[["USER_HEADER"]] <- wsl_safe_path(absolute_path(user_header))
-    private$using_user_header_ <- TRUE
   } else if (!is.null(cpp_options[["USER_HEADER"]])) {
     if (!is.null(cpp_options[["user_header"]])) {
       warning('User header specified both via cpp_options[["USER_HEADER"]] and cpp_options[["user_header"]].', call. = FALSE)
@@ -639,15 +638,14 @@ compile <- function(quiet = TRUE,
 
     user_header <- cpp_options[["USER_HEADER"]]
     cpp_options[["USER_HEADER"]] <- wsl_safe_path(absolute_path(cpp_options[["USER_HEADER"]]))
-    private$using_user_header_ <- TRUE
   } else if (!is.null(cpp_options[["user_header"]])) {
     user_header <- cpp_options[["user_header"]]
     cpp_options[["user_header"]] <- wsl_safe_path(absolute_path(cpp_options[["user_header"]]))
-    private$using_user_header_ <- TRUE
   }
 
 
-  if (!is.null(user_header)) {
+  using_user_header <- !is.null(user_header)
+  if (using_user_header) {
     stanc_options[["allow-undefined"]] <- TRUE
     user_header <- absolute_path(user_header) # As mentioned above, just absolute, not wsl_safe_path()
     if (!file.exists(user_header)) {
@@ -719,19 +717,13 @@ compile <- function(quiet = TRUE,
   }
   stanc_inc_paths <- include_paths_stanc3_args(include_paths, direct_call = TRUE)
   stancflags_standalone <- c("--standalone-functions", stanc_inc_paths, stancflags_direct)
-  self$functions$hpp_code <- get_standalone_hpp(temp_stan_file, stancflags_standalone)
+  standalone_hpp_code <- get_standalone_hpp(temp_stan_file, stancflags_standalone)
   private$model_methods_env_ <- new.env()
   private$model_methods_env_$hpp_code_ <- get_standalone_hpp(temp_stan_file, c(stanc_inc_paths, stancflags_direct))
-  self$functions$external <- !is.null(user_header)
-  self$functions$existing_exe <- FALSE
 
   stancflags_val <- paste0("STANCFLAGS += ", stancflags_val, paste0(" ", stancflags_combined, collapse = " "))
 
   if (!dry_run) {
-
-    if (compile_standalone) {
-      expose_stan_functions(self$functions, verbose = !quiet)
-    }
 
     withr::with_envvar(
       c("HOME" = short_path(Sys.getenv("HOME"))),
@@ -799,6 +791,22 @@ compile <- function(quiet = TRUE,
         args = c("chmod", "+x", wsl_safe_path(exe)),
         error_on_status = FALSE
       )
+    }
+
+    # The new executable is in place, so everything derived from the Stan
+    # program that was just compiled can be committed. A dry run or a failed
+    # compilation leaves the previously compiled state untouched. (#1228)
+    rm(list = ls(self$functions, all.names = TRUE), envir = self$functions)
+    self$functions$compiled <- FALSE
+    self$functions$hpp_code <- standalone_hpp_code
+    self$functions$external <- using_user_header
+    self$functions$existing_exe <- FALSE
+    private$stan_code_ <- readLines(temp_stan_file)
+    private$variables_ <- NULL
+    private$using_user_header_ <- using_user_header
+
+    if (compile_standalone) {
+      expose_stan_functions(self$functions, verbose = !quiet)
     }
 
     writeLines(private$model_methods_env_$hpp_code_,

--- a/R/model.R
+++ b/R/model.R
@@ -833,9 +833,11 @@ compile <- function(quiet = TRUE,
         # the symmetric comparison.
         built_options <- private$built_cpp_options_
         inherited <- merge_exe_info_cpp_options(list(), exe_info)
-        inherited <- inherited[
-          !tolower(names(inherited)) %in% tolower(names(built_options))
-        ]
+        # Which options were passed explicitly is a question about what make was
+        # given, not about the shape of the list: an unnamed "STAN_THREADS=TRUE"
+        # is as explicit as a named entry, and names() cannot see it.
+        explicit <- names(parsed_cpp_options(built_options)$assignments)
+        inherited <- inherited[!tolower(names(inherited)) %in% explicit]
         # Explicit options are appended last because cpp_options reach make on
         # the command line, which overrides make/local.
         options_mismatch <- cpp_options_disagree(
@@ -849,14 +851,8 @@ compile <- function(quiet = TRUE,
         # as wrong, and warning whenever provenance is unknown would fire on
         # ordinary reuse. Recording provenance beside the executable is the
         # fix (#1238).
-        #
-        # model_compile_info() reports upper-case names while
-        # exe_info_reflects_cpp_options() compares lower-case ones, so without
-        # aligning them the comparison finds no overlap and always agrees.
-        reported <- exe_info
-        names(reported) <- tolower(names(reported))
         options_mismatch <-
-          !isTRUE(exe_info_reflects_cpp_options(reported, cpp_options))
+          !isTRUE(exe_info_reflects_cpp_options(exe_info, cpp_options))
       }
     }
 

--- a/R/model.R
+++ b/R/model.R
@@ -686,18 +686,21 @@ compile <- function(quiet = TRUE,
     stanc_options[["allow-undefined"]] <- TRUE
     # Keep user_header as a host path for the WSL1 file check below.
     user_header <- resolve_path(user_header)
-    if (!file.exists(user_header)) {
-      stop(paste0("User header file '", user_header, "' does not exist."), call. = FALSE)
-    }
-    cpp_options[[resolved_header$spelling]] <- wsl_safe_path(user_header)
   }
 
-  # Save the request before compiling so a failed build can be retried.
+  # Save the request before anything can fail so a failed build can be retried.
   # Keep the dirty flag set until a build succeeds.
   private$user_header_dirty_ <- isTRUE(private$user_header_dirty_) ||
     !same_path(user_header, private$user_header_)
   private$user_header_ <- user_header
   private$using_user_header_ <- using_user_header
+
+  if (using_user_header) {
+    if (!file.exists(user_header)) {
+      stop(paste0("User header file '", user_header, "' does not exist."), call. = FALSE)
+    }
+    cpp_options[[resolved_header$spelling]] <- wsl_safe_path(user_header)
+  }
 
   # Do not adopt an executable from a new destination. Its generated C++ and
   # metadata may not match this object.

--- a/R/model.R
+++ b/R/model.R
@@ -618,6 +618,10 @@ compile <- function(quiet = TRUE,
   if (length(cpp_options) == 0 && !is.null(private$precompile_cpp_options_)) {
     cpp_options <- private$precompile_cpp_options_
   }
+  # Distinct from cpp_options_supplied, which is only about whether this call
+  # carried a conflicting header: options held from cmdstan_model(compile =
+  # FALSE) did not arrive with this call but are still the caller's intent.
+  cpp_options_available <- length(cpp_options) > 0
   if (length(stanc_options) == 0 && !is.null(private$precompile_stanc_options_)) {
     stanc_options <- private$precompile_stanc_options_
   }
@@ -726,13 +730,13 @@ compile <- function(quiet = TRUE,
     # stan_threads makes assert_valid_threads() run a threaded executable
     # single-threaded.
     recorded_cpp_options <-
-      if (cpp_options_supplied) cpp_options else private$cpp_options_
+      if (cpp_options_available) cpp_options else private$cpp_options_
 
     # Asking the executable about itself. Best effort, because
     # model_compile_info() runs it and errors outright rather than returning a
     # status when the file is not runnable.
     exe_info <- NULL
-    if (cpp_options_supplied || length(private$exe_file_) == 0) {
+    if (cpp_options_available || length(private$exe_file_) == 0) {
       exe_info <- tryCatch(
         model_compile_info(exe, self$cmdstan_version()),
         error = function(e) NULL
@@ -745,20 +749,15 @@ compile <- function(quiet = TRUE,
     # STAN_THREADS, runs single-threaded. Rebuilding on a mismatch is the real
     # fix and is still outstanding (see the skipped tests in
     # test-model-recompile-logic.R); until then, say so.
-    if (cpp_options_supplied && length(exe_info) > 0) {
+    options_mismatch <- FALSE
+    if (cpp_options_available && length(exe_info) > 0) {
       # model_compile_info() reports upper-case names while
       # exe_info_reflects_cpp_options() compares lower-case ones, so without
       # aligning them the comparison finds no overlap and always agrees.
       reported <- exe_info
       names(reported) <- tolower(names(reported))
-      if (!isTRUE(exe_info_reflects_cpp_options(reported, cpp_options))) {
-        warning(
-          "The existing executable was not built with the requested ",
-          "'cpp_options' and was not rebuilt, so they will have no effect. ",
-          "Use 'force_recompile = TRUE' to rebuild the model.",
-          call. = FALSE
-        )
-      }
+      options_mismatch <-
+        !isTRUE(exe_info_reflects_cpp_options(reported, cpp_options))
     }
 
     if (length(private$exe_file_) == 0) {
@@ -775,6 +774,17 @@ compile <- function(quiet = TRUE,
     }
     private$cpp_options_ <- recorded_cpp_options
     private$exe_file_ <- exe
+    # Warned about only once the state above is recorded: under
+    # options(warn = 2) this is an error, and raising it earlier would unwind
+    # with the object half-updated.
+    if (options_mismatch) {
+      warning(
+        "The existing executable was not built with the requested ",
+        "'cpp_options' and was not rebuilt, so they will have no effect. ",
+        "Use 'force_recompile = TRUE' to rebuild the model.",
+        call. = FALSE
+      )
+    }
     return(invisible(self))
   } else {
     if (rlang::is_interactive()) {
@@ -918,10 +928,6 @@ compile <- function(quiet = TRUE,
     private$precompile_cpp_options_ <- NULL
     private$precompile_stanc_options_ <- NULL
     private$precompile_include_paths_ <- NULL
-
-    if (compile_standalone) {
-      expose_stan_functions(self$functions, verbose = !quiet)
-    }
   } # End - if(!dry_run)
 
   # Both are exceptions to the rule that state describing the compiled artifact
@@ -932,6 +938,13 @@ compile <- function(quiet = TRUE,
   private$exe_file_ <- exe
 
   if (!dry_run) {
+    # Both exposures are optional and fallible, and both run only once every
+    # field describing the installed executable has been committed -- including
+    # exe_file_ above. Failing here must not leave the object unable to find an
+    # executable that is sitting on disk.
+    if (compile_standalone) {
+      expose_stan_functions(self$functions, verbose = !quiet)
+    }
     if (compile_model_methods) {
       expose_model_methods(env = private$model_methods_env_, verbose = !quiet)
     }

--- a/R/model.R
+++ b/R/model.R
@@ -244,6 +244,10 @@ CmdStanModel <- R6::R6Class(
     include_paths_ = NULL,
     user_header_ = NULL,
     using_user_header_ = FALSE,
+    # Neither configuration nor a description of the executable: a record that
+    # the two have drifted apart. Set by a change of header, cleared only by a
+    # successful executable replacement.
+    user_header_dirty_ = FALSE,
     precompile_cpp_options_ = NULL,
     precompile_stanc_options_ = NULL,
     precompile_include_paths_ = NULL,
@@ -263,13 +267,26 @@ CmdStanModel <- R6::R6Class(
         private$stan_file_ <- resolve_path(stan_file)
         private$stan_code_ <- readLines(stan_file)
         private$model_name_ <- gsub(" ", "_", strip_ext(basename(private$stan_file_)))
-        private$precompile_cpp_options_ <- args$cpp_options %||% list()
         private$precompile_stanc_options_ <- assert_valid_stanc_options(args$stanc_options) %||% list()
-        if (!is.null(args$user_header) || !is.null(args$cpp_options[["USER_HEADER"]]) ||
-            !is.null(args$cpp_options[["user_header"]])) {
-          private$using_user_header_ <- TRUE
+        # The same precedence $compile() applies, run here too: a model created
+        # with compile = FALSE never enters $compile(), so resolving the paths
+        # alone would let an explicit user_header = NULL be ignored. `...`
+        # preserves NULL entries, so names() is the missing() equivalent here.
+        resolved_header <- resolve_user_header(
+          user_header = args$user_header,
+          supplied = "user_header" %in% names(args),
+          cpp_options = args$cpp_options %||% list()
+        )
+        if (!compile) {
+          # Otherwise $compile() receives the original arguments below and warns
+          # once; warning here as well would double up.
+          warn_user_header_conflict(resolved_header$conflict)
         }
-        private$user_header_ <- args$user_header
+        private$precompile_cpp_options_ <- resolved_header$cpp_options
+        # Prepopulating this also keeps the first $compile() from seeing a
+        # change of header and rebuilding an already-current executable.
+        private$user_header_ <- resolve_path(resolved_header$user_header)
+        private$using_user_header_ <- !is.null(resolved_header$user_header)
         if (is.null(args$include_paths) && any(grepl("#include" , private$stan_code_))) {
           private$precompile_include_paths_ <- dirname(private$stan_file_)
         } else {
@@ -584,6 +601,11 @@ compile <- function(quiet = TRUE,
     )
   }
   assert_stan_file_exists(self$stan_file())
+  # Captured before either is reassigned below: an explicit user_header = NULL
+  # is indistinguishable from an omitted argument by value alone, and a header
+  # inherited from an earlier call is not a conflict worth warning about.
+  user_header_supplied <- !missing(user_header)
+  cpp_options_supplied <- length(cpp_options) > 0
   if (length(cpp_options) == 0 && !is.null(private$precompile_cpp_options_)) {
     cpp_options <- private$precompile_cpp_options_
   }
@@ -617,40 +639,43 @@ compile <- function(quiet = TRUE,
     stanc_options[["use-opencl"]] <- TRUE
   }
 
-  # Note that unlike cpp_options["USER_HEADER"], the user_header variable is deliberately
-  # not transformed with wsl_safe_path() as that breaks the check below on WSLv1
-  if (!is.null(user_header)) {
-    if (!is.null(cpp_options[["USER_HEADER"]]) || !is.null(cpp_options[["user_header"]])) {
-      warning("User header specified both via user_header argument and via cpp_options arguments")
-    }
-
-    cpp_options[["USER_HEADER"]] <- wsl_safe_path(absolute_path(user_header))
-  } else if (!is.null(cpp_options[["USER_HEADER"]])) {
-    if (!is.null(cpp_options[["user_header"]])) {
-      warning('User header specified both via cpp_options[["USER_HEADER"]] and cpp_options[["user_header"]].', call. = FALSE)
-    }
-
-    user_header <- cpp_options[["USER_HEADER"]]
-    cpp_options[["USER_HEADER"]] <- wsl_safe_path(absolute_path(cpp_options[["USER_HEADER"]]))
-  } else if (!is.null(cpp_options[["user_header"]])) {
-    user_header <- cpp_options[["user_header"]]
-    cpp_options[["user_header"]] <- wsl_safe_path(absolute_path(cpp_options[["user_header"]]))
-  } else if (!is.null(private$user_header_)) {
+  resolved_header <- resolve_user_header(
+    user_header = user_header,
+    supplied = user_header_supplied,
+    cpp_options = cpp_options,
+    cpp_options_supplied = cpp_options_supplied,
     # the header the model was last compiled with, or the one supplied to
     # cmdstan_model() if it has not been compiled yet
-    user_header <- private$user_header_
-    cpp_options[["USER_HEADER"]] <- wsl_safe_path(absolute_path(user_header))
-  }
-
+    previous = private$user_header_
+  )
+  warn_user_header_conflict(resolved_header$conflict)
+  user_header <- resolved_header$user_header
+  cpp_options <- resolved_header$cpp_options
 
   using_user_header <- !is.null(user_header)
   if (using_user_header) {
     stanc_options[["allow-undefined"]] <- TRUE
-    user_header <- absolute_path(user_header) # As mentioned above, just absolute, not wsl_safe_path()
+    # Note that unlike cpp_options["USER_HEADER"], the user_header variable is
+    # deliberately not transformed with wsl_safe_path() as that breaks the check
+    # below on WSLv1
+    user_header <- resolve_path(user_header)
     if (!file.exists(user_header)) {
       stop(paste0("User header file '", user_header, "' does not exist."), call. = FALSE)
     }
+    cpp_options[[resolved_header$spelling]] <- wsl_safe_path(user_header)
   }
+
+  # Source configuration, so assigned eagerly: it says what the next stanc or
+  # make invocation should use, and a failed compile must not revert it. The
+  # usual route to a failed compile with a new header is a bug in that header,
+  # and a bare retry after fixing it has to build the header the user supplied.
+  #
+  # The divergence marker is latched rather than assigned, because on that retry
+  # the reuse branch resolves back to the same header and nothing looks changed.
+  private$user_header_dirty_ <- isTRUE(private$user_header_dirty_) ||
+    !same_path(user_header, private$user_header_)
+  private$user_header_ <- user_header
+  private$using_user_header_ <- using_user_header
 
   # The resolved destination need not be the executable this object describes,
   # e.g. $compile(dir = ) aimed at a directory that already holds a current
@@ -662,11 +687,14 @@ compile <- function(quiet = TRUE,
   # - the user forced compilation,
   # - the executable does not exist
   # - the destination is not the executable this object already describes
+  # - the user header in use is not the one the executable was built against
   # - the stan model was changed since last compilation
   # - a user header is used and the user header changed since last compilation (#813)
   if (!file.exists(exe)) {
     force_recompile <- TRUE
   } else if (exe_changed) {
+    force_recompile <- TRUE
+  } else if (isTRUE(private$user_header_dirty_)) {
     force_recompile <- TRUE
   } else if (file.exists(self$stan_file())
              && file.mtime(exe) < file.mtime(self$stan_file())) {
@@ -831,8 +859,7 @@ compile <- function(quiet = TRUE,
     self$functions$existing_exe <- FALSE
     private$stan_code_ <- stan_code
     private$variables_ <- NULL
-    private$using_user_header_ <- using_user_header
-    private$user_header_ <- user_header
+    private$user_header_dirty_ <- FALSE
     private$hpp_file_ <- hpp_file
     private$model_methods_env_ <- model_methods_env
     private$precompile_cpp_options_ <- NULL

--- a/R/model.R
+++ b/R/model.R
@@ -244,17 +244,11 @@ CmdStanModel <- R6::R6Class(
     include_paths_ = NULL,
     user_header_ = NULL,
     using_user_header_ = FALSE,
-    # Neither configuration nor a description of the executable: a record that
-    # the two have drifted apart. Set by a change of header, cleared only by a
-    # successful executable replacement.
+    # Build inputs that have changed since the current executable was produced.
     user_header_dirty_ = FALSE,
-    # The same, for a change of include paths.
     include_paths_dirty_ = FALSE,
-    # The cpp_options actually passed to make for the current executable, as
-    # distinct from cpp_options_, which also carries what the binary reports
-    # about itself. Only these would be dropped by a recompilation that omitted
-    # them; anything else the binary has came from make/local and would be
-    # inherited again.
+    # Options this object passed to make. By contrast, cpp_options_ may also
+    # contain values discovered from executable metadata or make/local.
     built_cpp_options_ = NULL,
     precompile_cpp_options_ = NULL,
     precompile_stanc_options_ = NULL,
@@ -276,29 +270,22 @@ CmdStanModel <- R6::R6Class(
         private$stan_code_ <- readLines(stan_file)
         private$model_name_ <- gsub(" ", "_", strip_ext(basename(private$stan_file_)))
         private$precompile_stanc_options_ <- assert_valid_stanc_options(args$stanc_options) %||% list()
-        # The same precedence $compile() applies, run here too: a model created
-        # with compile = FALSE never enters $compile(), so resolving the paths
-        # alone would let an explicit user_header = NULL be ignored. `...`
-        # preserves NULL entries, so names() is the missing() equivalent here.
+        # Resolve headers here so compile = FALSE preserves an explicit NULL.
+        # names(args) distinguishes NULL from an omitted argument.
         resolved_header <- resolve_user_header(
           user_header = args$user_header,
           supplied = "user_header" %in% names(args),
           cpp_options = args$cpp_options %||% list()
         )
         if (!compile) {
-          # Otherwise $compile() receives the original arguments below and warns
-          # once; warning here as well would double up.
+          # compile() reports this conflict when compilation is requested.
           warn_user_header_conflict(resolved_header$conflict)
         }
-        # Deliberately without the header: the resolver strips both spellings
-        # and only $compile() reinserts the selected one. Storing it here would
-        # mean storing a WSL-safe path, which the next $compile() would pick up
-        # as its host-path `user_header` and fail to find on WSLv1 -- the hazard
-        # the comment at the resolver call in $compile() describes. user_header_
-        # below is the single source instead.
+        # Keep only the host path here. Persisting the WSL path would break reuse
+        # on WSL1.
         private$precompile_cpp_options_ <- resolved_header$cpp_options
-        # Prepopulating this also keeps the first $compile() from seeing a
-        # change of header and rebuilding an already-current executable.
+        # Use the header supplied to cmdstan_model() as the baseline for change
+        # detection.
         private$user_header_ <- resolve_path(resolved_header$user_header)
         private$using_user_header_ <- !is.null(resolved_header$user_header)
         if (is.null(args$include_paths) && any(grepl("#include" , private$stan_code_))) {
@@ -614,24 +601,11 @@ NULL
 #' # same as mod <- cmdstan_model(file_pedantic, pedantic = TRUE)
 #' }
 #'
-# The object holds three kinds of state, committed at different moments. The
-# comments through this function explain individual assignments; the rule they
-# are all instances of is:
-#
-#   Source configuration -- what the next build should use. Assigned eagerly and
-#     kept through a failure, because a bare retry after fixing a bad header or
-#     a wrong path has to build what the user last asked for.
-#   Artifact description -- what the executable on disk actually is. Committed
-#     only after that executable has been successfully replaced, so a dry run, a
-#     failed compile, or a failed install can never leave the object describing
-#     a program that was never built. (#1228)
-#   Divergence markers -- a record that the two have drifted apart, which is
-#     neither of the above. Latched rather than assigned, because on a retry the
-#     configuration resolves back to itself and nothing looks changed.
-#
-# exe_file_ and cmdstan_version_ are deliberate exceptions: they are also the
-# configured destination and the toolchain version, so they are assigned on a
-# dry run and on a no-op, but never on a failure.
+# Keep requested build inputs after a failure, but update executable-derived
+# state only after installation succeeds. user_header_dirty_ and
+# include_paths_dirty_ stay set until those inputs are compiled successfully.
+# exe_file_ and cmdstan_version_ also describe dry runs. exe_file_ is updated
+# on no-ops as well.
 compile <- function(quiet = TRUE,
                     dir = NULL,
                     pedantic = FALSE,
@@ -651,17 +625,14 @@ compile <- function(quiet = TRUE,
     )
   }
   assert_stan_file_exists(self$stan_file())
-  # Captured before either is reassigned below: an explicit user_header = NULL
-  # is indistinguishable from an omitted argument by value alone, and a header
-  # inherited from an earlier call is not a conflict worth warning about.
+  # missing() distinguishes an omitted header from user_header = NULL.
   user_header_supplied <- !missing(user_header)
   cpp_options_supplied <- length(cpp_options) > 0
   if (length(cpp_options) == 0 && !is.null(private$precompile_cpp_options_)) {
     cpp_options <- private$precompile_cpp_options_
   }
-  # Distinct from cpp_options_supplied, which is only about whether this call
-  # carried a conflicting header: options held from cmdstan_model(compile =
-  # FALSE) did not arrive with this call but are still the caller's intent.
+  # Precompile options still need mismatch checks even though they were not
+  # passed to this call.
   cpp_options_available <- length(cpp_options) > 0
   if (length(stanc_options) == 0 && !is.null(private$precompile_stanc_options_)) {
     stanc_options <- private$precompile_stanc_options_
@@ -671,16 +642,8 @@ compile <- function(quiet = TRUE,
     include_paths <- private$include_paths_ %||% private$precompile_include_paths_
   }
   resolved_include_paths <- resolve_path(include_paths)
-  # Compared before the assignment below, and latched for the same reason the
-  # header's marker is: a failed compile must keep the new paths, so on the
-  # retry they resolve back to themselves and nothing looks changed. Order is
-  # significant -- it decides which directory a directive resolves from -- so
-  # this is an ordered comparison, which same_path() already does.
-  #
-  # Only a change counts, never the first configuration: a fresh object holds no
-  # paths, so comparing against nothing would force a rebuild in every new R
-  # session. That leaves an executable adopted from an earlier session unproven,
-  # which is documented under `force_recompile`.
+  # Keep this dirty flag set across failed builds. Include-path order affects
+  # resolution. The first configured value is initial state, not a change.
   private$include_paths_dirty_ <- isTRUE(private$include_paths_dirty_) ||
     (length(private$include_paths_) > 0 &&
        !same_path(resolved_include_paths, private$include_paths_))
@@ -712,8 +675,6 @@ compile <- function(quiet = TRUE,
     supplied = user_header_supplied,
     cpp_options = cpp_options,
     cpp_options_supplied = cpp_options_supplied,
-    # the header the model was last compiled with, or the one supplied to
-    # cmdstan_model() if it has not been compiled yet
     previous = private$user_header_
   )
   warn_user_header_conflict(resolved_header$conflict)
@@ -723,9 +684,7 @@ compile <- function(quiet = TRUE,
   using_user_header <- !is.null(user_header)
   if (using_user_header) {
     stanc_options[["allow-undefined"]] <- TRUE
-    # Note that unlike cpp_options["USER_HEADER"], the user_header variable is
-    # deliberately not transformed with wsl_safe_path() as that breaks the check
-    # below on WSLv1
+    # Keep user_header as a host path for the WSL1 file check below.
     user_header <- resolve_path(user_header)
     if (!file.exists(user_header)) {
       stop(paste0("User header file '", user_header, "' does not exist."), call. = FALSE)
@@ -733,22 +692,15 @@ compile <- function(quiet = TRUE,
     cpp_options[[resolved_header$spelling]] <- wsl_safe_path(user_header)
   }
 
-  # Source configuration, so assigned eagerly: it says what the next stanc or
-  # make invocation should use, and a failed compile must not revert it. The
-  # usual route to a failed compile with a new header is a bug in that header,
-  # and a bare retry after fixing it has to build the header the user supplied.
-  #
-  # The divergence marker is latched rather than assigned, because on that retry
-  # the reuse branch resolves back to the same header and nothing looks changed.
+  # Save the request before compiling so a failed build can be retried.
+  # Keep the dirty flag set until a build succeeds.
   private$user_header_dirty_ <- isTRUE(private$user_header_dirty_) ||
     !same_path(user_header, private$user_header_)
   private$user_header_ <- user_header
   private$using_user_header_ <- using_user_header
 
-  # The resolved destination need not be the executable this object describes,
-  # e.g. $compile(dir = ) aimed at a directory that already holds a current
-  # executable. Adopting that binary while keeping this object's generated C++
-  # and metadata would produce a hybrid, so build the model there instead.
+  # Do not adopt an executable from a new destination. Its generated C++ and
+  # metadata may not match this object.
   exe_changed <- length(private$exe_file_) > 0 && !same_path(exe, private$exe_file_)
 
   # compile if:
@@ -780,24 +732,11 @@ compile <- function(quiet = TRUE,
     if (rlang::is_interactive()) {
       message("Model executable is up to date!")
     }
-    # Nothing was compiled, so nothing describing the current executable may be
-    # consumed or overwritten by configuration this call merely proposed.
-    # Options supplied to this call describe an executable that was not built,
-    # so they are deliberately not recorded: assert_valid_threads() and the
-    # OpenCL checks read these back as fact, and a stan_threads the binary
-    # lacks makes a plain $sample() fail with "the model executable was built
-    # with threading enabled", which is false and cannot be worked around
-    # without recompiling. What is already recorded still describes the
-    # executable that exists, so it is carried forward untouched. (#1019)
-    # This object holds the generated C++ for an executable only if it compiled
-    # it. Even then the record is only what was passed to make: options
-    # inherited from make/local never reach $compile() and so were never
-    # recorded, which is why the record alone is not the artifact.
+    # A no-op must not record options that were not compiled into the executable.
+    # hpp_code is present only when this object built the executable.
     built_here <- !is.null(self$functions$hpp_code)
 
-    # Asking the executable about itself. Best effort, because
-    # model_compile_info() runs it and errors outright rather than returning a
-    # status when the file is not runnable.
+    # Treat unreadable executable metadata as unavailable.
     exe_info <- NULL
     if (cpp_options_available || length(private$exe_file_) == 0) {
       exe_info <- tryCatch(
@@ -806,76 +745,47 @@ compile <- function(quiet = TRUE,
       )
     }
 
-    # The two accounts of the executable, combined: metadata reports the
-    # STAN_* flags actually compiled in, including any inherited from
-    # make/local, and the record holds the options metadata cannot report.
-    # Metadata wins where both speak, since it describes the binary; a metadata
-    # FALSE is skipped by the merge, so an explicit NULL survives as an empty
-    # assignment. A failed query leaves the record untouched.
+    # Add options reported as enabled by the executable and keep recorded values
+    # for anything it cannot report.
     recorded_cpp_options <-
       merge_exe_info_cpp_options(private$cpp_options_, exe_info)
 
-    # Recording options the executable does not have would otherwise be a quiet
-    # lie: nothing was rebuilt, so a requested stan_threads produces the
-    # "N thread(s) per chain" message while the binary, compiled without
-    # STAN_THREADS, runs single-threaded. Rebuilding on a mismatch is the real
-    # fix and is still outstanding (see the skipped tests in
-    # test-model-recompile-logic.R); until then, say so.
+    # A no-op cannot apply requested cpp_options. Warn instead of recording them
+    # as fact. It would be preferable to rebuild on mismatch (see #1019).
     options_mismatch <- FALSE
     if (cpp_options_available) {
       if (built_here) {
-        # Options the binary reports but the record never held cannot have come
-        # from $compile(), so they came from make/local -- and a rebuild would
-        # inherit them again. Applying them to both sides keeps an option the
-        # request never mentioned, and never had to, from reading as a change.
-        # Anything the record does hold was passed on the command line and
-        # would be dropped by a rebuild that omits it, so it stays subject to
-        # the symmetric comparison.
+        # Options reported by the executable but absent from built_options came
+        # from make/local, so a rebuild would inherit them again.
         built_options <- private$built_cpp_options_
         inherited <- merge_exe_info_cpp_options(list(), exe_info)
-        # Which options were passed explicitly is a question about what make was
-        # given, not about the shape of the list: an unnamed "STAN_THREADS=TRUE"
-        # is as explicit as a named entry, and names() cannot see it.
+        # Parse make flags so unnamed assignments also count as explicit.
         explicit <- names(parsed_cpp_options(built_options)$assignments)
         inherited <- inherited[!tolower(names(inherited)) %in% explicit]
-        # Explicit options are appended last because cpp_options reach make on
-        # the command line, which overrides make/local.
+        # Command-line options override make/local.
         options_mismatch <- cpp_options_disagree(
           c(inherited, cpp_options),
           c(inherited, built_options)
         )
       } else if (length(exe_info) > 0) {
-        # An adopted executable can only be asked about itself, and it answers
-        # about a handful of STAN_* flags. Options outside that set are left
-        # alone rather than reported as a mismatch: unverifiable is not the same
-        # as wrong, and warning whenever provenance is unknown would fire on
-        # ordinary reuse. Recording provenance beside the executable is the
-        # fix (#1238).
+        # For adopted executables, compare only reported options. The rest are
+        # unknown, not mismatches. It would be preferable to record build
+        # provenance alongside the executable (see #1238).
         options_mismatch <-
           !isTRUE(exe_info_reflects_cpp_options(exe_info, cpp_options))
       }
     }
 
+    # existing_exe means this object has no generated C++ for the executable.
     if (length(private$exe_file_) == 0) {
-      # This object is adopting an executable it did not build: it holds no
-      # generated C++ for it, and the only description of it beyond the request
-      # is what the binary reports about itself.
       self$functions$existing_exe <- TRUE
     } else {
-      # The flag means "we don't hold the generated C++ for this executable",
-      # which is not the same as "this call compiled nothing".
       self$functions$existing_exe <- is.null(self$functions$hpp_code)
     }
     private$cpp_options_ <- recorded_cpp_options
     private$exe_file_ <- exe
-    # Warned about only once the state above is recorded: under
-    # options(warn = 2) this is an error, and raising it earlier would unwind
-    # with the object half-updated.
+    # Update state before warning because warn = 2 turns the warning into an error.
     if (options_mismatch) {
-      # Deliberately not phrased as a claim about how the executable was built:
-      # options inherited from make/local are invisible here unless the binary
-      # reports them, so what is actually known is that the two descriptions
-      # disagree. (#1238)
       warning(
         "The 'cpp_options' recorded or reported for the existing executable ",
         "do not match the ones requested. The executable was not rebuilt, so ",
@@ -891,12 +801,8 @@ compile <- function(quiet = TRUE,
     }
   }
 
-  # Evaluated here rather than in the tail: cmdstan_version() is not infallible
-  # despite being an accessor, because set_cmdstan_path() can leave PATH set
-  # while VERSION stays NULL, and in that state stanc and make both run but this
-  # errors. Staging it removes a failure point after the executable is already
-  # installed. It cannot be hoisted above the no-op return, which today never
-  # reaches this call at all.
+  # Resolve the CmdStan version before replacing the executable because this
+  # lookup can fail.
   compiled_cmdstan_version <- cmdstan_version()
 
   if (os_is_wsl() && (compile_model_methods || compile_standalone)) {
@@ -931,8 +837,6 @@ compile <- function(quiet = TRUE,
   stanc_inc_paths <- include_paths_stanc3_args(include_paths, direct_call = TRUE)
   stancflags_standalone <- c("--standalone-functions", stanc_inc_paths, stancflags_direct)
   standalone_hpp_code <- get_standalone_hpp(temp_stan_file, stancflags_standalone)
-  # Staged in a local: this describes the program being compiled now, so it may
-  # not reach the object unless that program's executable is installed. (#1228)
   model_methods_env <- new.env()
   model_methods_env$hpp_code_ <- get_standalone_hpp(temp_stan_file, c(stanc_inc_paths, stancflags_direct))
 
@@ -996,25 +900,15 @@ compile <- function(quiet = TRUE,
       stop("An error occurred during compilation! See the message above for more information.",
            call. = FALSE)
     }
-    # Everything that can still fail happens before the executable is replaced,
-    # so that the commit block below is only assignments. Writing the
-    # model-method header is fallible and has to come after make, which
-    # generates its own .hpp at the same path.
+    # Finish fallible work before installing the executable. Write the model-method
+    # header after make because make uses the same path.
     stan_code <- readLines(temp_stan_file)
     writeLines(model_methods_env$hpp_code_,
                con = wsl_safe_path(hpp_file, revert = TRUE))
 
-    # The commit block below is otherwise only assignments, so nothing in it can
-    # fail once the executable is in place. Clearing the functions environment is
-    # the exception: it is done in place to keep the environment's identity for
-    # any fit holding a reference, so it needs an environment that can still be
-    # cleared. `functions` is public and R6 permits replacing it, so that is not
-    # guaranteed. Checked here rather than there because failing after the swap
-    # installs the executable and then leaves the object describing the previous
-    # program -- which is the #1228 failure this ordering exists to prevent.
-    #
-    # A locked binding is deliberately not checked: it does not stop rm() from
-    # removing it, and the assignments that follow create bindings afresh.
+    # Clear functions in place to preserve existing references. Because the public
+    # field can be replaced, verify it is a mutable environment before installing.
+    # Locked bindings are okay because rm() can remove them.
     if (!is.environment(self$functions) ||
         environmentIsLocked(self$functions)) {
       stop(
@@ -1024,15 +918,9 @@ compile <- function(quiet = TRUE,
       )
     }
 
-    # Errors if the executable could not be replaced, so a failure here can
-    # never leave the model with no executable at all. A backup that could not
-    # be cleaned up afterwards is reported rather than signalled, and warned
-    # about only once all the optional work below has had its chance to run.
     leftover_backup <- install_executable(tmp_exe, exe)
 
-    # The new executable is in place, so everything derived from the Stan
-    # program that was just compiled can be committed. A dry run or a failed
-    # compilation leaves the previously compiled state untouched. (#1228)
+    # Commit executable-derived state only after installation succeeds.
     rm(list = ls(self$functions, all.names = TRUE), envir = self$functions)
     self$functions$compiled <- FALSE
     self$functions$hpp_code <- standalone_hpp_code
@@ -1051,18 +939,12 @@ compile <- function(quiet = TRUE,
     private$precompile_include_paths_ <- NULL
   } # End - if(!dry_run)
 
-  # Both are exceptions to the rule that state describing the compiled artifact
-  # is committed only above: during a dry run they are also the configured
-  # destination and the toolchain version, so they are assigned on a dry run and
-  # on success -- and, for exe_file_, on a no-op -- but never on a failure.
+  # These fields also describe dry runs, so update them outside the commit block.
   private$cmdstan_version_ <- compiled_cmdstan_version
   private$exe_file_ <- exe
 
   if (!dry_run) {
-    # Both exposures are optional and fallible, and both run only once every
-    # field describing the installed executable has been committed -- including
-    # exe_file_ above. Failing here must not leave the object unable to find an
-    # executable that is sitting on disk.
+    # Run optional exposure only after executable state is committed.
     if (compile_standalone) {
       expose_stan_functions(self$functions, verbose = !quiet)
     }
@@ -1070,9 +952,7 @@ compile <- function(quiet = TRUE,
       expose_model_methods(env = private$model_methods_env_, verbose = !quiet)
     }
     if (!is.null(leftover_backup)) {
-      # Deliberately last: under options(warn = 2) this is an error, and raising
-      # it any earlier would abort exposure the user asked for -- or worse, roll
-      # back before the state describing the installed executable was recorded.
+      # Warn last because warn = 2 aborts the remaining work.
       warning(
         "The previously compiled executable could not be removed. ",
         "It has been left at '", leftover_backup, "'.",
@@ -1412,10 +1292,7 @@ format <- function(overwrite_file = FALSE,
   cat(run_log$stdout, file = out_file, sep = "\n")
   if (isTRUE(overwrite_file)) {
     private$stan_code_ <- readLines(self$stan_file())
-    # The program on disk has been rewritten, so anything parsed from it is
-    # stale. $variables() reparses when this is NULL; leaving it would let
-    # $code() and $variables() describe different programs, and the fitting
-    # methods validate data and inits against $variables(). (#1228)
+    # Force variables() to reparse the formatted source.
     private$variables_ <- NULL
   }
 

--- a/R/model.R
+++ b/R/model.R
@@ -263,6 +263,8 @@ CmdStanModel <- R6::R6Class(
       private$dir_ <- args$dir
       self$functions <- new.env()
       self$functions$compiled <- FALSE
+      # No generated C++ until a compilation commits some.
+      self$functions$existing_exe <- TRUE
       if (!is.null(stan_file)) {
         assert_file_exists(stan_file, access = "r", extension = c("stan", "stanfunctions"))
         checkmate::assert_flag(compile)

--- a/R/model.R
+++ b/R/model.R
@@ -975,6 +975,9 @@ check_syntax <- function(pedantic = FALSE,
   if (is.null(include_paths) && !is.null(self$include_paths())) {
     include_paths <- self$include_paths()
   }
+  if (private$using_user_header_) {
+    stanc_options[["allow-undefined"]] <- TRUE
+  }
 
   temp_hpp_file <- tempfile(pattern = "model-", fileext = ".hpp")
   stanc_options[["o"]] <- wsl_safe_path(temp_hpp_file)
@@ -1106,6 +1109,9 @@ format <- function(overwrite_file = FALSE,
     self$include_paths(),
     direct_call = TRUE
   )
+  if (private$using_user_header_) {
+    stanc_options[["allow-undefined"]] <- TRUE
+  }
   stanc_options[["auto-format"]] <- TRUE
   if (!is.null(max_line_length)) {
     stanc_options[["max-line-length"]] <- max_line_length

--- a/R/model.R
+++ b/R/model.R
@@ -786,8 +786,16 @@ compile <- function(quiet = TRUE,
     # Asking the executable about itself. Best effort, because
     # model_compile_info() runs it and errors outright rather than returning a
     # status when the file is not runnable.
+    # This object holds the generated C++ for an executable only if it compiled
+    # it, and in that case what make was run with is recorded exactly. No
+    # metadata query can improve on that, and metadata cannot speak to options
+    # like STAN_CPP_OPTIMS -- absent from CmdStan 2.39's output -- or to
+    # arbitrary make variables at all.
+    built_here <- !is.null(self$functions$hpp_code)
+
     exe_info <- NULL
-    if (cpp_options_available || length(private$exe_file_) == 0) {
+    if (length(private$exe_file_) == 0 ||
+        (cpp_options_available && !built_here)) {
       exe_info <- tryCatch(
         model_compile_info(exe, self$cmdstan_version()),
         error = function(e) NULL
@@ -801,14 +809,26 @@ compile <- function(quiet = TRUE,
     # fix and is still outstanding (see the skipped tests in
     # test-model-recompile-logic.R); until then, say so.
     options_mismatch <- FALSE
-    if (cpp_options_available && length(exe_info) > 0) {
-      # model_compile_info() reports upper-case names while
-      # exe_info_reflects_cpp_options() compares lower-case ones, so without
-      # aligning them the comparison finds no overlap and always agrees.
-      reported <- exe_info
-      names(reported) <- tolower(names(reported))
-      options_mismatch <-
-        !isTRUE(exe_info_reflects_cpp_options(reported, cpp_options))
+    if (cpp_options_available) {
+      if (built_here) {
+        options_mismatch <-
+          cpp_options_disagree(cpp_options, private$cpp_options_)
+      } else if (length(exe_info) > 0) {
+        # An adopted executable can only be asked about itself, and it answers
+        # about a handful of STAN_* flags. Options outside that set are left
+        # alone rather than reported as a mismatch: unverifiable is not the same
+        # as wrong, and warning whenever provenance is unknown would fire on
+        # ordinary reuse. Recording provenance beside the executable is the
+        # fix (#1238).
+        #
+        # model_compile_info() reports upper-case names while
+        # exe_info_reflects_cpp_options() compares lower-case ones, so without
+        # aligning them the comparison finds no overlap and always agrees.
+        reported <- exe_info
+        names(reported) <- tolower(names(reported))
+        options_mismatch <-
+          !isTRUE(exe_info_reflects_cpp_options(reported, cpp_options))
+      }
     }
 
     if (length(private$exe_file_) == 0) {

--- a/R/model.R
+++ b/R/model.R
@@ -720,32 +720,35 @@ compile <- function(quiet = TRUE,
     }
     # Nothing was compiled, so nothing describing the current executable may be
     # consumed or overwritten by configuration this call merely proposed.
+    # Options supplied to this call are the caller's declared intent, so they
+    # are recorded even though nothing was compiled: cmdstanr does not yet
+    # rebuild when they disagree with the executable (see the skipped tests in
+    # test-model-recompile-logic.R), and dropping them would disable a feature
+    # that was explicitly asked for. A bare $compile() supplies none, and must
+    # not erase what is already recorded -- an erased stan_threads makes
+    # assert_valid_threads() run a threaded executable single-threaded.
+    recorded_cpp_options <-
+      if (cpp_options_supplied) cpp_options else private$cpp_options_
     if (length(private$exe_file_) == 0) {
       # This object is adopting an executable it did not build: it holds no
-      # generated C++ for it, and the only available description of it is what
-      # the binary reports about itself. Best effort, because
+      # generated C++ for it, and the only description of it beyond the request
+      # is what the binary reports about itself. Best effort, because
       # model_compile_info() runs the executable and errors outright rather than
       # returning a status when the file is not runnable.
       self$functions$existing_exe <- TRUE
-      # Seeded with the options this call asked for, then filled in from the
-      # binary. Nothing is overwritten, because there is nothing here yet, and
-      # dropping the request would silently disable a feature the caller asked
-      # for: cmdstanr does not yet rebuild when the requested options disagree
-      # with the executable (see the skipped tests in
-      # test-model-recompile-logic.R), so an adopted executable is described by
-      # the request plus whatever it reports about itself.
-      private$cpp_options_ <- tryCatch(
+      recorded_cpp_options <- tryCatch(
         merge_exe_info_cpp_options(
-          cpp_options,
+          recorded_cpp_options,
           model_compile_info(exe, self$cmdstan_version())
         ),
-        error = function(e) cpp_options
+        error = function(e) recorded_cpp_options
       )
     } else {
       # The flag means "we don't hold the generated C++ for this executable",
       # which is not the same as "this call compiled nothing".
       self$functions$existing_exe <- is.null(self$functions$hpp_code)
     }
+    private$cpp_options_ <- recorded_cpp_options
     private$exe_file_ <- exe
     return(invisible(self))
   } else {

--- a/R/model.R
+++ b/R/model.R
@@ -815,17 +815,11 @@ compile <- function(quiet = TRUE,
     writeLines(model_methods_env$hpp_code_,
                con = wsl_safe_path(hpp_file, revert = TRUE))
 
-    if (file.exists(exe)) {
-      file.remove(exe)
-    }
-    file.copy(tmp_exe, exe, overwrite = TRUE)
-    if (os_is_wsl()) {
-      res <- processx::run(
-        command = "wsl",
-        args = c("chmod", "+x", wsl_safe_path(exe)),
-        error_on_status = FALSE
-      )
-    }
+    # Errors if the executable could not be replaced, so a failure here can
+    # never leave the model with no executable at all. A backup that could not
+    # be cleaned up afterwards is reported rather than signalled, and warned
+    # about only once all the optional work below has had its chance to run.
+    leftover_backup <- install_executable(tmp_exe, exe)
 
     # The new executable is in place, so everything derived from the Stan
     # program that was just compiled can be committed. A dry run or a failed
@@ -857,6 +851,16 @@ compile <- function(quiet = TRUE,
   if (!dry_run) {
     if (compile_model_methods) {
       expose_model_methods(env = private$model_methods_env_, verbose = !quiet)
+    }
+    if (!is.null(leftover_backup)) {
+      # Deliberately last: under options(warn = 2) this is an error, and raising
+      # it any earlier would abort exposure the user asked for -- or worse, roll
+      # back before the state describing the installed executable was recorded.
+      warning(
+        "The previously compiled executable could not be removed. ",
+        "It has been left at '", leftover_backup, "'.",
+        call. = FALSE
+      )
     }
   }
   invisible(self)

--- a/R/model.R
+++ b/R/model.R
@@ -248,6 +248,8 @@ CmdStanModel <- R6::R6Class(
     # the two have drifted apart. Set by a change of header, cleared only by a
     # successful executable replacement.
     user_header_dirty_ = FALSE,
+    # The same, for a change of include paths.
+    include_paths_dirty_ = FALSE,
     precompile_cpp_options_ = NULL,
     precompile_stanc_options_ = NULL,
     precompile_include_paths_ = NULL,
@@ -629,7 +631,21 @@ compile <- function(quiet = TRUE,
   if (is.null(include_paths)) {
     include_paths <- private$include_paths_ %||% private$precompile_include_paths_
   }
-  private$include_paths_ <- resolve_path(include_paths)
+  resolved_include_paths <- resolve_path(include_paths)
+  # Compared before the assignment below, and latched for the same reason the
+  # header's marker is: a failed compile must keep the new paths, so on the
+  # retry they resolve back to themselves and nothing looks changed. Order is
+  # significant -- it decides which directory a directive resolves from -- so
+  # this is an ordered comparison, which same_path() already does.
+  #
+  # Only a change counts, never the first configuration: a fresh object holds no
+  # paths, so comparing against nothing would force a rebuild in every new R
+  # session. That leaves an executable adopted from an earlier session unproven,
+  # which is documented under `force_recompile`.
+  private$include_paths_dirty_ <- isTRUE(private$include_paths_dirty_) ||
+    (length(private$include_paths_) > 0 &&
+       !same_path(resolved_include_paths, private$include_paths_))
+  private$include_paths_ <- resolved_include_paths
   include_paths <- private$include_paths_
   if (is.null(dir) && !is.null(private$dir_)) {
     dir <- absolute_path(private$dir_)
@@ -701,6 +717,7 @@ compile <- function(quiet = TRUE,
   # - the executable does not exist
   # - the destination is not the executable this object already describes
   # - the user header in use is not the one the executable was built against
+  # - the include paths in use are not the ones the executable was built against
   # - the stan model was changed since last compilation
   # - a user header is used and the user header changed since last compilation (#813)
   if (!file.exists(exe)) {
@@ -708,6 +725,8 @@ compile <- function(quiet = TRUE,
   } else if (exe_changed) {
     force_recompile <- TRUE
   } else if (isTRUE(private$user_header_dirty_)) {
+    force_recompile <- TRUE
+  } else if (isTRUE(private$include_paths_dirty_)) {
     force_recompile <- TRUE
   } else if (file.exists(self$stan_file())
              && file.mtime(exe) < file.mtime(self$stan_file())) {
@@ -923,6 +942,7 @@ compile <- function(quiet = TRUE,
     private$stan_code_ <- stan_code
     private$variables_ <- NULL
     private$user_header_dirty_ <- FALSE
+    private$include_paths_dirty_ <- FALSE
     private$hpp_file_ <- hpp_file
     private$model_methods_env_ <- model_methods_env
     private$cpp_options_ <- cpp_options

--- a/R/model.R
+++ b/R/model.R
@@ -643,15 +643,17 @@ compile <- function(quiet = TRUE,
     stanc_options <- private$precompile_stanc_options_
   }
   stanc_options <- assert_valid_stanc_options(stanc_options)
+  previous_include_paths <-
+    private$include_paths_ %||% private$precompile_include_paths_
   if (is.null(include_paths)) {
-    include_paths <- private$include_paths_ %||% private$precompile_include_paths_
+    include_paths <- previous_include_paths
   }
   resolved_include_paths <- resolve_path(include_paths)
   # Keep this dirty flag set across failed builds. Include-path order affects
   # resolution. The first configured value is initial state, not a change.
   private$include_paths_dirty_ <- isTRUE(private$include_paths_dirty_) ||
-    (length(private$include_paths_) > 0 &&
-       !same_path(resolved_include_paths, private$include_paths_))
+    (length(previous_include_paths) > 0 &&
+       !same_path(resolved_include_paths, previous_include_paths))
   private$include_paths_ <- resolved_include_paths
   include_paths <- private$include_paths_
   if (is.null(dir) && !is.null(private$dir_)) {
@@ -745,13 +747,10 @@ compile <- function(quiet = TRUE,
     built_here <- !is.null(self$functions$hpp_code)
 
     # Treat unreadable executable metadata as unavailable.
-    exe_info <- NULL
-    if (cpp_options_available || length(private$exe_file_) == 0) {
-      exe_info <- tryCatch(
-        model_compile_info(exe, self$cmdstan_version()),
-        error = function(e) NULL
-      )
-    }
+    exe_info <- tryCatch(
+      model_compile_info(exe, self$cmdstan_version()),
+      error = function(e) NULL
+    )
 
     # Add options reported as enabled by the executable and keep recorded values
     # for anything it cannot report.

--- a/R/model.R
+++ b/R/model.R
@@ -1291,6 +1291,11 @@ format <- function(overwrite_file = FALSE,
   cat(run_log$stdout, file = out_file, sep = "\n")
   if (isTRUE(overwrite_file)) {
     private$stan_code_ <- readLines(self$stan_file())
+    # The program on disk has been rewritten, so anything parsed from it is
+    # stale. $variables() reparses when this is NULL; leaving it would let
+    # $code() and $variables() describe different programs, and the fitting
+    # methods validate data and inits against $variables(). (#1228)
+    private$variables_ <- NULL
   }
 
   invisible(TRUE)

--- a/R/model.R
+++ b/R/model.R
@@ -504,13 +504,17 @@ NULL
 #'   the model object is created (or when `$compile()` is called) and stored as
 #'   absolute paths, so subsequent changes to the working directory do not
 #'   affect them. If `$compile()` is called again without `include_paths`, the
-#'   most recently supplied paths are reused.
+#'   most recently supplied paths are reused, and changing them forces
+#'   recompilation. Edits to the included files themselves do not; see
+#'   `force_recompile`.
 #' @param user_header (string) The path to a C++ file (with a .hpp extension)
 #'   to compile with the Stan model. If `$compile()` is called again without
 #'   `user_header`, the most recently supplied header is reused, and changing
 #'   it forces recompilation. Pass `user_header = NULL` to compile without one.
 #'   A header can also be supplied via `cpp_options` as `USER_HEADER` or
 #'   `user_header`; the `user_header` argument takes precedence over both.
+#'   See `force_recompile` for the case of a header supplied for a program
+#'   whose executable is already up to date.
 #' @param cpp_options (list) Any makefile options to be used when compiling the
 #'   model (`stan_threads`, `stan_mpi`, `stan_opencl`, etc.). Anything you would
 #'   otherwise write in the `make/local` file. For an example of using threading
@@ -529,6 +533,15 @@ NULL
 #' @param force_recompile (logical) Should the model be recompiled even if it
 #'   has not been modified since it was last compiled? The default is `FALSE`.
 #'   Can also be set via a global `cmdstanr_force_recompile` option.
+#'
+#'   Only the Stan program itself and the user header (if any) are checked for
+#'   modification. Files pulled in by `#include` directives are not, at any
+#'   depth, so editing an included file does not on its own trigger
+#'   recompilation. Use `force_recompile = TRUE` after changing one. Similarly,
+#'   when a model object is created for a Stan program whose executable already
+#'   exists and is up to date, CmdStanR cannot tell which `user_header` or
+#'   `include_paths` that executable was built with, so supplying different
+#'   ones does not force a rebuild.
 #' @param compile_model_methods (logical) Compile additional model methods
 #'   (`log_prob()`, `grad_log_prob()`, `hessian()`, `constrain_variables()`,
 #'   `unconstrain_variables()`, `unconstrain_draws()`, and

--- a/R/model.R
+++ b/R/model.R
@@ -1004,6 +1004,26 @@ compile <- function(quiet = TRUE,
     writeLines(model_methods_env$hpp_code_,
                con = wsl_safe_path(hpp_file, revert = TRUE))
 
+    # The commit block below is otherwise only assignments, so nothing in it can
+    # fail once the executable is in place. Clearing the functions environment is
+    # the exception: it is done in place to keep the environment's identity for
+    # any fit holding a reference, so it needs an environment that can still be
+    # cleared. `functions` is public and R6 permits replacing it, so that is not
+    # guaranteed. Checked here rather than there because failing after the swap
+    # installs the executable and then leaves the object describing the previous
+    # program -- which is the #1228 failure this ordering exists to prevent.
+    #
+    # A locked binding is deliberately not checked: it does not stop rm() from
+    # removing it, and the assignments that follow create bindings afresh.
+    if (!is.environment(self$functions) ||
+        environmentIsLocked(self$functions)) {
+      stop(
+        "The model's 'functions' environment is missing or locked, so the ",
+        "compiled model could not be recorded. The executable was not replaced.",
+        call. = FALSE
+      )
+    }
+
     # Errors if the executable could not be replaced, so a failure here can
     # never leave the model with no executable at all. A backup that could not
     # be cleaned up afterwards is reported rather than signalled, and warned

--- a/R/model.R
+++ b/R/model.R
@@ -282,6 +282,12 @@ CmdStanModel <- R6::R6Class(
           # once; warning here as well would double up.
           warn_user_header_conflict(resolved_header$conflict)
         }
+        # Deliberately without the header: the resolver strips both spellings
+        # and only $compile() reinserts the selected one. Storing it here would
+        # mean storing a WSL-safe path, which the next $compile() would pick up
+        # as its host-path `user_header` and fail to find on WSLv1 -- the hazard
+        # the comment at the resolver call in $compile() describes. user_header_
+        # below is the single source instead.
         private$precompile_cpp_options_ <- resolved_header$cpp_options
         # Prepopulating this also keeps the first $compile() from seeing a
         # change of header and rebuilding an already-current executable.

--- a/R/model.R
+++ b/R/model.R
@@ -721,28 +721,53 @@ compile <- function(quiet = TRUE,
     # Nothing was compiled, so nothing describing the current executable may be
     # consumed or overwritten by configuration this call merely proposed.
     # Options supplied to this call are the caller's declared intent, so they
-    # are recorded even though nothing was compiled: cmdstanr does not yet
-    # rebuild when they disagree with the executable (see the skipped tests in
-    # test-model-recompile-logic.R), and dropping them would disable a feature
-    # that was explicitly asked for. A bare $compile() supplies none, and must
-    # not erase what is already recorded -- an erased stan_threads makes
-    # assert_valid_threads() run a threaded executable single-threaded.
+    # are recorded even though nothing was compiled. A bare $compile() supplies
+    # none, and must not erase what is already recorded -- an erased
+    # stan_threads makes assert_valid_threads() run a threaded executable
+    # single-threaded.
     recorded_cpp_options <-
       if (cpp_options_supplied) cpp_options else private$cpp_options_
+
+    # Asking the executable about itself. Best effort, because
+    # model_compile_info() runs it and errors outright rather than returning a
+    # status when the file is not runnable.
+    exe_info <- NULL
+    if (cpp_options_supplied || length(private$exe_file_) == 0) {
+      exe_info <- tryCatch(
+        model_compile_info(exe, self$cmdstan_version()),
+        error = function(e) NULL
+      )
+    }
+
+    # Recording options the executable does not have would otherwise be a quiet
+    # lie: nothing was rebuilt, so a requested stan_threads produces the
+    # "N thread(s) per chain" message while the binary, compiled without
+    # STAN_THREADS, runs single-threaded. Rebuilding on a mismatch is the real
+    # fix and is still outstanding (see the skipped tests in
+    # test-model-recompile-logic.R); until then, say so.
+    if (cpp_options_supplied && length(exe_info) > 0) {
+      # model_compile_info() reports upper-case names while
+      # exe_info_reflects_cpp_options() compares lower-case ones, so without
+      # aligning them the comparison finds no overlap and always agrees.
+      reported <- exe_info
+      names(reported) <- tolower(names(reported))
+      if (!isTRUE(exe_info_reflects_cpp_options(reported, cpp_options))) {
+        warning(
+          "The existing executable was not built with the requested ",
+          "'cpp_options' and was not rebuilt, so they will have no effect. ",
+          "Use 'force_recompile = TRUE' to rebuild the model.",
+          call. = FALSE
+        )
+      }
+    }
+
     if (length(private$exe_file_) == 0) {
       # This object is adopting an executable it did not build: it holds no
       # generated C++ for it, and the only description of it beyond the request
-      # is what the binary reports about itself. Best effort, because
-      # model_compile_info() runs the executable and errors outright rather than
-      # returning a status when the file is not runnable.
+      # is what the binary reports about itself.
       self$functions$existing_exe <- TRUE
-      recorded_cpp_options <- tryCatch(
-        merge_exe_info_cpp_options(
-          recorded_cpp_options,
-          model_compile_info(exe, self$cmdstan_version())
-        ),
-        error = function(e) recorded_cpp_options
-      )
+      recorded_cpp_options <-
+        merge_exe_info_cpp_options(recorded_cpp_options, exe_info)
     } else {
       # The flag means "we don't hold the generated C++ for this executable",
       # which is not the same as "this call compiled nothing".

--- a/R/model.R
+++ b/R/model.R
@@ -606,6 +606,24 @@ NULL
 #' # same as mod <- cmdstan_model(file_pedantic, pedantic = TRUE)
 #' }
 #'
+# The object holds three kinds of state, committed at different moments. The
+# comments through this function explain individual assignments; the rule they
+# are all instances of is:
+#
+#   Source configuration -- what the next build should use. Assigned eagerly and
+#     kept through a failure, because a bare retry after fixing a bad header or
+#     a wrong path has to build what the user last asked for.
+#   Artifact description -- what the executable on disk actually is. Committed
+#     only after that executable has been successfully replaced, so a dry run, a
+#     failed compile, or a failed install can never leave the object describing
+#     a program that was never built. (#1228)
+#   Divergence markers -- a record that the two have drifted apart, which is
+#     neither of the above. Latched rather than assigned, because on a retry the
+#     configuration resolves back to itself and nothing looks changed.
+#
+# exe_file_ and cmdstan_version_ are deliberate exceptions: they are also the
+# configured destination and the toolchain version, so they are assigned on a
+# dry run and on a no-op, but never on a failure.
 compile <- function(quiet = TRUE,
                     dir = NULL,
                     pedantic = FALSE,

--- a/R/model.R
+++ b/R/model.R
@@ -908,7 +908,6 @@ compile <- function(quiet = TRUE,
 
     # Clear functions in place to preserve existing references. Because the public
     # field can be replaced, verify it is a mutable environment before installing.
-    # Locked bindings are okay because rm() can remove them.
     if (!is.environment(self$functions) ||
         environmentIsLocked(self$functions)) {
       stop(

--- a/R/model.R
+++ b/R/model.R
@@ -296,13 +296,10 @@ CmdStanModel <- R6::R6Class(
       # as the version the model was compiled with
       private$cmdstan_version_ <- cmdstan_version()
       if (length(self$exe_file()) > 0 && file.exists(self$exe_file())) {
-        cpp_options <- model_compile_info(self$exe_file(), self$cmdstan_version())
-        for (cpp_option_name in names(cpp_options)) {
-          if (tolower(cpp_option_name) != "stan_version" &&
-              (!is.logical(cpp_options[[cpp_option_name]]) || isTRUE(cpp_options[[cpp_option_name]]))) {
-            private$cpp_options_[[cpp_option_name]] <- cpp_options[[cpp_option_name]]
-          }
-        }
+        private$cpp_options_ <- merge_exe_info_cpp_options(
+          private$cpp_options_,
+          model_compile_info(self$exe_file(), self$cmdstan_version())
+        )
       }
       invisible(self)
     },
@@ -607,9 +604,6 @@ compile <- function(quiet = TRUE,
   if (!is.null(dir)) {
     dir <- repair_path(dir)
     assert_dir_exists(dir, access = "rw")
-    if (length(self$exe_file()) != 0) {
-      private$exe_file_ <- file.path(dir, basename(self$exe_file()))
-    }
   }
 
   exe <- resolve_exe_path(dir, private$dir_, self$exe_file(), self$stan_file())
@@ -658,13 +652,21 @@ compile <- function(quiet = TRUE,
     }
   }
 
+  # The resolved destination need not be the executable this object describes,
+  # e.g. $compile(dir = ) aimed at a directory that already holds a current
+  # executable. Adopting that binary while keeping this object's generated C++
+  # and metadata would produce a hybrid, so build the model there instead.
+  exe_changed <- length(private$exe_file_) > 0 && !same_path(exe, private$exe_file_)
+
   # compile if:
   # - the user forced compilation,
   # - the executable does not exist
+  # - the destination is not the executable this object already describes
   # - the stan model was changed since last compilation
   # - a user header is used and the user header changed since last compilation (#813)
-  self$exe_file(exe)
   if (!file.exists(exe)) {
+    force_recompile <- TRUE
+  } else if (exe_changed) {
     force_recompile <- TRUE
   } else if (file.exists(self$stan_file())
              && file.mtime(exe) < file.mtime(self$stan_file())) {
@@ -679,11 +681,28 @@ compile <- function(quiet = TRUE,
     if (rlang::is_interactive()) {
       message("Model executable is up to date!")
     }
-    private$cpp_options_ <- cpp_options
-    private$precompile_cpp_options_ <- NULL
-    private$precompile_stanc_options_ <- NULL
-    private$precompile_include_paths_ <- NULL
-    self$functions$existing_exe <- TRUE
+    # Nothing was compiled, so nothing describing the current executable may be
+    # consumed or overwritten by configuration this call merely proposed.
+    if (length(private$exe_file_) == 0) {
+      # This object is adopting an executable it did not build: it holds no
+      # generated C++ for it, and the only available description of it is what
+      # the binary reports about itself. Best effort, because
+      # model_compile_info() runs the executable and errors outright rather than
+      # returning a status when the file is not runnable.
+      self$functions$existing_exe <- TRUE
+      private$cpp_options_ <- tryCatch(
+        merge_exe_info_cpp_options(
+          private$cpp_options_,
+          model_compile_info(exe, self$cmdstan_version())
+        ),
+        error = function(e) private$cpp_options_
+      )
+    } else {
+      # The flag means "we don't hold the generated C++ for this executable",
+      # which is not the same as "this call compiled nothing".
+      self$functions$existing_exe <- is.null(self$functions$hpp_code)
+    }
+    private$exe_file_ <- exe
     return(invisible(self))
   } else {
     if (rlang::is_interactive()) {
@@ -706,7 +725,7 @@ compile <- function(quiet = TRUE,
   if (os_is_windows() && !os_is_wsl()) {
     tmp_exe <- utils::shortPathName(tmp_exe)
   }
-  private$hpp_file_ <- paste0(temp_file_no_ext, ".hpp")
+  hpp_file <- paste0(temp_file_no_ext, ".hpp")
 
   stancflags_val <- include_paths_stanc3_args(include_paths)
 
@@ -723,8 +742,10 @@ compile <- function(quiet = TRUE,
   stanc_inc_paths <- include_paths_stanc3_args(include_paths, direct_call = TRUE)
   stancflags_standalone <- c("--standalone-functions", stanc_inc_paths, stancflags_direct)
   standalone_hpp_code <- get_standalone_hpp(temp_stan_file, stancflags_standalone)
-  private$model_methods_env_ <- new.env()
-  private$model_methods_env_$hpp_code_ <- get_standalone_hpp(temp_stan_file, c(stanc_inc_paths, stancflags_direct))
+  # Staged in a local: this describes the program being compiled now, so it may
+  # not reach the object unless that program's executable is installed. (#1228)
+  model_methods_env <- new.env()
+  model_methods_env$hpp_code_ <- get_standalone_hpp(temp_stan_file, c(stanc_inc_paths, stancflags_direct))
 
   stancflags_val <- paste0("STANCFLAGS += ", stancflags_val, paste0(" ", stancflags_combined, collapse = " "))
 
@@ -786,6 +807,14 @@ compile <- function(quiet = TRUE,
       stop("An error occurred during compilation! See the message above for more information.",
            call. = FALSE)
     }
+    # Everything that can still fail happens before the executable is replaced,
+    # so that the commit block below is only assignments. Writing the
+    # model-method header is fallible and has to come after make, which
+    # generates its own .hpp at the same path.
+    stan_code <- readLines(temp_stan_file)
+    writeLines(model_methods_env$hpp_code_,
+               con = wsl_safe_path(hpp_file, revert = TRUE))
+
     if (file.exists(exe)) {
       file.remove(exe)
     }
@@ -806,10 +835,12 @@ compile <- function(quiet = TRUE,
     self$functions$hpp_code <- standalone_hpp_code
     self$functions$external <- using_user_header
     self$functions$existing_exe <- FALSE
-    private$stan_code_ <- readLines(temp_stan_file)
+    private$stan_code_ <- stan_code
     private$variables_ <- NULL
     private$using_user_header_ <- using_user_header
     private$user_header_ <- user_header
+    private$hpp_file_ <- hpp_file
+    private$model_methods_env_ <- model_methods_env
     private$precompile_cpp_options_ <- NULL
     private$precompile_stanc_options_ <- NULL
     private$precompile_include_paths_ <- NULL
@@ -817,9 +848,6 @@ compile <- function(quiet = TRUE,
     if (compile_standalone) {
       expose_stan_functions(self$functions, verbose = !quiet)
     }
-
-    writeLines(private$model_methods_env_$hpp_code_,
-               con = wsl_safe_path(private$hpp_file_, revert = TRUE))
   } # End - if(!dry_run)
 
   private$cmdstan_version_ <- cmdstan_version()

--- a/R/model.R
+++ b/R/model.R
@@ -250,6 +250,12 @@ CmdStanModel <- R6::R6Class(
     user_header_dirty_ = FALSE,
     # The same, for a change of include paths.
     include_paths_dirty_ = FALSE,
+    # The cpp_options actually passed to make for the current executable, as
+    # distinct from cpp_options_, which also carries what the binary reports
+    # about itself. Only these would be dropped by a recompilation that omitted
+    # them; anything else the binary has came from make/local and would be
+    # inherited again.
+    built_cpp_options_ = NULL,
     precompile_cpp_options_ = NULL,
     precompile_stanc_options_ = NULL,
     precompile_include_paths_ = NULL,
@@ -783,26 +789,31 @@ compile <- function(quiet = TRUE,
     # with threading enabled", which is false and cannot be worked around
     # without recompiling. What is already recorded still describes the
     # executable that exists, so it is carried forward untouched. (#1019)
-    recorded_cpp_options <- private$cpp_options_
+    # This object holds the generated C++ for an executable only if it compiled
+    # it. Even then the record is only what was passed to make: options
+    # inherited from make/local never reach $compile() and so were never
+    # recorded, which is why the record alone is not the artifact.
+    built_here <- !is.null(self$functions$hpp_code)
 
     # Asking the executable about itself. Best effort, because
     # model_compile_info() runs it and errors outright rather than returning a
     # status when the file is not runnable.
-    # This object holds the generated C++ for an executable only if it compiled
-    # it, and in that case what make was run with is recorded exactly. No
-    # metadata query can improve on that, and metadata cannot speak to options
-    # like STAN_CPP_OPTIMS -- absent from CmdStan 2.39's output -- or to
-    # arbitrary make variables at all.
-    built_here <- !is.null(self$functions$hpp_code)
-
     exe_info <- NULL
-    if (length(private$exe_file_) == 0 ||
-        (cpp_options_available && !built_here)) {
+    if (cpp_options_available || length(private$exe_file_) == 0) {
       exe_info <- tryCatch(
         model_compile_info(exe, self$cmdstan_version()),
         error = function(e) NULL
       )
     }
+
+    # The two accounts of the executable, combined: metadata reports the
+    # STAN_* flags actually compiled in, including any inherited from
+    # make/local, and the record holds the options metadata cannot report.
+    # Metadata wins where both speak, since it describes the binary; a metadata
+    # FALSE is skipped by the merge, so an explicit NULL survives as an empty
+    # assignment. A failed query leaves the record untouched.
+    recorded_cpp_options <-
+      merge_exe_info_cpp_options(private$cpp_options_, exe_info)
 
     # Recording options the executable does not have would otherwise be a quiet
     # lie: nothing was rebuilt, so a requested stan_threads produces the
@@ -813,8 +824,24 @@ compile <- function(quiet = TRUE,
     options_mismatch <- FALSE
     if (cpp_options_available) {
       if (built_here) {
-        options_mismatch <-
-          cpp_options_disagree(cpp_options, private$cpp_options_)
+        # Options the binary reports but the record never held cannot have come
+        # from $compile(), so they came from make/local -- and a rebuild would
+        # inherit them again. Applying them to both sides keeps an option the
+        # request never mentioned, and never had to, from reading as a change.
+        # Anything the record does hold was passed on the command line and
+        # would be dropped by a rebuild that omits it, so it stays subject to
+        # the symmetric comparison.
+        built_options <- private$built_cpp_options_
+        inherited <- merge_exe_info_cpp_options(list(), exe_info)
+        inherited <- inherited[
+          !tolower(names(inherited)) %in% tolower(names(built_options))
+        ]
+        # Explicit options are appended last because cpp_options reach make on
+        # the command line, which overrides make/local.
+        options_mismatch <- cpp_options_disagree(
+          c(inherited, cpp_options),
+          c(inherited, built_options)
+        )
       } else if (length(exe_info) > 0) {
         # An adopted executable can only be asked about itself, and it answers
         # about a handful of STAN_* flags. Options outside that set are left
@@ -838,8 +865,6 @@ compile <- function(quiet = TRUE,
       # generated C++ for it, and the only description of it beyond the request
       # is what the binary reports about itself.
       self$functions$existing_exe <- TRUE
-      recorded_cpp_options <-
-        merge_exe_info_cpp_options(recorded_cpp_options, exe_info)
     } else {
       # The flag means "we don't hold the generated C++ for this executable",
       # which is not the same as "this call compiled nothing".
@@ -851,10 +876,15 @@ compile <- function(quiet = TRUE,
     # options(warn = 2) this is an error, and raising it earlier would unwind
     # with the object half-updated.
     if (options_mismatch) {
+      # Deliberately not phrased as a claim about how the executable was built:
+      # options inherited from make/local are invisible here unless the binary
+      # reports them, so what is actually known is that the two descriptions
+      # disagree. (#1238)
       warning(
-        "The existing executable was not built with the requested ",
-        "'cpp_options' and was not rebuilt, so they will have no effect. ",
-        "Use 'force_recompile = TRUE' to rebuild the model.",
+        "The 'cpp_options' recorded or reported for the existing executable ",
+        "do not match the ones requested. The executable was not rebuilt, so ",
+        "this call did not apply them. Use 'force_recompile = TRUE' to ",
+        "rebuild the model.",
         call. = FALSE
       )
     }
@@ -999,6 +1029,7 @@ compile <- function(quiet = TRUE,
     private$hpp_file_ <- hpp_file
     private$model_methods_env_ <- model_methods_env
     private$cpp_options_ <- cpp_options
+    private$built_cpp_options_ <- cpp_options
     private$precompile_cpp_options_ <- NULL
     private$precompile_stanc_options_ <- NULL
     private$precompile_include_paths_ <- NULL

--- a/R/model.R
+++ b/R/model.R
@@ -727,12 +727,19 @@ compile <- function(quiet = TRUE,
       # model_compile_info() runs the executable and errors outright rather than
       # returning a status when the file is not runnable.
       self$functions$existing_exe <- TRUE
+      # Seeded with the options this call asked for, then filled in from the
+      # binary. Nothing is overwritten, because there is nothing here yet, and
+      # dropping the request would silently disable a feature the caller asked
+      # for: cmdstanr does not yet rebuild when the requested options disagree
+      # with the executable (see the skipped tests in
+      # test-model-recompile-logic.R), so an adopted executable is described by
+      # the request plus whatever it reports about itself.
       private$cpp_options_ <- tryCatch(
         merge_exe_info_cpp_options(
-          private$cpp_options_,
+          cpp_options,
           model_compile_info(exe, self$cmdstan_version())
         ),
-        error = function(e) private$cpp_options_
+        error = function(e) cpp_options
       )
     } else {
       # The flag means "we don't hold the generated C++ for this executable",

--- a/R/model.R
+++ b/R/model.R
@@ -724,13 +724,14 @@ compile <- function(quiet = TRUE,
     }
     # Nothing was compiled, so nothing describing the current executable may be
     # consumed or overwritten by configuration this call merely proposed.
-    # Options supplied to this call are the caller's declared intent, so they
-    # are recorded even though nothing was compiled. A bare $compile() supplies
-    # none, and must not erase what is already recorded -- an erased
-    # stan_threads makes assert_valid_threads() run a threaded executable
-    # single-threaded.
-    recorded_cpp_options <-
-      if (cpp_options_available) cpp_options else private$cpp_options_
+    # Options supplied to this call describe an executable that was not built,
+    # so they are deliberately not recorded: assert_valid_threads() and the
+    # OpenCL checks read these back as fact, and a stan_threads the binary
+    # lacks makes a plain $sample() fail with "the model executable was built
+    # with threading enabled", which is false and cannot be worked around
+    # without recompiling. What is already recorded still describes the
+    # executable that exists, so it is carried forward untouched. (#1019)
+    recorded_cpp_options <- private$cpp_options_
 
     # Asking the executable about itself. Best effort, because
     # model_compile_info() runs it and errors outright rather than returning a

--- a/R/utils.R
+++ b/R/utils.R
@@ -302,6 +302,19 @@ copy_temp_files <-
 #'   signalling from here would unwind before the caller could record the state
 #'   describing it.
 install_executable <- function(from, to) {
+  # Checked before anything is staged or moved: file.exists() is true of
+  # directories, and both $exe_file(path) and cmdstan_model(exe_file = ) reach
+  # here without one, so a destination that is a directory would otherwise be
+  # renamed aside as though it were the previous executable -- leaving a regular
+  # file in its place, the directory displaced under a name the leftover-backup
+  # warning calls an executable, and the user hunting for their data.
+  if (dir.exists(to)) {
+    stop(
+      "Cannot install the compiled executable at '", to,
+      "' because that path is a directory. Nothing was modified.",
+      call. = FALSE
+    )
+  }
   # repair_path() because tempfile() joins with a backslash on Windows, giving
   # "//wsl$/distro/path/to/dir\\exe-new-1234". The Win32 calls below tolerate the
   # mixed separators, but wsl_safe_path() only rewrites the prefix, so the POSIX

--- a/R/utils.R
+++ b/R/utils.R
@@ -303,6 +303,17 @@ copy_temp_files <-
 #'   describing it.
 install_executable <- function(from, to) {
   candidate <- tempfile(pattern = "exe-new-", tmpdir = dirname(to))
+  # Discarding the staged copy can fail too, so the diagnostics say where it was
+  # left rather than implying it is gone and sending the user looking for a file
+  # that is still there.
+  discard_candidate <- function() {
+    if (unlink(candidate) == 0L) {
+      ""
+    } else {
+      paste0(" The staged copy has been left at '", candidate, "'.")
+    }
+  }
+
   if (!isTRUE(suppressWarnings(file.copy(from, candidate)))) {
     stop(
       "Could not stage the compiled executable at '", candidate, "'. ",
@@ -317,10 +328,10 @@ install_executable <- function(from, to) {
       error_on_status = FALSE
     )
     if (is.na(chmod$status) || chmod$status != 0) {
-      unlink(candidate)
       stop(
         "Could not make the compiled executable executable. ",
         "The model executable at '", to, "' was not modified.",
+        discard_candidate(),
         call. = FALSE
       )
     }
@@ -330,20 +341,21 @@ install_executable <- function(from, to) {
   if (file.exists(to)) {
     backup <- tempfile(pattern = "exe-old-", tmpdir = dirname(to))
     if (!isTRUE(suppressWarnings(file.rename(to, backup)))) {
-      unlink(candidate)
       stop(
         "Could not move the existing executable '", to, "' aside. ",
         "It was not modified.",
+        discard_candidate(),
         call. = FALSE
       )
     }
   }
 
   if (!isTRUE(suppressWarnings(file.rename(candidate, to)))) {
-    unlink(candidate)
+    leftover_candidate <- discard_candidate()
     if (is.null(backup)) {
       stop(
         "Could not install the compiled executable at '", to, "'.",
+        leftover_candidate,
         call. = FALSE
       )
     }
@@ -352,12 +364,14 @@ install_executable <- function(from, to) {
         "Could not install the compiled executable at '", to, "' and the ",
         "previously compiled executable could not be restored. It has been ",
         "kept at '", backup, "'.",
+        leftover_candidate,
         call. = FALSE
       )
     }
     stop(
       "Could not install the compiled executable at '", to, "'. ",
       "The previously compiled executable has been restored.",
+      leftover_candidate,
       call. = FALSE
     )
   }

--- a/R/utils.R
+++ b/R/utils.R
@@ -302,7 +302,11 @@ copy_temp_files <-
 #'   signalling from here would unwind before the caller could record the state
 #'   describing it.
 install_executable <- function(from, to) {
-  candidate <- tempfile(pattern = "exe-new-", tmpdir = dirname(to))
+  # repair_path() because tempfile() joins with a backslash on Windows, giving
+  # "//wsl$/distro/path/to/dir\\exe-new-1234". The Win32 calls below tolerate the
+  # mixed separators, but wsl_safe_path() only rewrites the prefix, so the POSIX
+  # chmod inside WSL would be handed a path that does not exist.
+  candidate <- repair_path(tempfile(pattern = "exe-new-", tmpdir = dirname(to)))
   # Discarding the staged copy can fail too, so the diagnostics say where it was
   # left rather than implying it is gone and sending the user looking for a file
   # that is still there.
@@ -339,7 +343,7 @@ install_executable <- function(from, to) {
 
   backup <- NULL
   if (file.exists(to)) {
-    backup <- tempfile(pattern = "exe-old-", tmpdir = dirname(to))
+    backup <- repair_path(tempfile(pattern = "exe-old-", tmpdir = dirname(to)))
     if (!isTRUE(suppressWarnings(file.rename(to, backup)))) {
       stop(
         "Could not move the existing executable '", to, "' aside. ",

--- a/R/utils.R
+++ b/R/utils.R
@@ -205,15 +205,8 @@ resolve_path <- function(path) {
   repair_path(absolute_path(path))
 }
 
-# Do two paths name the same file? Compared canonically rather than as strings,
-# so that symlink aliases, ".." components, separator differences and (on
-# Windows) casing don't make one file look like two.
-#
-# mustWork = FALSE is deliberate: neither path is guaranteed to exist, and the
-# default mustWork = NA warns when a path cannot be normalized, which
-# options(warn = 2) would turn into an error. A path that cannot be normalized
-# is compared as given, which for a missing path against an existing one means
-# "different" -- the safe answer for both callers.
+# Compare canonical paths without requiring them to exist. mustWork = FALSE
+# also avoids normalizePath() warnings under warn = 2.
 same_path <- function(x, y) {
   if (length(x) == 0 || length(y) == 0) {
     return(length(x) == length(y))
@@ -275,39 +268,19 @@ copy_temp_files <-
     absolute_path(destinations)
   }
 
-#' Replace a model executable with a newly compiled one
+#' Replace a model executable while preserving the previous one
 #'
-#' Stages the new executable beside the destination, moves any existing
-#' executable aside, and only then renames the staged copy into place. Every step
-#' that fails before the final rename leaves the destination exactly as it was;
-#' a failed final rename restores the previous executable.
-#'
-#' Staged and rollback-capable rather than transactional: a crash between the two
-#' renames can still leave the previous executable at the backup path only.
-#'
-#' Every filesystem call is wrapped in `suppressWarnings()` and checked by value.
-#' `file.copy()` and `file.rename()` warn on failure, so under
-#' `options(warn = 2)` base would throw before returning `FALSE` -- and if that
-#' happened on the final rename, the rollback below would never run and the only
-#' good executable would be stranded at the backup path. `unlink()` reports a
-#' status without signalling, so it needs no such treatment, but it returns
-#' `0L` for success rather than `TRUE`.
+#' Stage the new executable, move the old one aside, and attempt to restore it
+#' if installation fails. Suppress file.copy() and file.rename() warnings so
+#' warn = 2 cannot interrupt rollback. A crash between renames may leave only
+#' the backup.
 #'
 #' @noRd
 #' @param from Path to the newly compiled executable.
 #' @param to Path the executable should be installed at.
-#' @return `NULL` on a clean install, or the path to a backup of the previous
-#'   executable that could not be removed afterwards. Callers must not treat a
-#'   returned path as a failure: the new executable is installed either way, and
-#'   signalling from here would unwind before the caller could record the state
-#'   describing it.
+#' @return NULL after a clean install, or the leftover backup path if cleanup
+#'   fails. The new executable is installed in either case.
 install_executable <- function(from, to) {
-  # Checked before anything is staged or moved: file.exists() is true of
-  # directories, and both $exe_file(path) and cmdstan_model(exe_file = ) reach
-  # here without one, so a destination that is a directory would otherwise be
-  # renamed aside as though it were the previous executable -- leaving a regular
-  # file in its place, the directory displaced under a name the leftover-backup
-  # warning calls an executable, and the user hunting for their data.
   if (dir.exists(to)) {
     stop(
       "Cannot install the compiled executable at '", to,
@@ -315,14 +288,8 @@ install_executable <- function(from, to) {
       call. = FALSE
     )
   }
-  # repair_path() because tempfile() joins with a backslash on Windows, giving
-  # "//wsl$/distro/path/to/dir\\exe-new-1234". The Win32 calls below tolerate the
-  # mixed separators, but wsl_safe_path() only rewrites the prefix, so the POSIX
-  # chmod inside WSL would be handed a path that does not exist.
+  # Normalize mixed Windows separators before converting the path for WSL.
   candidate <- repair_path(tempfile(pattern = "exe-new-", tmpdir = dirname(to)))
-  # Discarding the staged copy can fail too, so the diagnostics say where it was
-  # left rather than implying it is gone and sending the user looking for a file
-  # that is still there.
   discard_candidate <- function() {
     if (unlink(candidate, expand = FALSE) == 0L) {
       ""

--- a/R/utils.R
+++ b/R/utils.R
@@ -275,6 +275,99 @@ copy_temp_files <-
     absolute_path(destinations)
   }
 
+#' Replace a model executable with a newly compiled one
+#'
+#' Stages the new executable beside the destination, moves any existing
+#' executable aside, and only then renames the staged copy into place. Every step
+#' that fails before the final rename leaves the destination exactly as it was;
+#' a failed final rename restores the previous executable.
+#'
+#' Staged and rollback-capable rather than transactional: a crash between the two
+#' renames can still leave the previous executable at the backup path only.
+#'
+#' Every filesystem call is wrapped in `suppressWarnings()` and checked by value.
+#' `file.copy()` and `file.rename()` warn on failure, so under
+#' `options(warn = 2)` base would throw before returning `FALSE` -- and if that
+#' happened on the final rename, the rollback below would never run and the only
+#' good executable would be stranded at the backup path. `unlink()` reports a
+#' status without signalling, so it needs no such treatment, but it returns
+#' `0L` for success rather than `TRUE`.
+#'
+#' @noRd
+#' @param from Path to the newly compiled executable.
+#' @param to Path the executable should be installed at.
+#' @return `NULL` on a clean install, or the path to a backup of the previous
+#'   executable that could not be removed afterwards. Callers must not treat a
+#'   returned path as a failure: the new executable is installed either way, and
+#'   signalling from here would unwind before the caller could record the state
+#'   describing it.
+install_executable <- function(from, to) {
+  candidate <- tempfile(pattern = "exe-new-", tmpdir = dirname(to))
+  if (!isTRUE(suppressWarnings(file.copy(from, candidate)))) {
+    stop(
+      "Could not stage the compiled executable at '", candidate, "'. ",
+      "The model executable at '", to, "' was not modified.",
+      call. = FALSE
+    )
+  }
+  if (os_is_wsl()) {
+    chmod <- processx::run(
+      command = "wsl",
+      args = c("chmod", "+x", wsl_safe_path(candidate)),
+      error_on_status = FALSE
+    )
+    if (is.na(chmod$status) || chmod$status != 0) {
+      unlink(candidate)
+      stop(
+        "Could not make the compiled executable executable. ",
+        "The model executable at '", to, "' was not modified.",
+        call. = FALSE
+      )
+    }
+  }
+
+  backup <- NULL
+  if (file.exists(to)) {
+    backup <- tempfile(pattern = "exe-old-", tmpdir = dirname(to))
+    if (!isTRUE(suppressWarnings(file.rename(to, backup)))) {
+      unlink(candidate)
+      stop(
+        "Could not move the existing executable '", to, "' aside. ",
+        "It was not modified.",
+        call. = FALSE
+      )
+    }
+  }
+
+  if (!isTRUE(suppressWarnings(file.rename(candidate, to)))) {
+    unlink(candidate)
+    if (is.null(backup)) {
+      stop(
+        "Could not install the compiled executable at '", to, "'.",
+        call. = FALSE
+      )
+    }
+    if (!isTRUE(suppressWarnings(file.rename(backup, to)))) {
+      stop(
+        "Could not install the compiled executable at '", to, "' and the ",
+        "previously compiled executable could not be restored. It has been ",
+        "kept at '", backup, "'.",
+        call. = FALSE
+      )
+    }
+    stop(
+      "Could not install the compiled executable at '", to, "'. ",
+      "The previously compiled executable has been restored.",
+      call. = FALSE
+    )
+  }
+
+  if (!is.null(backup) && unlink(backup) != 0L) {
+    return(backup)
+  }
+  NULL
+}
+
 # generate new file names
 # see doc above for copy_temp_files
 generate_file_names <-

--- a/R/utils.R
+++ b/R/utils.R
@@ -307,7 +307,7 @@ install_executable <- function(from, to) {
   # left rather than implying it is gone and sending the user looking for a file
   # that is still there.
   discard_candidate <- function() {
-    if (unlink(candidate) == 0L) {
+    if (unlink(candidate, expand = FALSE) == 0L) {
       ""
     } else {
       paste0(" The staged copy has been left at '", candidate, "'.")
@@ -376,7 +376,7 @@ install_executable <- function(from, to) {
     )
   }
 
-  if (!is.null(backup) && unlink(backup) != 0L) {
+  if (!is.null(backup) && unlink(backup, expand = FALSE) != 0L) {
     return(backup)
   }
   NULL

--- a/R/utils.R
+++ b/R/utils.R
@@ -205,6 +205,25 @@ resolve_path <- function(path) {
   repair_path(absolute_path(path))
 }
 
+# Do two paths name the same file? Compared canonically rather than as strings,
+# so that symlink aliases, ".." components, separator differences and (on
+# Windows) casing don't make one file look like two.
+#
+# mustWork = FALSE is deliberate: neither path is guaranteed to exist, and the
+# default mustWork = NA warns when a path cannot be normalized, which
+# options(warn = 2) would turn into an error. A path that cannot be normalized
+# is compared as given, which for a missing path against an existing one means
+# "different" -- the safe answer for both callers.
+same_path <- function(x, y) {
+  if (length(x) == 0 || length(y) == 0) {
+    return(length(x) == length(y))
+  }
+  identical(
+    normalizePath(x, winslash = "/", mustWork = FALSE),
+    normalizePath(y, winslash = "/", mustWork = FALSE)
+  )
+}
+
 # read, write, and copy files --------------------------------------------
 
 #' Copy temporary files (e.g., output, data) to a different location

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -40,10 +40,12 @@ should look for files specified in \verb{#include} directives in the Stan
 program. Relative paths are resolved against the working directory when
 the model object is created (or when \verb{$compile()} is called) and stored as
 absolute paths, so subsequent changes to the working directory do not
-affect them.}
+affect them. If \verb{$compile()} is called again without \code{include_paths}, the
+paths used for the previous compilation are reused.}
 
 \item{user_header}{(string) The path to a C++ file (with a .hpp extension)
-to compile with the Stan model.}
+to compile with the Stan model. If \verb{$compile()} is called again without
+\code{user_header}, the header used for the previous compilation is reused.}
 
 \item{cpp_options}{(list) Any makefile options to be used when compiling the
 model (\code{stan_threads}, \code{stan_mpi}, \code{stan_opencl}, etc.). Anything you would

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -41,11 +41,14 @@ program. Relative paths are resolved against the working directory when
 the model object is created (or when \verb{$compile()} is called) and stored as
 absolute paths, so subsequent changes to the working directory do not
 affect them. If \verb{$compile()} is called again without \code{include_paths}, the
-paths used for the previous compilation are reused.}
+most recently supplied paths are reused.}
 
 \item{user_header}{(string) The path to a C++ file (with a .hpp extension)
 to compile with the Stan model. If \verb{$compile()} is called again without
-\code{user_header}, the header used for the previous compilation is reused.}
+\code{user_header}, the most recently supplied header is reused, and changing
+it forces recompilation. Pass \code{user_header = NULL} to compile without one.
+A header can also be supplied via \code{cpp_options} as \code{USER_HEADER} or
+\code{user_header}; the \code{user_header} argument takes precedence over both.}
 
 \item{cpp_options}{(list) Any makefile options to be used when compiling the
 model (\code{stan_threads}, \code{stan_mpi}, \code{stan_opencl}, etc.). Anything you would

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -61,8 +61,10 @@ see the Stan case study \href{https://mc-stan.org/users/documentation/case-studi
 \strong{Note:} For historical reasons, CmdStan treats some options as enabled
 whenever their \code{Make} variable is non-empty. In particular, setting
 \code{stan_threads} to \code{FALSE} passes \code{STAN_THREADS=FALSE} to \code{Make}, which
-still enables threading! To leave threading disabled, simply omit
-\code{stan_threads} entirely or set it to \code{NULL}.}
+still enables threading! To leave threading disabled, either omit
+\code{stan_threads} entirely, which leaves any setting in \code{make/local} in
+place, or set it to \code{NULL}, which passes an empty \verb{STAN_THREADS=} and so
+overrides \code{make/local} too.}
 
 \item{stanc_options}{(list) Any Stan-to-C++ transpiler options to be used
 when compiling the model. See the \strong{Examples} section below as well as the

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -41,14 +41,18 @@ program. Relative paths are resolved against the working directory when
 the model object is created (or when \verb{$compile()} is called) and stored as
 absolute paths, so subsequent changes to the working directory do not
 affect them. If \verb{$compile()} is called again without \code{include_paths}, the
-most recently supplied paths are reused.}
+most recently supplied paths are reused, and changing them forces
+recompilation. Edits to the included files themselves do not; see
+\code{force_recompile}.}
 
 \item{user_header}{(string) The path to a C++ file (with a .hpp extension)
 to compile with the Stan model. If \verb{$compile()} is called again without
 \code{user_header}, the most recently supplied header is reused, and changing
 it forces recompilation. Pass \code{user_header = NULL} to compile without one.
 A header can also be supplied via \code{cpp_options} as \code{USER_HEADER} or
-\code{user_header}; the \code{user_header} argument takes precedence over both.}
+\code{user_header}; the \code{user_header} argument takes precedence over both.
+See \code{force_recompile} for the case of a header supplied for a program
+whose executable is already up to date.}
 
 \item{cpp_options}{(list) Any makefile options to be used when compiling the
 model (\code{stan_threads}, \code{stan_mpi}, \code{stan_opencl}, etc.). Anything you would
@@ -67,7 +71,16 @@ on available options.}
 
 \item{force_recompile}{(logical) Should the model be recompiled even if it
 has not been modified since it was last compiled? The default is \code{FALSE}.
-Can also be set via a global \code{cmdstanr_force_recompile} option.}
+Can also be set via a global \code{cmdstanr_force_recompile} option.
+
+Only the Stan program itself and the user header (if any) are checked for
+modification. Files pulled in by \verb{#include} directives are not, at any
+depth, so editing an included file does not on its own trigger
+recompilation. Use \code{force_recompile = TRUE} after changing one. Similarly,
+when a model object is created for a Stan program whose executable already
+exists and is up to date, CmdStanR cannot tell which \code{user_header} or
+\code{include_paths} that executable was built with, so supplying different
+ones does not force a rebuild.}
 
 \item{compile_model_methods}{(logical) Compile additional model methods
 (\code{log_prob()}, \code{grad_log_prob()}, \code{hessian()}, \code{constrain_variables()},

--- a/tests/testthat/_snaps/model-compile.md
+++ b/tests/testthat/_snaps/model-compile.md
@@ -1,0 +1,11 @@
+# a leftover backup doesn't unwind a compile when warnings are errors
+
+    Code
+      withr::with_options(list(warn = 2), model$compile(cpp_options = list(
+        stan_threads = TRUE), force_recompile = TRUE))
+    Message
+      mock-compile-was-called
+    Condition
+      Error:
+      ! (converted from warning) The previously compiled executable could not be removed. It has been left at '<dir>/exe-old-<random>'.
+

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -60,3 +60,42 @@
       Error:
       ! Could not install the compiled executable at '<dir>/model-exe' and the previously compiled executable could not be restored. It has been kept at '<dir>/exe-old-<random>'.
 
+# local_make_local_backup() stops when file backup creation fails
+
+    Code
+      local({
+        local_make_local_backup()
+      })
+    Condition
+      Error:
+      ! Could not create a verified recovery backup of CmdStan's 'make/local' at '<fake-cmdstan>/make/local.cmdstanr-test-backup'. 'make/local' was not modified.
+
+# local_make_local_backup() stops when sentinel creation fails
+
+    Code
+      local({
+        local_make_local_backup()
+      })
+    Condition
+      Error:
+      ! Could not create a verified recovery backup of CmdStan's 'make/local' at '<fake-cmdstan>/make/local.cmdstanr-test-backup'. 'make/local' was not modified.
+
+# local_make_local_backup() retains a failed recovery backup
+
+    Code
+      local({
+        local_make_local_backup()
+        writeLines("MUTATED=true", make_local_path)
+      })
+    Condition
+      Error:
+      ! Could not restore CmdStan's 'make/local'. The recovery backup has been retained at '<fake-cmdstan>/make/local.cmdstanr-test-backup'.
+
+# restore_cmdstan_make_local() preserves the backup when verification fails
+
+    Code
+      restore_cmdstan_make_local()
+    Condition
+      Error:
+      ! Could not restore CmdStan's 'make/local'. The recovery backup has been retained at '<fake-cmdstan>/make/local.cmdstanr-test-backup'.
+

--- a/tests/testthat/_snaps/utils.md
+++ b/tests/testthat/_snaps/utils.md
@@ -28,3 +28,35 @@
       Error:
       ! Failed to move files: one or more files could not be copied. No original files were removed.
 
+# install_executable() leaves the destination alone if staging fails
+
+    Code
+      install_executable(fixture$from, fixture$to)
+    Condition
+      Error:
+      ! Could not stage the compiled executable at '<dir>/exe-new-<random>'. The model executable at '<dir>/model-exe' was not modified.
+
+# install_executable() leaves the destination alone if the backup fails
+
+    Code
+      install_executable(fixture$from, fixture$to)
+    Condition
+      Error:
+      ! Could not move the existing executable '<dir>/model-exe' aside. It was not modified.
+
+# install_executable() restores the backup if the install fails
+
+    Code
+      install_executable(fixture$from, fixture$to)
+    Condition
+      Error:
+      ! Could not install the compiled executable at '<dir>/model-exe'. The previously compiled executable has been restored.
+
+# install_executable() keeps the backup if it cannot be restored
+
+    Code
+      install_executable(fixture$from, fixture$to)
+    Condition
+      Error:
+      ! Could not install the compiled executable at '<dir>/model-exe' and the previously compiled executable could not be restored. It has been kept at '<dir>/exe-old-<random>'.
+

--- a/tests/testthat/helper-envvars-and-paths.R
+++ b/tests/testthat/helper-envvars-and-paths.R
@@ -24,11 +24,54 @@ delete_extensions <- function() {
   }
 }
 
+# Tracks whether an outer local_cmdstan_make_local() is holding the on-disk
+# backup, so nested calls restore in memory without disturbing it.
+make_local_backup <- new.env(parent = emptyenv())
+make_local_backup$held <- FALSE
+
+make_local_backup_path <- function() {
+  # make/ is included file by file, with no globs, so this is inert to make.
+  file.path(cmdstan_path(), "make", "local.cmdstanr-test-backup")
+}
+
+# Restore make/local from the on-disk backup and remove it. An empty backup
+# stands for "no make/local", which make treats the same as an empty one.
+restore_cmdstan_make_local <- function() {
+  backup_path <- make_local_backup_path()
+  if (!file.exists(backup_path)) {
+    return(invisible(NULL))
+  }
+  make_local_path <- file.path(cmdstan_path(), "make", "local")
+  if (file.size(backup_path) == 0) {
+    unlink(make_local_path)
+  } else {
+    file.copy(backup_path, make_local_path, overwrite = TRUE)
+  }
+  unlink(backup_path)
+  invisible(NULL)
+}
+
 # Write cpp_options to the make/local of the current CmdStan installation and
 # restore its original contents (or absence) when `envir` exits. Called at the
 # top level of a test file, the restore runs after all tests in that file.
+#
+# The outermost call also copies make/local aside for the duration. That copy is
+# what makes a killed run recoverable: the restore below never runs, but the next
+# call heals from the backup before taking its own snapshot, instead of adopting
+# the residue as its baseline and compounding it.
 local_cmdstan_make_local <- function(cpp_options, envir = parent.frame()) {
   make_local_path <- file.path(cmdstan_path(), "make", "local")
+  outermost <- !isTRUE(make_local_backup$held)
+  if (outermost) {
+    restore_cmdstan_make_local()
+    backup_path <- make_local_backup_path()
+    if (file.exists(make_local_path)) {
+      file.copy(make_local_path, backup_path, overwrite = TRUE)
+    } else {
+      file.create(backup_path)
+    }
+    make_local_backup$held <- TRUE
+  }
   make_local_orig <- if (file.exists(make_local_path)) {
     readBin(make_local_path, "raw", file.size(make_local_path))
   } else {
@@ -40,6 +83,10 @@ local_cmdstan_make_local <- function(cpp_options, envir = parent.frame()) {
         unlink(make_local_path)
       } else {
         writeBin(make_local_orig, make_local_path)
+      }
+      if (outermost) {
+        unlink(make_local_backup_path())
+        make_local_backup$held <- FALSE
       }
     },
     envir = envir

--- a/tests/testthat/helper-envvars-and-paths.R
+++ b/tests/testthat/helper-envvars-and-paths.R
@@ -34,6 +34,16 @@ make_local_backup_path <- function() {
   file.path(cmdstan_path(), "make", "local.cmdstanr-test-backup")
 }
 
+read_make_local_contents <- function(path) {
+  if (!file.exists(path)) {
+    return(NULL)
+  }
+  tryCatch(
+    readBin(path, "raw", file.size(path)),
+    error = function(e) FALSE
+  )
+}
+
 # Restore make/local from the on-disk backup and remove it. An empty backup
 # stands for "no make/local", which make treats the same as an empty one.
 restore_cmdstan_make_local <- function() {
@@ -42,12 +52,37 @@ restore_cmdstan_make_local <- function() {
     return(invisible(NULL))
   }
   make_local_path <- file.path(cmdstan_path(), "make", "local")
-  if (file.size(backup_path) == 0) {
-    unlink(make_local_path)
+  backup_contents <- read_make_local_contents(backup_path)
+  if (!is.raw(backup_contents)) {
+    restored <- FALSE
+  } else if (length(backup_contents) == 0) {
+    suppressWarnings(unlink(make_local_path))
+    restored <- !file.exists(make_local_path)
   } else {
-    file.copy(backup_path, make_local_path, overwrite = TRUE)
+    tryCatch(
+      suppressWarnings(file.copy(backup_path, make_local_path, overwrite = TRUE)),
+      error = function(e) FALSE
+    )
+    restored <- identical(
+      read_make_local_contents(make_local_path),
+      backup_contents
+    )
   }
-  unlink(backup_path)
+  if (!isTRUE(restored)) {
+    stop(
+      "Could not restore CmdStan's 'make/local'. The recovery backup has ",
+      "been retained at '", backup_path, "'.",
+      call. = FALSE
+    )
+  }
+  suppressWarnings(unlink(backup_path))
+  if (file.exists(backup_path)) {
+    stop(
+      "CmdStan's 'make/local' was restored, but the recovery backup could ",
+      "not be removed from '", backup_path, "'.",
+      call. = FALSE
+    )
+  }
   invisible(NULL)
 }
 
@@ -65,28 +100,69 @@ local_make_local_backup <- function(envir = parent.frame()) {
   if (outermost) {
     restore_cmdstan_make_local()
     backup_path <- make_local_backup_path()
-    if (file.exists(make_local_path)) {
-      file.copy(make_local_path, backup_path, overwrite = TRUE)
+    make_local_orig <- read_make_local_contents(make_local_path)
+    if (is.raw(make_local_orig)) {
+      created <- tryCatch(
+        suppressWarnings(
+          file.copy(make_local_path, backup_path, overwrite = TRUE)
+        ),
+        error = function(e) FALSE
+      )
     } else {
-      file.create(backup_path)
+      created <- tryCatch(
+        suppressWarnings(file.create(backup_path)),
+        error = function(e) FALSE
+      )
+    }
+    backup_contents <- read_make_local_contents(backup_path)
+    expected_backup <- if (is.null(make_local_orig)) raw() else make_local_orig
+    if (!isTRUE(created) || !identical(backup_contents, expected_backup)) {
+      suppressWarnings(unlink(backup_path))
+      stop(
+        "Could not create a verified recovery backup of CmdStan's ",
+        "'make/local' at '", backup_path, "'. 'make/local' was not modified.",
+        call. = FALSE
+      )
     }
     make_local_backup$held <- TRUE
-  }
-  make_local_orig <- if (file.exists(make_local_path)) {
-    readBin(make_local_path, "raw", file.size(make_local_path))
   } else {
-    NULL
+    make_local_orig <- read_make_local_contents(make_local_path)
+    if (!is.null(make_local_orig) && !is.raw(make_local_orig)) {
+      stop(
+        "Could not snapshot CmdStan's 'make/local' for nested restoration. ",
+        "The recovery backup is at '", make_local_backup_path(), "'.",
+        call. = FALSE
+      )
+    }
   }
   withr::defer(
     {
-      if (is.null(make_local_orig)) {
-        unlink(make_local_path)
-      } else {
-        writeBin(make_local_orig, make_local_path)
-      }
       if (outermost) {
-        unlink(make_local_backup_path())
+        # Clear this before restoration so an error cannot poison later calls.
         make_local_backup$held <- FALSE
+        restore_cmdstan_make_local()
+      } else {
+        tryCatch(
+          {
+            if (is.null(make_local_orig)) {
+              suppressWarnings(unlink(make_local_path))
+            } else {
+              writeBin(make_local_orig, make_local_path)
+            }
+          },
+          error = function(e) FALSE
+        )
+        if (!identical(
+          read_make_local_contents(make_local_path),
+          make_local_orig
+        )) {
+          stop(
+            "Could not restore nested CmdStan 'make/local' state. The ",
+            "recovery backup has been retained at '",
+            make_local_backup_path(), "'.",
+            call. = FALSE
+          )
+        }
       }
     },
     envir = envir

--- a/tests/testthat/helper-envvars-and-paths.R
+++ b/tests/testthat/helper-envvars-and-paths.R
@@ -24,7 +24,7 @@ delete_extensions <- function() {
   }
 }
 
-# Tracks whether an outer local_cmdstan_make_local() is holding the on-disk
+# Tracks whether an outer local_make_local_backup() is holding the on-disk
 # backup, so nested calls restore in memory without disturbing it.
 make_local_backup <- new.env(parent = emptyenv())
 make_local_backup$held <- FALSE
@@ -51,15 +51,15 @@ restore_cmdstan_make_local <- function() {
   invisible(NULL)
 }
 
-# Write cpp_options to the make/local of the current CmdStan installation and
-# restore its original contents (or absence) when `envir` exits. Called at the
-# top level of a test file, the restore runs after all tests in that file.
+# Restore the make/local of the current CmdStan installation when `envir` exits,
+# without writing to it. Use this directly when the test does its own writing;
+# use local_cmdstan_make_local() below when it just wants options set.
 #
 # The outermost call also copies make/local aside for the duration. That copy is
 # what makes a killed run recoverable: the restore below never runs, but the next
 # call heals from the backup before taking its own snapshot, instead of adopting
 # the residue as its baseline and compounding it.
-local_cmdstan_make_local <- function(cpp_options, envir = parent.frame()) {
+local_make_local_backup <- function(envir = parent.frame()) {
   make_local_path <- file.path(cmdstan_path(), "make", "local")
   outermost <- !isTRUE(make_local_backup$held)
   if (outermost) {
@@ -91,5 +91,14 @@ local_cmdstan_make_local <- function(cpp_options, envir = parent.frame()) {
     },
     envir = envir
   )
-  cmdstan_make_local(cpp_options = cpp_options)
+  invisible(NULL)
+}
+
+# Write cpp_options to the make/local of the current CmdStan installation and
+# restore its original contents (or absence) when `envir` exits. Called at the
+# top level of a test file, the restore runs after all tests in that file.
+local_cmdstan_make_local <- function(cpp_options, envir = parent.frame(),
+                                     append = TRUE) {
+  local_make_local_backup(envir = envir)
+  cmdstan_make_local(cpp_options = cpp_options, append = append)
 }

--- a/tests/testthat/helper-mock-cli.R
+++ b/tests/testthat/helper-mock-cli.R
@@ -12,6 +12,13 @@ with_mocked_cli <- function(code, compile_ret, info_ret) {
         && startsWith(basename(args[1]), "model-")
       ) {
         message("mock-compile-was-called")
+        # Real `make` writes the executable named by args[1] when it succeeds and
+        # writes nothing when it fails. Without this, code that installs the
+        # compiled artifact silently has nothing to install. `isTRUE()` because
+        # callers may pass a `compile_ret` with no status at all.
+        if (isTRUE(compile_ret$status == 0)) {
+          file.create(wsl_safe_path(args[1], revert = TRUE))
+        }
         compile_ret
       } else if (!is.null(args) && args[1] == "info") {
         info_ret

--- a/tests/testthat/helper-mock-cli.R
+++ b/tests/testthat/helper-mock-cli.R
@@ -16,8 +16,12 @@ with_mocked_cli <- function(code, compile_ret, info_ret) {
         # writes nothing when it fails. Without this, code that installs the
         # compiled artifact silently has nothing to install. `isTRUE()` because
         # callers may pass a `compile_ret` with no status at all.
+        # Executable mode as well, so that installation losing it is something
+        # the tests can notice rather than something the mock never modelled.
         if (isTRUE(compile_ret$status == 0)) {
-          file.create(wsl_safe_path(args[1], revert = TRUE))
+          mock_exe <- wsl_safe_path(args[1], revert = TRUE)
+          file.create(mock_exe)
+          Sys.chmod(mock_exe, "0755", use_umask = FALSE)
         }
         compile_ret
       } else if (!is.null(args) && args[1] == "info") {

--- a/tests/testthat/helper-mock-cli.R
+++ b/tests/testthat/helper-mock-cli.R
@@ -1,5 +1,17 @@
 real_wcr <- wsl_compatible_run
 
+# Distinct contents for every mocked build in the session. A mock that wrote the
+# same empty file each time could not tell "the new artifact was installed" from
+# "the old one was left in place", which is the invariant most of these tests
+# exist to check.
+mock_exe_contents <- local({
+  n <- 0L
+  function() {
+    n <<- n + 1L
+    paste0("mock executable ", n)
+  }
+})
+
 with_mocked_cli <- function(code, compile_ret, info_ret) {
   code <- substitute(code)
   caller <- parent.frame()
@@ -22,7 +34,7 @@ with_mocked_cli <- function(code, compile_ret, info_ret) {
         # the tests can notice rather than something the mock never modelled.
         if (isTRUE(compile_ret$status == 0)) {
           mock_exe <- wsl_safe_path(args[1], revert = TRUE)
-          file.create(mock_exe)
+          writeLines(mock_exe_contents(), mock_exe)
           Sys.chmod(mock_exe, "0755", use_umask = FALSE)
         }
         compile_ret

--- a/tests/testthat/helper-mock-cli.R
+++ b/tests/testthat/helper-mock-cli.R
@@ -6,8 +6,10 @@ with_mocked_cli <- function(code, compile_ret, info_ret) {
   local_mocked_bindings(
     wsl_compatible_run = function(command, args, ...) {
       if (
+        # make_cmd() rather than "make": production honours $MAKE, so a literal
+        # comparison lets the mock be bypassed and the real command run.
         !is.null(command)
-        && command == "make"
+        && command == make_cmd()
         && !is.null(args)
         && startsWith(basename(args[1]), "model-")
       ) {

--- a/tests/testthat/helper-mock-cli.R
+++ b/tests/testthat/helper-mock-cli.R
@@ -1,9 +1,6 @@
 real_wcr <- wsl_compatible_run
 
-# Distinct contents for every mocked build in the session. A mock that wrote the
-# same empty file each time could not tell "the new artifact was installed" from
-# "the old one was left in place", which is the invariant most of these tests
-# exist to check.
+# Use distinct contents so tests can tell successive builds apart.
 mock_exe_contents <- local({
   n <- 0L
   function() {
@@ -18,20 +15,14 @@ with_mocked_cli <- function(code, compile_ret, info_ret) {
   local_mocked_bindings(
     wsl_compatible_run = function(command, args, ...) {
       if (
-        # make_cmd() rather than "make": production honours $MAKE, so a literal
-        # comparison lets the mock be bypassed and the real command run.
+        # Match the configured make command.
         !is.null(command)
         && command == make_cmd()
         && !is.null(args)
         && startsWith(basename(args[1]), "model-")
       ) {
         message("mock-compile-was-called")
-        # Real `make` writes the executable named by args[1] when it succeeds and
-        # writes nothing when it fails. Without this, code that installs the
-        # compiled artifact silently has nothing to install. `isTRUE()` because
-        # callers may pass a `compile_ret` with no status at all.
-        # Executable mode as well, so that installation losing it is something
-        # the tests can notice rather than something the mock never modelled.
+        # Successful builds create an executable artifact, just like make.
         if (isTRUE(compile_ret$status == 0)) {
           mock_exe <- wsl_safe_path(args[1], revert = TRUE)
           writeLines(mock_exe_contents(), mock_exe)

--- a/tests/testthat/test-cpp_opts.R
+++ b/tests/testthat/test-cpp_opts.R
@@ -155,3 +155,41 @@ test_that("exe_info cpp_options comparison works", {
     "Recompiling is recommended"
   )
 })
+
+test_that("exe_info comparison reads cpp_options the way make does", {
+  # Upper-case, as model_compile_info() reports it.
+  disabled <- list(STAN_THREADS = FALSE)
+
+  # An unnamed raw assignment is as much a request as a named one; reading the
+  # list's names cannot see it.
+  expect_not_true(
+    exe_info_reflects_cpp_options(disabled, list("STAN_THREADS=TRUE"))
+  )
+
+  # Every duplicate reaches make and a makefile takes the last, so the order
+  # decides which of these agrees.
+  expect_true(exe_info_reflects_cpp_options(
+    disabled,
+    list(stan_threads = TRUE, stan_threads = NULL)
+  ))
+  expect_not_true(exe_info_reflects_cpp_options(
+    disabled,
+    list(stan_threads = NULL, stan_threads = TRUE)
+  ))
+
+  # A vector value expands into one assignment per element. This used to error.
+  expect_not_true(exe_info_reflects_cpp_options(
+    disabled,
+    list(stan_threads = c(TRUE, FALSE))
+  ))
+
+  # Non-empty enables whatever the value, so FALSE does not ask for "off".
+  expect_not_true(
+    exe_info_reflects_cpp_options(disabled, list(stan_threads = FALSE))
+  )
+
+  # An option the binary cannot report is unverifiable, not a mismatch.
+  expect_true(
+    exe_info_reflects_cpp_options(disabled, list(my_custom_make_flag = TRUE))
+  )
+})

--- a/tests/testthat/test-model-code-print.R
+++ b/tests/testthat/test-model-code-print.R
@@ -23,7 +23,7 @@ test_that("code() and print() still work if file is removed", {
   expect_identical(mod_removed_stan_file$code(), code_answer)
 })
 
-test_that("code() doesn't change when file changes (unless model is recreated)", {
+test_that("code() doesn't change when file changes (unless recompiled or recreated)", {
   code_1 <- "
   parameters {
     real y;
@@ -52,11 +52,20 @@ test_that("code() doesn't change when file changes (unless model is recreated)",
   # overwrite with new code, but mod$code() shouldn't change
   file.copy(stan_file_2, stan_file_1, overwrite = TRUE)
   expect_identical(mod$code(), code_1_answer)
+  expect_identical(utils::capture.output(mod$print()), code_1_answer)
 
   # recreate CmdStanModel object, now mod$code() should change
   mod <- cmdstan_model(stan_file_1, compile = FALSE)
   expect_identical(mod$code(), code_2_answer)
   expect_identical(utils::capture.output(mod$print()), code_2_answer)
+
+  # overwrite with the original code, mod$code() shouldn't change until the
+  # model is successfully recompiled (#1228)
+  writeLines(code_1_answer, stan_file_1)
+  expect_identical(mod$code(), code_2_answer)
+  mod$compile()
+  expect_identical(mod$code(), code_1_answer)
+  expect_identical(utils::capture.output(mod$print()), code_1_answer)
 })
 
 test_that("code() warns and print() errors if only exe and no Stan file", {

--- a/tests/testthat/test-model-code-print.R
+++ b/tests/testthat/test-model-code-print.R
@@ -59,8 +59,7 @@ test_that("code() doesn't change when file changes (unless recompiled or recreat
   expect_identical(mod$code(), code_2_answer)
   expect_identical(utils::capture.output(mod$print()), code_2_answer)
 
-  # overwrite with the original code, mod$code() shouldn't change until the
-  # model is successfully recompiled (#1228)
+  # Recompilation refreshes the cached code (#1228).
   writeLines(code_1_answer, stan_file_1)
   expect_identical(mod$code(), code_2_answer)
   mod$compile()

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -6,9 +6,7 @@ local_mocked_stanc <- function(.local_envir = parent.frame()) {
   )
 }
 
-# A mocked compile installs an executable, so anything that compiles for real
-# (even with a mocked compiler) works on a temporary copy rather than writing
-# into the package's test resources.
+# Mocked compiles use temporary model copies to protect test resources.
 local_external_model <- function(.local_envir = parent.frame()) {
   stan_file <- file.path(
     withr::local_tempdir(.local_envir = .local_envir),
@@ -26,9 +24,7 @@ user_header_routes <- function(header) {
   )
 }
 
-# This test is deliberately placed above the file-level skip_if(os_is_macos())
-# below: it mocks the stanc call and never compiles, so it needs no toolchain
-# and should run on every platform.
+# Keep mocked compilation tests above the toolchain skip below.
 test_that("cpp_options user headers allow undefined functions", {
   stan_file <- testing_stan_file("bernoulli_external")
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
@@ -61,8 +57,6 @@ test_that("cpp_options user headers allow undefined functions", {
   )
 })
 
-# Also above the file-level skip_if() below: the compiler is mocked, so these
-# need no toolchain either.
 test_that("compile() reuses the user header from the previous compilation", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli_external.stan")
   file.copy(testing_stan_file("bernoulli_external"), stan_file)
@@ -128,8 +122,6 @@ test_that("a no-op compile preserves a header supplied via cpp_options", {
     wsl_safe_path(absolute_path(user_header))
   )
 
-  # The executable is up to date, so this call compiles nothing and must leave
-  # the options describing it alone.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -157,8 +149,7 @@ test_that("compile() uses a user header supplied to cmdstan_model()", {
     user_header = user_header,
     compile = FALSE
   )
-  # A mocked compile rather than a dry run: a dry run builds nothing, so it
-  # records nothing about a compiled artifact.
+  # Use a successful compile so its options are recorded.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -192,12 +183,8 @@ test_that("a header configured over a current executable does not rebuild", {
   Sys.setFileTime(header, Sys.time() - 60)
   Sys.setFileTime(exe, Sys.time())
 
-  # Nothing records which header an executable was built with -- the binary
-  # cannot report it and nothing is written alongside it -- so a fresh object
-  # cannot tell a header it was configured with from the one already compiled
-  # in. Rebuilding on the possibility would recompile in every new R session,
-  # so the up-to-date executable is kept and $cpp_options() does not claim a
-  # header it cannot vouch for. Documented under `force_recompile`.
+  # A fresh object cannot know which header built an existing executable, so it
+  # keeps the executable without recording the requested header.
   for (route in user_header_routes(header)) {
     model <- do.call(
       cmdstan_model,
@@ -210,8 +197,7 @@ test_that("a header configured over a current executable does not rebuild", {
     )
     expect_null(model$cpp_options()[["USER_HEADER"]])
     expect_null(model$cpp_options()[["user_header"]])
-    # Source configuration is a separate axis and still reflects the request:
-    # it is what makes stanc accept the undefined functions the header defines.
+    # Stanc still uses the configured header.
     expect_true(model$.__enclos_env__$private$using_user_header_)
   }
 })
@@ -303,8 +289,6 @@ test_that("a bare retry after a failed compile keeps the newly supplied header",
   expect_equal(private$user_header_, resolve_path(h1))
   expect_false(private$user_header_dirty_)
 
-  # The usual route to this is a bug in h2 itself, so the header the user just
-  # supplied has to survive the failure.
   with_mocked_cli(
     compile_ret = list(status = 1),
     info_ret = list(status = 1),
@@ -313,8 +297,7 @@ test_that("a bare retry after a failed compile keeps the newly supplied header",
   expect_equal(private$user_header_, resolve_path(h2))
   expect_true(private$user_header_dirty_)
 
-  # A bare retry must build h2 rather than reverting to h1 or no-op'ing: the
-  # reuse branch resolves back to h2, so nothing here looks like a change.
+  # A bare retry must build h2 rather than reverting to h1.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -369,8 +352,7 @@ test_that("user_header = NULL clears a header from every supply route", {
     )
     expect_true(private$using_user_header_)
 
-    # The executable is up to date but was built against a header the model no
-    # longer uses, so clearing has to force a rebuild rather than no-op.
+    # Clearing a compiled header must force a rebuild.
     with_mocked_cli(
       compile_ret = list(status = 0),
       info_ret = list(status = 1),
@@ -387,11 +369,7 @@ test_that("duplicate headers of one spelling take the last, as make does", {
   first <- withr::local_tempfile(lines = "", fileext = ".hpp")
   second <- withr::local_tempfile(lines = "", fileext = ".hpp")
 
-  # Every duplicate reaches make and a makefile takes the last, which is what
-  # the cpp_options parser implements. Reading with [["USER_HEADER"]] took the
-  # first instead, so the model compiled against a header make would not have
-  # used -- and removing by name dropped only one occurrence, leaving the other
-  # to reach make alongside the header selected here.
+  # Use the last duplicate and remove every header entry before calling make.
   for (spelling in c("USER_HEADER", "user_header")) {
     duplicated <- structure(
       list(first, second),
@@ -402,8 +380,7 @@ test_that("duplicate headers of one spelling take the last, as make does", {
     expect_length(resolved$cpp_options, 0)
   }
 
-  # Across spellings, the last of each is what make would have seen, and
-  # precedence still picks USER_HEADER. Neither survives the strip.
+  # USER_HEADER still takes precedence across spellings.
   mixed <- structure(
     list(first, second, first),
     names = c("user_header", "USER_HEADER", "user_header")
@@ -417,11 +394,7 @@ test_that("a NULL header entry clears a persisted one rather than being ignored"
   persisted <- withr::local_tempfile(lines = "", fileext = ".hpp")
   first <- withr::local_tempfile(lines = "", fileext = ".hpp")
 
-  # A NULL entry stands for an explicit `USER_HEADER=`, which make takes as
-  # clearing whatever came before it. Reading presence off the value made NULL
-  # indistinguishable from absence, so the persisted header was carried forward
-  # and the object described a header the build did not use. Every shape below
-  # went wrong the same way; only the trailing-duplicate one was reported.
+  # A NULL entry emits USER_HEADER= and clears any previous header.
   for (spelling in c("USER_HEADER", "user_header")) {
     single <- structure(list(NULL), names = spelling)
     resolved <- resolve_user_header(NULL, FALSE, single, previous = persisted)
@@ -599,64 +572,26 @@ test_that("cmdstan_model works with user_header with mock", {
 test_that("wsl path conversion is done as expected", {
   tmp_file <- withr::local_tempfile(lines = hpp, fileext = ".hpp")
   local_mocked_stanc()
-  # Mocked successful compiles rather than dry runs: only a compilation that
-  # produced an executable records the options describing it.
 
- # Case 1: arg
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = {
-      mod <- cmdstan_model(
-        stan_file = local_external_model(),
-        user_header = tmp_file
-      )
-    }
-  )
-
-  # USER_HEADER is converted
-  # user_header is NULL
-  expect_equal(mod$cpp_options()[['USER_HEADER']],  w_path(tmp_file))
-  expect_true(is.null(mod$cpp_options()[['user_header']]))
-
-  # Case 2: cpp opt USER_HEADER
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = {
-      mod <- cmdstan_model(
-        stan_file = local_external_model(),
-        cpp_options = list(
-          USER_HEADER = tmp_file
+  routes <- user_header_routes(tmp_file)
+  expected_names <- c("USER_HEADER", "USER_HEADER", "user_header")
+  for (i in seq_along(routes)) {
+    with_mocked_cli(
+      compile_ret = list(status = 0),
+      info_ret = list(status = 1),
+      code = {
+        mod <- do.call(
+          cmdstan_model,
+          c(list(stan_file = local_external_model()), routes[[i]])
         )
-      )
-    }
-  )
+      }
+    )
 
-  # USER_HEADER is converted
-  # user_header is unconverted
-  expect_equal(mod$cpp_options()[['USER_HEADER']],  w_path(tmp_file))
-  expect_true(is.null(mod$cpp_options()[['user_header']]))
-
-  # Case # 3: only user_header opt
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = {
-      mod <- cmdstan_model(
-        stan_file = local_external_model(),
-        cpp_options = list(
-          user_header = tmp_file
-        )
-      )
-    }
-  )
-
-
-  # In  other cases, in the *output* USER_HEADER is windows style user_header is not.
-  # In this case, USER_HEADER is null.
-  expect_true(is.null(mod$cpp_options()[['USER_HEADER']]))
-  expect_equal(mod$cpp_options()[['user_header']],  w_path(tmp_file))
+    expected_name <- expected_names[[i]]
+    other_name <- setdiff(c("USER_HEADER", "user_header"), expected_name)
+    expect_equal(mod$cpp_options()[[expected_name]], w_path(tmp_file))
+    expect_null(mod$cpp_options()[[other_name]])
+  }
 })
 
 test_that("user_header precedence order is correct", {
@@ -667,12 +602,9 @@ test_that("user_header precedence order is correct", {
   ))
 
   local_mocked_stanc()
-  # Asserted after a mocked successful compile rather than a dry run: only a
-  # compilation that produced an executable records the options describing it.
-  # The ignored spelling is dropped in every case, so the next compile has a
-  # single source for the header.
+  # Successful compiles record the selected header and drop ignored spellings.
 
-  # Case # 1: all 3 specified
+  # The explicit argument wins.
   mod <- cmdstan_model(local_external_model(), compile = FALSE)
   with_mocked_cli(
     compile_ret = list(status = 0),
@@ -688,16 +620,13 @@ test_that("user_header precedence order is correct", {
       )
     }, "User header specified both")
   )
-  # In this case:
-  # cpp_options[['USER_HEADER']] == tmp_files[1] <- actually used
-  # tmp_files[2] and tmp_files[3] are not stored
   expect_equal(
     match(!!(mod$cpp_options()[['USER_HEADER']]), w_path(tmp_files)),
     1
   )
   expect_null(mod$cpp_options()[['user_header']])
 
-  # Case # 2: Both opts, but no arg
+  # USER_HEADER wins over user_header.
   mod <- cmdstan_model(local_external_model(), compile = FALSE)
   with_mocked_cli(
     compile_ret = list(status = 0),
@@ -712,16 +641,13 @@ test_that("user_header precedence order is correct", {
       )
     }, "User header specified both")
   )
-  # In this case:
-  # cpp_options[['USER_HEADER']] == tmp_files[2] <- actually used
-  # tmp_files[3] is not stored
   expect_equal(
     match(!!(mod$cpp_options()[['USER_HEADER']]), w_path(tmp_files)),
     2
   )
   expect_null(mod$cpp_options()[['user_header']])
 
-  # Case # 3: Both opts, other order
+  # Option order does not change precedence.
   mod <- cmdstan_model(local_external_model(), compile = FALSE)
   with_mocked_cli(
     compile_ret = list(status = 0),
@@ -736,7 +662,6 @@ test_that("user_header precedence order is correct", {
       )
     }, "User header specified both")
   )
-  # Same as Case #2: USER_HEADER wins whichever order the two appear in
   expect_equal(
     match(!!(mod$cpp_options()[['USER_HEADER']]), w_path(tmp_files)),
     2

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -33,15 +33,19 @@ test_that("cpp_options user headers allow undefined functions", {
   )
 })
 
-# Also above the file-level skip_if() below: the compiler is mocked, so this
-# needs no toolchain either.
-test_that("compile() commits the user header setting after compiling", {
+# Also above the file-level skip_if() below: the compiler is mocked, so these
+# need no toolchain either.
+test_that("compile() reuses the user header from the previous compilation", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli_external.stan")
   file.copy(testing_stan_file("bernoulli_external"), stan_file)
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  received_stancflags <- list()
   local_mocked_bindings(
     get_cmdstan_flags = function(flag_name) character(),
-    get_standalone_hpp = function(stan_file, stancflags) ""
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
   )
   model <- cmdstan_model(stan_file, compile = FALSE)
   expect_false(model$.__enclos_env__$private$using_user_header_)
@@ -53,14 +57,46 @@ test_that("compile() commits the user header setting after compiling", {
   )
   expect_true(model$.__enclos_env__$private$using_user_header_)
 
-  # a bare recompile doesn't carry the user header over, so the setting is
-  # committed as FALSE, matching what was actually compiled
+  received_stancflags <- list()
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 0),
     code = model$compile(force_recompile = TRUE)
   )
-  expect_false(model$.__enclos_env__$private$using_user_header_)
+  expect_true(model$.__enclos_env__$private$using_user_header_)
+  expect_equal(
+    model$cpp_options()[["USER_HEADER"]],
+    wsl_safe_path(absolute_path(user_header))
+  )
+  expect_equal(
+    vapply(received_stancflags, function(x) "--allow-undefined" %in% x, logical(1)),
+    rep(TRUE, 2)
+  )
+})
+
+test_that("compile() uses a user header supplied to cmdstan_model()", {
+  stan_file <- testing_stan_file("bernoulli_external")
+  user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  received_stancflags <- list()
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
+  )
+
+  model <- cmdstan_model(stan_file, user_header = user_header, compile = FALSE)
+  model$compile(force_recompile = TRUE, dry_run = TRUE)
+
+  expect_equal(
+    model$cpp_options()[["USER_HEADER"]],
+    wsl_safe_path(absolute_path(user_header))
+  )
+  expect_equal(
+    vapply(received_stancflags, function(x) "--allow-undefined" %in% x, logical(1)),
+    rep(TRUE, 2)
+  )
 })
 
 skip_if(os_is_macos())

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -1,3 +1,31 @@
+local_mocked_stanc <- function(.local_envir = parent.frame()) {
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) "",
+    .env = .local_envir
+  )
+}
+
+# A mocked compile installs an executable, so anything that compiles for real
+# (even with a mocked compiler) works on a temporary copy rather than writing
+# into the package's test resources.
+local_external_model <- function(.local_envir = parent.frame()) {
+  stan_file <- file.path(
+    withr::local_tempdir(.local_envir = .local_envir),
+    "bernoulli_external.stan"
+  )
+  file.copy(testing_stan_file("bernoulli_external"), stan_file)
+  stan_file
+}
+
+user_header_routes <- function(header) {
+  list(
+    list(user_header = header),
+    list(cpp_options = list(USER_HEADER = header)),
+    list(cpp_options = list(user_header = header))
+  )
+}
+
 # This test is deliberately placed above the file-level skip_if(os_is_macos())
 # below: it mocks the stanc call and never compiles, so it needs no toolchain
 # and should run on every platform.
@@ -138,6 +166,173 @@ test_that("compile() uses a user header supplied to cmdstan_model()", {
   )
 })
 
+test_that("cmdstan_model() records a user header from every supply route", {
+  header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+
+  for (route in user_header_routes(header)) {
+    model <- do.call(
+      cmdstan_model,
+      c(list(testing_stan_file("bernoulli_external"), compile = FALSE), route)
+    )
+    private <- model$.__enclos_env__$private
+    expect_equal(private$user_header_, resolve_path(header))
+    expect_true(private$using_user_header_)
+    expect_false(private$user_header_dirty_)
+  }
+})
+
+test_that("cmdstan_model() honours an explicit user_header = NULL", {
+  header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+
+  expect_warning(
+    model <- cmdstan_model(
+      testing_stan_file("bernoulli_external"),
+      compile = FALSE,
+      user_header = NULL,
+      cpp_options = list(USER_HEADER = header)
+    ),
+    "User header specified both"
+  )
+
+  private <- model$.__enclos_env__$private
+  expect_null(private$user_header_)
+  expect_false(private$using_user_header_)
+  expect_null(private$precompile_cpp_options_[["USER_HEADER"]])
+  expect_null(private$precompile_cpp_options_[["user_header"]])
+})
+
+test_that("cmdstan_model() rejects an empty user header", {
+  expect_error(
+    cmdstan_model(
+      testing_stan_file("bernoulli_external"),
+      compile = FALSE,
+      user_header = character(0)
+    ),
+    "user_header"
+  )
+  model <- cmdstan_model(testing_stan_file("bernoulli_external"), compile = FALSE)
+  expect_error(model$compile(user_header = character(0)), "user_header")
+})
+
+test_that("a relative cpp_options user header survives a directory change", {
+  model_dir <- withr::local_tempdir()
+  file.copy(testing_stan_file("bernoulli_external"), model_dir)
+  writeLines("", file.path(model_dir, "header.hpp"))
+  local_mocked_stanc()
+
+  model <- withr::with_dir(
+    model_dir,
+    cmdstan_model(
+      "bernoulli_external.stan",
+      compile = FALSE,
+      cpp_options = list(USER_HEADER = "header.hpp")
+    )
+  )
+
+  expect_equal(
+    normalizePath(model$.__enclos_env__$private$user_header_),
+    normalizePath(file.path(model_dir, "header.hpp"))
+  )
+  # The compile happens from the test's own working directory.
+  expect_no_error(model$compile(force_recompile = TRUE, dry_run = TRUE))
+})
+
+test_that("a bare retry after a failed compile keeps the newly supplied header", {
+  stan_file <- local_external_model()
+  h1 <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  h2 <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  local_mocked_stanc()
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  private <- model$.__enclos_env__$private
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(user_header = h1, force_recompile = TRUE)
+  )
+  expect_equal(private$user_header_, resolve_path(h1))
+  expect_false(private$user_header_dirty_)
+
+  # The usual route to this is a bug in h2 itself, so the header the user just
+  # supplied has to survive the failure.
+  with_mocked_cli(
+    compile_ret = list(status = 1),
+    info_ret = list(status = 1),
+    code = expect_error(model$compile(user_header = h2), "An error occurred")
+  )
+  expect_equal(private$user_header_, resolve_path(h2))
+  expect_true(private$user_header_dirty_)
+
+  # A bare retry must build h2 rather than reverting to h1 or no-op'ing: the
+  # reuse branch resolves back to h2, so nothing here looks like a change.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_mock_compile(model$compile())
+  )
+  expect_equal(private$user_header_, resolve_path(h2))
+  expect_false(private$user_header_dirty_)
+  expect_equal(
+    model$cpp_options()[["USER_HEADER"]],
+    wsl_safe_path(resolve_path(h2))
+  )
+})
+
+test_that("changing the user header forces compilation", {
+  stan_file <- local_external_model()
+  h1 <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  h2 <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  local_mocked_stanc()
+  model <- cmdstan_model(stan_file, compile = FALSE)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(user_header = h1, force_recompile = TRUE)
+  )
+  # Older than the executable, so only the change of header identity can force
+  # a rebuild here (#813 only covers a header that was modified in place).
+  Sys.setFileTime(h2, file.mtime(model$exe_file()) - 60)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_mock_compile(model$compile(user_header = h2))
+  )
+  expect_equal(
+    model$cpp_options()[["USER_HEADER"]],
+    wsl_safe_path(resolve_path(h2))
+  )
+})
+
+test_that("user_header = NULL clears a header from every supply route", {
+  header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  local_mocked_stanc()
+
+  for (route in user_header_routes(header)) {
+    model <- cmdstan_model(local_external_model(), compile = FALSE)
+    private <- model$.__enclos_env__$private
+    with_mocked_cli(
+      compile_ret = list(status = 0),
+      info_ret = list(status = 1),
+      code = do.call(model$compile, c(route, list(force_recompile = TRUE)))
+    )
+    expect_true(private$using_user_header_)
+
+    # The executable is up to date but was built against a header the model no
+    # longer uses, so clearing has to force a rebuild rather than no-op.
+    with_mocked_cli(
+      compile_ret = list(status = 0),
+      info_ret = list(status = 1),
+      code = expect_mock_compile(model$compile(user_header = NULL))
+    )
+    expect_null(private$user_header_)
+    expect_false(private$using_user_header_)
+    expect_null(model$cpp_options()[["USER_HEADER"]])
+    expect_null(model$cpp_options()[["user_header"]])
+  }
+})
+
 skip_if(os_is_macos())
 
 w_path <- function(f) {
@@ -192,7 +387,10 @@ test_that("cmdstan_model works with user_header with mock", {
 
   with_mocked_cli(
     compile_ret = list(status = 0),
-    info_ret = list(),
+    # The mocked compile installs an executable, so the constructor queries it
+    # for compilation info; report a failure rather than an empty list, which
+    # model_compile_info() cannot interpret.
+    info_ret = list(status = 1),
     code = expect_mock_compile({
       mod_2 <- cmdstan_model(
         stan_file = testing_stan_file("bernoulli_external"),
@@ -205,8 +403,8 @@ test_that("cmdstan_model works with user_header with mock", {
 
   # Check recompilation upon changing header
   exe_mtime <- header_mtime + 10
-  # Mocked compile does not create the executable that real compilation writes.
-  file.create(file_that_exists)
+  # The mocked compile above installed the executable with a fresh mtime; pin it
+  # so the up-to-date check below compares against a known value.
   Sys.setFileTime(file_that_exists, exe_mtime)
   with_mocked_cli(
     compile_ret = list(status = 0),
@@ -226,8 +424,6 @@ test_that("cmdstan_model works with user_header with mock", {
     })
   )
 
-  # Mocked compile does not create the executable that real compilation writes.
-  file.create(mod$exe_file())
   Sys.setFileTime(mod$exe_file(), header_mtime + 10) # make exe newer than header
 
   # Alternative spec of user header
@@ -353,85 +549,80 @@ test_that("user_header precedence order is correct", {
     .local_envir = parent.frame(3)
   ))
 
+  local_mocked_stanc()
+  # Asserted after a mocked successful compile rather than a dry run: only a
+  # compilation that produced an executable records the options describing it.
+  # The ignored spelling is dropped in every case, so the next compile has a
+  # single source for the header.
+
   # Case # 1: all 3 specified
+  mod <- cmdstan_model(local_external_model(), compile = FALSE)
   with_mocked_cli(
-    compile_ret = list(status = 1),
-    info_ret = list(),
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
     code = expect_warning({
-      mod <- cmdstan_model(
-        stan_file = testing_stan_file("bernoulli_external"),
+      mod$compile(
         user_header = tmp_files[1],
         cpp_options = list(
           USER_HEADER = tmp_files[2],
           user_header = tmp_files[3]
         ),
-        dry_run = TRUE
+        force_recompile = TRUE
       )
     }, "User header specified both")
   )
   # In this case:
   # cpp_options[['USER_HEADER']] == tmp_files[1] <- actually used
-  # cpp_options[['user_header']] == tmp_files[3] <- ignored
-  # tmp_files[2] is not stored
+  # tmp_files[2] and tmp_files[3] are not stored
   expect_equal(
     match(!!(mod$cpp_options()[['USER_HEADER']]), w_path(tmp_files)),
     1
   )
-  expect_equal(
-    match(!!(mod$cpp_options()[['user_header']]), tmp_files),
-    3
-  )
+  expect_null(mod$cpp_options()[['user_header']])
 
   # Case # 2: Both opts, but no arg
+  mod <- cmdstan_model(local_external_model(), compile = FALSE)
   with_mocked_cli(
-    compile_ret = list(status = 1),
-    info_ret = list(),
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
     code = expect_warning({
-      mod <- cmdstan_model(
-        stan_file = testing_stan_file("bernoulli_external"),
+      mod$compile(
         cpp_options = list(
           USER_HEADER = tmp_files[2],
           user_header = tmp_files[3]
         ),
-        dry_run = TRUE
+        force_recompile = TRUE
       )
     }, "User header specified both")
   )
   # In this case:
-  # cpp_options[['USER_HEADER']] == tmp_files[2]
-  # cpp_options[['user_header']] == tmp_files[3]
-  # tmp_files[2] is not stored
+  # cpp_options[['USER_HEADER']] == tmp_files[2] <- actually used
+  # tmp_files[3] is not stored
   expect_equal(
     match(!!(mod$cpp_options()[['USER_HEADER']]), w_path(tmp_files)),
     2
   )
-  expect_equal(
-    match(!!(mod$cpp_options()[['user_header']]), tmp_files),
-    3
-  )
+  expect_null(mod$cpp_options()[['user_header']])
 
   # Case # 3: Both opts, other order
+  mod <- cmdstan_model(local_external_model(), compile = FALSE)
   with_mocked_cli(
-    compile_ret = list(status = 1),
-    info_ret = list(),
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
     code = expect_warning({
-      mod <- cmdstan_model(
-        stan_file = testing_stan_file("bernoulli_external"),
+      mod$compile(
         cpp_options = list(
           user_header = tmp_files[3],
           USER_HEADER = tmp_files[2]
         ),
-        dry_run = TRUE
+        force_recompile = TRUE
       )
     }, "User header specified both")
   )
-  # Same as Case #2
+  # Same as Case #2: USER_HEADER wins whichever order the two appear in
   expect_equal(
     match(!!(mod$cpp_options()[['USER_HEADER']]), w_path(tmp_files)),
     2
   )
-  expect_equal(
-    match(!!(mod$cpp_options()[['user_header']]), tmp_files),
-    3
-  )
+  expect_null(mod$cpp_options()[['user_header']])
 })

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -311,6 +311,34 @@ test_that("a bare retry after a failed compile keeps the newly supplied header",
   )
 })
 
+test_that("a header that does not exist is still recorded as the request", {
+  stan_file <- local_external_model()
+  header <- file.path(withr::local_tempdir(), "not_yet_written.hpp")
+  local_mocked_stanc()
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  private <- model$.__enclos_env__$private
+
+  expect_error(
+    model$compile(user_header = header, force_recompile = TRUE),
+    "does not exist"
+  )
+  expect_equal(private$user_header_, resolve_path(header))
+  expect_true(private$using_user_header_)
+  expect_true(private$user_header_dirty_)
+
+  # A bare retry once the header exists must build against it.
+  file.create(header)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_mock_compile(model$compile())
+  )
+  expect_equal(
+    model$cpp_options()[["USER_HEADER"]],
+    wsl_safe_path(resolve_path(header))
+  )
+})
+
 test_that("changing the user header forces compilation", {
   stan_file <- local_external_model()
   h1 <- withr::local_tempfile(lines = "", fileext = ".hpp")

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -142,7 +142,6 @@ test_that("a no-op compile preserves a header supplied via cpp_options", {
 })
 
 test_that("compile() uses a user header supplied to cmdstan_model()", {
-  stan_file <- testing_stan_file("bernoulli_external")
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
   received_stancflags <- list()
   local_mocked_bindings(
@@ -153,8 +152,18 @@ test_that("compile() uses a user header supplied to cmdstan_model()", {
     }
   )
 
-  model <- cmdstan_model(stan_file, user_header = user_header, compile = FALSE)
-  model$compile(force_recompile = TRUE, dry_run = TRUE)
+  model <- cmdstan_model(
+    local_external_model(),
+    user_header = user_header,
+    compile = FALSE
+  )
+  # A mocked compile rather than a dry run: a dry run builds nothing, so it
+  # records nothing about a compiled artifact.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(force_recompile = TRUE)
+  )
 
   expect_equal(
     model$cpp_options()[["USER_HEADER"]],
@@ -482,15 +491,18 @@ test_that("cmdstan_model works with user_header with mock", {
 
 test_that("wsl path conversion is done as expected", {
   tmp_file <- withr::local_tempfile(lines = hpp, fileext = ".hpp")
+  local_mocked_stanc()
+  # Mocked successful compiles rather than dry runs: only a compilation that
+  # produced an executable records the options describing it.
+
  # Case 1: arg
   with_mocked_cli(
-    compile_ret = list(status = 1),
-    info_ret = list(),
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
     code = {
       mod <- cmdstan_model(
-        stan_file = testing_stan_file("bernoulli_external"),
-        user_header = tmp_file,
-        dry_run = TRUE
+        stan_file = local_external_model(),
+        user_header = tmp_file
       )
     }
   )
@@ -502,15 +514,14 @@ test_that("wsl path conversion is done as expected", {
 
   # Case 2: cpp opt USER_HEADER
   with_mocked_cli(
-    compile_ret = list(status = 1),
-    info_ret = list(),
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
     code = {
       mod <- cmdstan_model(
-        stan_file = testing_stan_file("bernoulli_external"),
+        stan_file = local_external_model(),
         cpp_options = list(
           USER_HEADER = tmp_file
-        ),
-        dry_run = TRUE
+        )
       )
     }
   )
@@ -522,15 +533,14 @@ test_that("wsl path conversion is done as expected", {
 
   # Case # 3: only user_header opt
   with_mocked_cli(
-    compile_ret = list(status = 1),
-    info_ret = list(),
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
     code = {
       mod <- cmdstan_model(
-        stan_file = testing_stan_file("bernoulli_external"),
+        stan_file = local_external_model(),
         cpp_options = list(
           user_header = tmp_file
-        ),
-        dry_run = TRUE
+        )
       )
     }
   )

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -175,6 +175,47 @@ test_that("compile() uses a user header supplied to cmdstan_model()", {
   )
 })
 
+test_that("a header configured over a current executable does not rebuild", {
+  stan_file <- local_external_model()
+  header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  local_mocked_stanc()
+
+  # An executable that already exists and is newer than both the program and
+  # the header, built through a different object.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(stan_file, force_recompile = TRUE)
+  )
+  exe <- cmdstan_ext(strip_ext(stan_file))
+  Sys.setFileTime(stan_file, Sys.time() - 60)
+  Sys.setFileTime(header, Sys.time() - 60)
+  Sys.setFileTime(exe, Sys.time())
+
+  # Nothing records which header an executable was built with -- the binary
+  # cannot report it and nothing is written alongside it -- so a fresh object
+  # cannot tell a header it was configured with from the one already compiled
+  # in. Rebuilding on the possibility would recompile in every new R session,
+  # so the up-to-date executable is kept and $cpp_options() does not claim a
+  # header it cannot vouch for. Documented under `force_recompile`.
+  for (route in user_header_routes(header)) {
+    model <- do.call(
+      cmdstan_model,
+      c(list(stan_file, compile = FALSE), route)
+    )
+    with_mocked_cli(
+      compile_ret = list(status = 0),
+      info_ret = list(status = 1),
+      code = expect_no_mock_compile(model$compile())
+    )
+    expect_null(model$cpp_options()[["USER_HEADER"]])
+    expect_null(model$cpp_options()[["user_header"]])
+    # Source configuration is a separate axis and still reflects the request:
+    # it is what makes stanc accept the undefined functions the header defines.
+    expect_true(model$.__enclos_env__$private$using_user_header_)
+  }
+})
+
 test_that("cmdstan_model() records a user header from every supply route", {
   header <- withr::local_tempfile(lines = "", fileext = ".hpp")
 

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -33,6 +33,36 @@ test_that("cpp_options user headers allow undefined functions", {
   )
 })
 
+# Also above the file-level skip_if() below: the compiler is mocked, so this
+# needs no toolchain either.
+test_that("compile() commits the user header setting after compiling", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli_external.stan")
+  file.copy(testing_stan_file("bernoulli_external"), stan_file)
+  user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) ""
+  )
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  expect_false(model$.__enclos_env__$private$using_user_header_)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0),
+    code = model$compile(user_header = user_header, force_recompile = TRUE)
+  )
+  expect_true(model$.__enclos_env__$private$using_user_header_)
+
+  # a bare recompile doesn't carry the user header over, so the setting is
+  # committed as FALSE, matching what was actually compiled
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0),
+    code = model$compile(force_recompile = TRUE)
+  )
+  expect_false(model$.__enclos_env__$private$using_user_header_)
+})
+
 skip_if(os_is_macos())
 
 w_path <- function(f) {

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -383,6 +383,36 @@ test_that("user_header = NULL clears a header from every supply route", {
   }
 })
 
+test_that("duplicate headers of one spelling take the last, as make does", {
+  first <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  second <- withr::local_tempfile(lines = "", fileext = ".hpp")
+
+  # Every duplicate reaches make and a makefile takes the last, which is what
+  # the cpp_options parser implements. Reading with [["USER_HEADER"]] took the
+  # first instead, so the model compiled against a header make would not have
+  # used -- and removing by name dropped only one occurrence, leaving the other
+  # to reach make alongside the header selected here.
+  for (spelling in c("USER_HEADER", "user_header")) {
+    duplicated <- structure(
+      list(first, second),
+      names = c(spelling, spelling)
+    )
+    resolved <- resolve_user_header(NULL, FALSE, duplicated)
+    expect_equal(resolved$user_header, second)
+    expect_length(resolved$cpp_options, 0)
+  }
+
+  # Across spellings, the last of each is what make would have seen, and
+  # precedence still picks USER_HEADER. Neither survives the strip.
+  mixed <- structure(
+    list(first, second, first),
+    names = c("user_header", "USER_HEADER", "user_header")
+  )
+  resolved <- resolve_user_header(NULL, FALSE, mixed)
+  expect_equal(resolved$user_header, second)
+  expect_length(resolved$cpp_options, 0)
+})
+
 skip_if(os_is_macos())
 
 w_path <- function(f) {

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -413,6 +413,42 @@ test_that("duplicate headers of one spelling take the last, as make does", {
   expect_length(resolved$cpp_options, 0)
 })
 
+test_that("a NULL header entry clears a persisted one rather than being ignored", {
+  persisted <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  first <- withr::local_tempfile(lines = "", fileext = ".hpp")
+
+  # A NULL entry stands for an explicit `USER_HEADER=`, which make takes as
+  # clearing whatever came before it. Reading presence off the value made NULL
+  # indistinguishable from absence, so the persisted header was carried forward
+  # and the object described a header the build did not use. Every shape below
+  # went wrong the same way; only the trailing-duplicate one was reported.
+  for (spelling in c("USER_HEADER", "user_header")) {
+    single <- structure(list(NULL), names = spelling)
+    resolved <- resolve_user_header(NULL, FALSE, single, previous = persisted)
+    expect_null(resolved$user_header)
+    expect_length(resolved$cpp_options, 0)
+
+    duplicated <- structure(list(first, NULL), names = c(spelling, spelling))
+    resolved <- resolve_user_header(NULL, FALSE, duplicated, previous = persisted)
+    expect_null(resolved$user_header)
+    expect_length(resolved$cpp_options, 0)
+  }
+
+  # A non-NULL last occurrence still wins, so this is not just "any NULL clears".
+  kept <- structure(list(NULL, first), names = c("USER_HEADER", "USER_HEADER"))
+  resolved <- resolve_user_header(NULL, FALSE, kept, previous = persisted)
+  expect_equal(resolved$user_header, first)
+
+  # An entry that clears is still an entry, so it conflicts with the argument.
+  resolved <- resolve_user_header(
+    first,
+    TRUE,
+    list(USER_HEADER = NULL),
+    previous = persisted
+  )
+  expect_identical(resolved$conflict, "argument")
+})
+
 skip_if(os_is_macos())
 
 w_path <- function(f) {

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -74,6 +74,45 @@ test_that("compile() reuses the user header from the previous compilation", {
   )
 })
 
+test_that("a no-op compile preserves a header supplied via cpp_options", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli_external.stan")
+  file.copy(testing_stan_file("bernoulli_external"), stan_file)
+  user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) ""
+  )
+  model <- cmdstan_model(stan_file, compile = FALSE)
+
+  # The lowercase spelling is the telling one: a bare recompile re-derives the
+  # header under the USER_HEADER spelling, so only this one shows whether the
+  # no-op path rebuilt the recorded options or left them alone.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(
+      cpp_options = list(user_header = user_header),
+      force_recompile = TRUE
+    )
+  )
+  expect_equal(
+    model$cpp_options()[["user_header"]],
+    wsl_safe_path(absolute_path(user_header))
+  )
+
+  # The executable is up to date, so this call compiles nothing and must leave
+  # the options describing it alone.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(model$compile())
+  )
+  expect_equal(
+    model$cpp_options()[["user_header"]],
+    wsl_safe_path(absolute_path(user_header))
+  )
+})
+
 test_that("compile() uses a user header supplied to cmdstan_model()", {
   stan_file <- testing_stan_file("bernoulli_external")
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -968,6 +968,19 @@ test_that("cpp_options work with settings in make/local", {
   cmdstan_make_local(cpp_options = backup, append = FALSE)
 })
 
+test_that("a recompile records options inherited from make/local", {
+  local_cmdstan_make_local(cpp_options = list(STAN_THREADS = "true"))
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+  mod$compile(force_recompile = TRUE)
+
+  # Nothing was passed to $compile(), so only the binary can report threading.
+  expect_true(cpp_option_value(mod$cpp_options(), "stan_threads"))
+  expect_silent(assert_valid_threads(2, mod$cpp_options(), multiple_chains = TRUE))
+})
+
 test_that("cpp_options() excludes the Stan version reported by the executable", {
   mod <- cmdstan_model(stan_file = stan_program)
   expect_null(mod$cpp_options()$STAN_VERSION)

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -552,11 +552,19 @@ test_that("a leftover backup warns without discarding a successful compile", {
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
-    code = expect_warning(
+    code = condition <- expect_warning(
       model$compile(cpp_options = list(stan_threads = TRUE), force_recompile = TRUE),
       "could not be removed"
     )
   )
+
+  # Reporting the backup instead of deleting it is only worth anything if the
+  # path named is real and still holds the previous executable, so check the
+  # path out of the message rather than trusting that one was mentioned.
+  leftover <- sub(".*left at '([^']*)'.*", "\\1", conditionMessage(condition))
+  expect_true(file.exists(leftover))
+  expect_identical(readLines(leftover), "old executable")
+  expect_false(same_path(leftover, model$exe_file()))
 
   expect_describes_new_program(model)
 })

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -241,9 +241,7 @@ test_that("$compile() reuses include paths from the previous compilation", {
     include_paths = include_dir,
     compile = FALSE
   )
-  # A successful compile rather than a dry run: a dry run leaves
-  # precompile_include_paths_ in place, so the call after it can find the paths
-  # there and the reuse through the compiled state is never exercised.
+  # Use a successful compile to move the paths out of precompile state.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -251,8 +249,6 @@ test_that("$compile() reuses include paths from the previous compilation", {
   )
   expect_null(mod$.__enclos_env__$private$precompile_include_paths_)
 
-  # The include path isn't supplied again, but the included file is still found
-  # and the path still reaches stanc.
   received_stancflags <- list()
   with_mocked_cli(
     compile_ret = list(status = 0),
@@ -260,9 +256,7 @@ test_that("$compile() reuses include paths from the previous compilation", {
     code = expect_no_error(mod$compile(force_recompile = TRUE, quiet = TRUE))
   )
   expect_equal(mod$include_paths(), resolve_path(include_dir))
-  # Compared against the arguments stanc is actually handed, not the stored
-  # path: under WSL the model holds a Windows host path while the stanc
-  # argument is converted to /mnt/<drive>/..., so the two do not match.
+  # Compare stanc arguments because WSL converts stored Windows paths.
   include_args <- include_paths_stanc3_args(mod$include_paths(), direct_call = TRUE)
   expect_true(all(vapply(
     received_stancflags,
@@ -272,8 +266,7 @@ test_that("$compile() reuses include paths from the previous compilation", {
 })
 
 test_that("$compile() doesn't reuse cpp and stanc options from the previous compilation", {
-  # A mocked compile installs a real (empty) executable, so this has to build a
-  # temporary copy rather than the shared test model.
+  # Use a temporary copy because mocked compiles install executables.
   model_dir <- withr::local_tempdir()
   stan_file <- file.path(model_dir, "bernoulli.stan")
   file.copy(testing_stan_file("bernoulli"), stan_file)
@@ -287,10 +280,7 @@ test_that("$compile() doesn't reuse cpp and stanc options from the previous comp
     }
   )
 
-  # Successful compiles rather than dry runs: the precompile state these options
-  # travel in is cleared only once an executable has been installed, so a pair
-  # of dry runs never reaches the transition this test is named for and passes
-  # merely because arguments to one call are absent from another.
+  # Successful compiles clear one-shot cpp and stanc options.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -352,8 +342,6 @@ test_that("$compile() doesn't reuse cpp and stanc options supplied to cmdstan_mo
     rep(TRUE, 2)
   )
 
-  # The held options are released only by a successful compilation, so this is
-  # the transition that a pair of dry runs cannot reach.
   received_stancflags <- list()
   with_mocked_cli(
     compile_ret = list(status = 0),
@@ -504,14 +492,7 @@ test_that("a failed compile() doesn't refresh cached model state", {
   expect_false(model$functions$compiled)
 })
 
-# A compiled model whose compiler is mocked, so that stanc runs for real and
-# only the C++ stage can be made to fail. That is the case the tests above miss:
-# the generated C++ for the new program is already in hand, so any state derived
-# from it that is recorded before the executable is replaced would outlive a
-# failure and describe a program the executable was never built from.
-#
-# The copy is temporary because a mocked compile installs a real (empty)
-# executable, and the model here is the CmdStan installation's own example.
+# Run stanc normally but mock the C++ compiler on a temporary model copy.
 local_mocked_bernoulli_model <- function(.local_envir = parent.frame()) {
   stan_file <- file.path(
     withr::local_tempdir(.local_envir = .local_envir),
@@ -534,37 +515,15 @@ test_that("a failed C++ compile doesn't refresh generated-code state", {
   functions_before <- as.list(model$functions)
   hpp_file_before <- model$hpp_file()
   hpp_code_before <- private$model_methods_env_$hpp_code_
+  exe_before <- model$exe_file()
+  other_dir <- withr::local_tempdir()
   expect_true(any(nzchar(hpp_code_before)))
 
-  # The model-method environment is handed to every fit, so a stale pairing here
-  # means fit$init_model_methods() compiles log_prob() from a program the draws
-  # did not come from.
+  # model_methods_env_ must describe the same program as the executable.
   writeLines(
     "parameters { real beta; } model { beta ~ std_normal(); }",
     model$stan_file()
   )
-  with_mocked_cli(
-    compile_ret = list(status = 1),
-    info_ret = list(status = 1),
-    code = expect_error(
-      model$compile(force_recompile = TRUE),
-      "An error occurred during compilation!",
-      fixed = TRUE
-    )
-  )
-
-  expect_identical(model$code(), code_before)
-  expect_identical(model$variables(), variables_before)
-  expect_identical(as.list(model$functions), functions_before)
-  expect_identical(model$hpp_file(), hpp_file_before)
-  expect_identical(private$model_methods_env_$hpp_code_, hpp_code_before)
-})
-
-test_that("a failed C++ compile doesn't move the executable path", {
-  model <- local_mocked_bernoulli_model()
-  exe_before <- model$exe_file()
-  other_dir <- withr::local_tempdir()
-
   with_mocked_cli(
     compile_ret = list(status = 1),
     info_ret = list(status = 1),
@@ -575,49 +534,16 @@ test_that("a failed C++ compile doesn't move the executable path", {
     )
   )
 
+  expect_identical(model$code(), code_before)
+  expect_identical(model$variables(), variables_before)
+  expect_identical(as.list(model$functions), functions_before)
+  expect_identical(model$hpp_file(), hpp_file_before)
+  expect_identical(private$model_methods_env_$hpp_code_, hpp_code_before)
   expect_identical(model$exe_file(), exe_before)
   expect_true(file.exists(exe_before))
 })
 
-test_that("compile() errors if the executable cannot be replaced", {
-  model <- local_mocked_bernoulli_model()
-  exe <- model$exe_file()
-  writeLines("old executable", exe)
-
-  # Fail the first attempt to put a file at the destination. A replacement that
-  # fails unnoticed leaves the model with no executable at all.
-  real_file_copy <- base::file.copy
-  real_file_rename <- base::file.rename
-  installs <- 0
-  local_mocked_bindings(
-    file.copy = function(from, to, ...) {
-      if (identical(to, exe)) {
-        installs <<- installs + 1
-        if (installs == 1L) return(FALSE)
-      }
-      real_file_copy(from, to, ...)
-    },
-    file.rename = function(from, to) {
-      if (identical(to, exe)) {
-        installs <<- installs + 1
-        if (installs == 1L) return(FALSE)
-      }
-      real_file_rename(from, to)
-    },
-    .package = "base"
-  )
-
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = expect_error(model$compile(force_recompile = TRUE))
-  )
-  expect_true(file.exists(exe))
-  expect_identical(readLines(exe), "old executable")
-})
-
-# Set up a model whose executable is about to be replaced by a program that can
-# be told apart from it, with removal of the old executable's backup failing.
+# Build a distinct replacement whose old backup cannot be removed.
 local_leftover_backup_model <- function(.local_envir = parent.frame()) {
   model <- local_mocked_bernoulli_model(.local_envir = .local_envir)
   writeLines("old executable", model$exe_file())
@@ -643,43 +569,14 @@ expect_describes_new_program <- function(model) {
   expect_match(paste(private$model_methods_env_$hpp_code_, collapse = "\n"), "beta")
   expect_match(paste(readLines(model$hpp_file()), collapse = "\n"), "beta")
   expect_true(model$cpp_options()$stan_threads)
-  # The installed file is the mocked replacement rather than the executable it
-  # replaced, told apart by contents. Size alone used to carry this, because the
-  # mock wrote an empty file and the fixture's old executable was not empty.
   expect_match(readLines(model$exe_file()), "^mock executable ")
 }
-
-test_that("a leftover backup warns without discarding a successful compile", {
-  model <- local_leftover_backup_model()
-
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = condition <- expect_warning(
-      model$compile(cpp_options = list(stan_threads = TRUE), force_recompile = TRUE),
-      "could not be removed"
-    )
-  )
-
-  # Reporting the backup instead of deleting it is only worth anything if the
-  # path named is real and still holds the previous executable, so check the
-  # path out of the message rather than trusting that one was mentioned.
-  leftover <- sub(".*left at '([^']*)'.*", "\\1", conditionMessage(condition))
-  expect_true(file.exists(leftover))
-  expect_identical(readLines(leftover), "old executable")
-  expect_false(same_path(leftover, model$exe_file()))
-
-  expect_describes_new_program(model)
-})
 
 test_that("a leftover backup doesn't unwind a compile when warnings are errors", {
   model <- local_leftover_backup_model()
   model_dir <- dirname(model$exe_file())
 
-  # Signalling the cleanup failure before the state is committed would install
-  # the new executable while the object still described the old program -- the
-  # exact hybrid this all exists to prevent. The option is scoped to the call so
-  # that testthat's own snapshot warnings stay warnings.
+  # The warning must come after the new executable state is committed.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -689,8 +586,7 @@ test_that("a leftover backup doesn't unwind a compile when warnings are errors",
         list(warn = 2),
         model$compile(cpp_options = list(stan_threads = TRUE), force_recompile = TRUE)
       ),
-      # Separators are normalized first: on Windows the backup path arrives as
-      # "<dir>\exe-old-1234", since tempfile() joins with a backslash.
+      # Normalize Windows separators and the random backup name.
       transform = function(lines) {
         for (dir in unique(c(model_dir, repair_path(model_dir)))) {
           lines <- gsub(dir, "<dir>", lines, fixed = TRUE)
@@ -807,11 +703,10 @@ test_that("*hpp_file() functions work", {
   expect_equal(mod$hpp_file(), file.path(dirname(mod$stan_file()), "bernoulli.hpp"))
   mod$save_hpp_file(tmp_dir)
   expect_equal(mod$hpp_file(), file.path(tmp_dir, "bernoulli.hpp"))
-  # A dry run generates no C++, so it leaves the saved location alone rather
-  # than pointing $hpp_file() at a temporary file that was never written.
+  # A dry run leaves the saved header location unchanged.
   mod$compile(force_recompile = TRUE, dry_run = TRUE)
   expect_equal(mod$hpp_file(), file.path(tmp_dir, "bernoulli.hpp"))
-  # A real recompilation does write it, to a fresh temporary location.
+  # A real recompilation uses a fresh temporary header.
   expect_call_compilation(mod$compile(force_recompile = TRUE))
   expect_false(isTRUE(all.equal(mod$hpp_file(), file.path(tmp_dir, "bernoulli.hpp"))))
   expect_false(isTRUE(all.equal(mod$hpp_file(), file.path(dirname(mod$stan_file()), "bernoulli.hpp"))))
@@ -934,9 +829,7 @@ test_that("check_syntax() works with include_paths on compiled model", {
 
 test_that("check_syntax() and format() allow undefined functions with a user header", {
   stan_file <- testing_stan_file("bernoulli_external")
-  # both methods only run stanc, which never reads the user header, so an empty
-  # one is enough here. Compiling against a real header is tested in
-  # test-model-compile-user_header.R
+  # Stanc does not read the header, so an empty one is enough.
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
   mod <- cmdstan_model(stan_file, user_header = user_header, compile = FALSE)
 
@@ -1229,10 +1122,7 @@ test_that("format(overwrite_file = TRUE) refreshes cached variables", {
   model <- cmdstan_model(stan_file, compile = FALSE)
   expect_equal(names(model$variables()$parameters), "alpha")
 
-  # The program is edited behind the object's back, then formatted in place.
-  # $format() reloads $code() from disk, so a cached $variables() would go on
-  # describing a different program than $code() does -- and the fitting methods
-  # validate data and initial values against $variables(). (#1228)
+  # Formatting in place must refresh variables along with the cached code.
   writeLines(
     "parameters { real beta; } model { beta ~ std_normal(); }",
     stan_file
@@ -1605,10 +1495,7 @@ test_that("compile() checks it can commit before replacing the executable", {
 
   lockEnvironment(model$functions, bindings = FALSE)
 
-  # The commit block clears this environment in place, which is the one thing in
-  # it that is not an assignment, and it fails on a locked environment. Failing
-  # there installed the new executable and then left the object recording
-  # nothing about it -- exactly the hybrid the ordering exists to prevent.
+  # Clearing a locked environment would fail during the state commit.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -1622,50 +1509,6 @@ test_that("compile() checks it can commit before replacing the executable", {
   expect_length(model$exe_file(), 0)
 })
 
-test_that("compile() checks the functions environment is still there", {
-  model_dir <- withr::local_tempdir()
-  stan_file <- file.path(model_dir, "bernoulli.stan")
-  file.copy(testing_stan_file("bernoulli"), stan_file)
-  model <- cmdstan_model(stan_file, compile = FALSE)
-  exe <- cmdstan_ext(strip_ext(stan_file))
-
-  # R6's lock_objects prevents adding fields, not replacing them, so this is
-  # allowed. Without the check the commit block reached rm(envir = NULL) after
-  # the executable had already been installed.
-  model$functions <- NULL
-
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = expect_error(
-      model$compile(force_recompile = TRUE),
-      "missing or locked",
-      fixed = TRUE
-    )
-  )
-  expect_false(file.exists(exe))
-})
-
-test_that("compile() tolerates a locked binding in the functions environment", {
-  model_dir <- withr::local_tempdir()
-  stan_file <- file.path(model_dir, "bernoulli.stan")
-  file.copy(testing_stan_file("bernoulli"), stan_file)
-  model <- cmdstan_model(stan_file, compile = FALSE)
-
-  # A locked binding is not a locked environment: rm() still removes it, and the
-  # commit block's assignments then create bindings afresh rather than meeting a
-  # locked one. Rejecting this would refuse a compilation that works.
-  model$functions$compiled <- FALSE
-  lockBinding("compiled", model$functions)
-
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = expect_no_error(model$compile(force_recompile = TRUE))
-  )
-  expect_true(file.exists(cmdstan_ext(strip_ext(stan_file))))
-})
-
 test_that("compile() refuses an executable destination that is a directory", {
   model_dir <- withr::local_tempdir()
   stan_file <- file.path(model_dir, "bernoulli.stan")
@@ -1675,8 +1518,6 @@ test_that("compile() refuses an executable destination that is a directory", {
   writeLines("important", file.path(destination, "data.txt"))
 
   model <- cmdstan_model(stan_file, compile = FALSE)
-  # $exe_file(path) assigns without validating, so this is the shortest route to
-  # a destination the compile path never checks.
   model$exe_file(destination)
 
   with_mocked_cli(
@@ -1699,9 +1540,6 @@ test_that("compile() installs the artifact it just built, not the previous one",
   model <- cmdstan_model(stan_file, compile = FALSE)
   exe <- cmdstan_ext(strip_ext(stan_file))
 
-  # Each mocked build writes distinct contents, so "the new artifact was
-  # installed" is distinguishable from "the old one was left in place". While
-  # every build produced the same empty file, no test could tell the two apart.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -227,16 +227,44 @@ test_that("$compile() reuses include paths from the previous compilation", {
   file.copy(testing_stan_file("bernoulli_include"), model_dir)
   file.copy(testing_stan_file("divide_real_by_two"), include_dir)
 
+  received_stancflags <- list()
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
+  )
+
   mod <- cmdstan_model(
     file.path(model_dir, "bernoulli_include.stan"),
     include_paths = include_dir,
     compile = FALSE
   )
-  mod$compile(dry_run = TRUE, quiet = TRUE)
+  # A successful compile rather than a dry run: a dry run leaves
+  # precompile_include_paths_ in place, so the call after it can find the paths
+  # there and the reuse through the compiled state is never exercised.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = mod$compile(force_recompile = TRUE, quiet = TRUE)
+  )
+  expect_null(mod$.__enclos_env__$private$precompile_include_paths_)
 
-  # the include path isn't supplied again, but the included file is still found
-  expect_no_error(mod$compile(force_recompile = TRUE, dry_run = TRUE, quiet = TRUE))
+  # The include path isn't supplied again, but the included file is still found
+  # and the path still reaches stanc.
+  received_stancflags <- list()
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_error(mod$compile(force_recompile = TRUE, quiet = TRUE))
+  )
   expect_equal(mod$include_paths(), resolve_path(include_dir))
+  expect_true(all(vapply(
+    received_stancflags,
+    function(x) any(grepl(mod$include_paths(), x, fixed = TRUE)),
+    logical(1)
+  )))
 })
 
 test_that("$compile() doesn't reuse cpp and stanc options from the previous compilation", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -304,6 +304,58 @@ test_that("compile() performs stanc checks during dry runs", {
   )
 })
 
+test_that("compile() with dry_run = TRUE doesn't refresh cached model state", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- write_stan_file(
+    "parameters { real alpha; } model { alpha ~ std_normal(); }",
+    dir = model_dir,
+    basename = "issue1228-dry-run.stan"
+  )
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  code_before <- model$code()
+  variables_before <- model$variables()
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) ""
+  )
+
+  write_stan_file(
+    "parameters { real beta; } model { beta ~ std_normal(); }",
+    dir = model_dir,
+    basename = "issue1228-dry-run.stan"
+  )
+  model$compile(force_recompile = TRUE, dry_run = TRUE)
+
+  expect_identical(model$code(), code_before)
+  expect_identical(model$variables(), variables_before)
+  expect_equal(ls(model$functions), "compiled")
+  expect_false(model$functions$compiled)
+})
+
+test_that("a failed compile() doesn't refresh cached model state", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- write_stan_file(
+    "parameters { real alpha; } model { alpha ~ std_normal(); }",
+    dir = model_dir,
+    basename = "issue1228-failed-compile.stan"
+  )
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  code_before <- model$code()
+  variables_before <- model$variables()
+
+  file.copy(testing_stan_file("fail"), stan_file, overwrite = TRUE)
+  expect_error(
+    model$compile(force_recompile = TRUE),
+    "An error occurred during compilation!",
+    fixed = TRUE
+  )
+
+  expect_identical(model$code(), code_before)
+  expect_identical(model$variables(), variables_before)
+  expect_equal(ls(model$functions), "compiled")
+  expect_false(model$functions$compiled)
+})
+
 test_that("dir arg works for cmdstan_model and $compile()", {
   tmp_dir <- tempdir()
   tmp_dir_2 <- tempdir()

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -220,6 +220,53 @@ test_that("relative include_paths given to $compile() are resolved when it is ca
   expect_true(mod$check_syntax(quiet = TRUE))
 })
 
+test_that("$compile() reuses include paths from the previous compilation", {
+  model_dir <- withr::local_tempdir()
+  include_dir <- file.path(model_dir, "includes")
+  dir.create(include_dir)
+  file.copy(testing_stan_file("bernoulli_include"), model_dir)
+  file.copy(testing_stan_file("divide_real_by_two"), include_dir)
+
+  mod <- cmdstan_model(
+    file.path(model_dir, "bernoulli_include.stan"),
+    include_paths = include_dir,
+    compile = FALSE
+  )
+  mod$compile(dry_run = TRUE, quiet = TRUE)
+
+  # the include path isn't supplied again, but the included file is still found
+  expect_no_error(mod$compile(force_recompile = TRUE, dry_run = TRUE, quiet = TRUE))
+  expect_equal(mod$include_paths(), resolve_path(include_dir))
+})
+
+test_that("$compile() doesn't reuse cpp and stanc options from the previous compilation", {
+  stan_file <- testing_stan_file("bernoulli")
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  received_stancflags <- list()
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
+  )
+
+  model$compile(
+    cpp_options = list(stan_threads = TRUE),
+    stanc_options = list("warn-pedantic" = TRUE),
+    force_recompile = TRUE,
+    dry_run = TRUE
+  )
+  received_stancflags <- list()
+  model$compile(force_recompile = TRUE, dry_run = TRUE)
+
+  expect_null(model$cpp_options()[["stan_threads"]])
+  expect_equal(
+    vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
+    rep(FALSE, 2)
+  )
+})
+
 test_that("name in STANCFLAGS is set correctly", {
   local_reproducible_output()
   out <- utils::capture.output(mod$compile(quiet = FALSE, force_recompile = TRUE))

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -1593,3 +1593,29 @@ test_that("compile() ignores directory chatter from MAKEFLAGS when reading STANC
   withr::local_envvar(MAKEFLAGS = "-w -j 4")
   expect_compilation(mod, quiet = TRUE, force_recompile = TRUE)
 })
+
+test_that("compile() refuses an executable destination that is a directory", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(testing_stan_file("bernoulli"), stan_file)
+  destination <- file.path(model_dir, "target-dir")
+  dir.create(destination)
+  writeLines("important", file.path(destination, "data.txt"))
+
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  # $exe_file(path) assigns without validating, so this is the shortest route to
+  # a destination the compile path never checks.
+  model$exe_file(destination)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_error(
+      model$compile(force_recompile = TRUE),
+      "is a directory",
+      fixed = TRUE
+    )
+  )
+  expect_true(dir.exists(destination))
+  expect_identical(readLines(file.path(destination, "data.txt")), "important")
+})

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -692,9 +692,15 @@ test_that("*hpp_file() functions work", {
   expect_equal(mod$hpp_file(), file.path(dirname(mod$stan_file()), "bernoulli.hpp"))
   mod$save_hpp_file(tmp_dir)
   expect_equal(mod$hpp_file(), file.path(tmp_dir, "bernoulli.hpp"))
+  # A dry run generates no C++, so it leaves the saved location alone rather
+  # than pointing $hpp_file() at a temporary file that was never written.
   mod$compile(force_recompile = TRUE, dry_run = TRUE)
+  expect_equal(mod$hpp_file(), file.path(tmp_dir, "bernoulli.hpp"))
+  # A real recompilation does write it, to a fresh temporary location.
+  expect_call_compilation(mod$compile(force_recompile = TRUE))
   expect_false(isTRUE(all.equal(mod$hpp_file(), file.path(tmp_dir, "bernoulli.hpp"))))
   expect_false(isTRUE(all.equal(mod$hpp_file(), file.path(dirname(mod$stan_file()), "bernoulli.hpp"))))
+  checkmate::expect_file_exists(mod$hpp_file())
 })
 
 test_that("check_syntax() works", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -643,8 +643,10 @@ expect_describes_new_program <- function(model) {
   expect_match(paste(private$model_methods_env_$hpp_code_, collapse = "\n"), "beta")
   expect_match(paste(readLines(model$hpp_file()), collapse = "\n"), "beta")
   expect_true(model$cpp_options()$stan_threads)
-  # The mocked replacement is empty, the executable it replaced was not.
-  expect_equal(file.size(model$exe_file()), 0)
+  # The installed file is the mocked replacement rather than the executable it
+  # replaced, told apart by contents. Size alone used to carry this, because the
+  # mock wrote an empty file and the fixture's old executable was not empty.
+  expect_match(readLines(model$exe_file()), "^mock executable ")
 }
 
 test_that("a leftover backup warns without discarding a successful compile", {
@@ -1688,4 +1690,27 @@ test_that("compile() refuses an executable destination that is a directory", {
   )
   expect_true(dir.exists(destination))
   expect_identical(readLines(file.path(destination, "data.txt")), "important")
+})
+
+test_that("compile() installs the artifact it just built, not the previous one", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(testing_stan_file("bernoulli"), stan_file)
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  exe <- cmdstan_ext(strip_ext(stan_file))
+
+  # Each mocked build writes distinct contents, so "the new artifact was
+  # installed" is distinguishable from "the old one was left in place". While
+  # every build produced the same empty file, no test could tell the two apart.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = {
+      model$compile(force_recompile = TRUE)
+      first <- readLines(exe)
+      model$compile(force_recompile = TRUE)
+      second <- readLines(exe)
+    }
+  )
+  expect_false(identical(first, second))
 })

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -578,8 +578,11 @@ test_that("a leftover backup doesn't unwind a compile when warnings are errors",
         list(warn = 2),
         model$compile(cpp_options = list(stan_threads = TRUE), force_recompile = TRUE)
       ),
+      # Separators are normalized first: on Windows the backup path arrives as
+      # "<dir>\exe-old-1234", since tempfile() joins with a backslash.
       transform = function(lines) {
-        lines <- gsub(model_dir, "<dir>", lines, fixed = TRUE)
+        lines <- gsub("\\\\", "/", lines)
+        lines <- gsub(gsub("\\\\", "/", model_dir), "<dir>", lines, fixed = TRUE)
         gsub("exe-old-[0-9a-f]+", "exe-old-<random>", lines)
       }
     )

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -1594,6 +1594,76 @@ test_that("compile() ignores directory chatter from MAKEFLAGS when reading STANC
   expect_compilation(mod, quiet = TRUE, force_recompile = TRUE)
 })
 
+test_that("compile() checks it can commit before replacing the executable", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(testing_stan_file("bernoulli"), stan_file)
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  exe <- cmdstan_ext(strip_ext(stan_file))
+
+  lockEnvironment(model$functions, bindings = FALSE)
+
+  # The commit block clears this environment in place, which is the one thing in
+  # it that is not an assignment, and it fails on a locked environment. Failing
+  # there installed the new executable and then left the object recording
+  # nothing about it -- exactly the hybrid the ordering exists to prevent.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_error(
+      model$compile(force_recompile = TRUE),
+      "missing or locked",
+      fixed = TRUE
+    )
+  )
+  expect_false(file.exists(exe))
+  expect_length(model$exe_file(), 0)
+})
+
+test_that("compile() checks the functions environment is still there", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(testing_stan_file("bernoulli"), stan_file)
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  exe <- cmdstan_ext(strip_ext(stan_file))
+
+  # R6's lock_objects prevents adding fields, not replacing them, so this is
+  # allowed. Without the check the commit block reached rm(envir = NULL) after
+  # the executable had already been installed.
+  model$functions <- NULL
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_error(
+      model$compile(force_recompile = TRUE),
+      "missing or locked",
+      fixed = TRUE
+    )
+  )
+  expect_false(file.exists(exe))
+})
+
+test_that("compile() tolerates a locked binding in the functions environment", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(testing_stan_file("bernoulli"), stan_file)
+  model <- cmdstan_model(stan_file, compile = FALSE)
+
+  # A locked binding is not a locked environment: rm() still removes it, and the
+  # commit block's assignments then create bindings afresh rather than meeting a
+  # locked one. Rejecting this would refuse a compilation that works.
+  model$functions$compiled <- FALSE
+  lockBinding("compiled", model$functions)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_error(model$compile(force_recompile = TRUE))
+  )
+  expect_true(file.exists(cmdstan_ext(strip_ext(stan_file))))
+})
+
 test_that("compile() refuses an executable destination that is a directory", {
   model_dir <- withr::local_tempdir()
   stan_file <- file.path(model_dir, "bernoulli.stan")

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -626,6 +626,18 @@ test_that("check_syntax() works with include_paths on compiled model", {
 
 })
 
+test_that("check_syntax() and format() allow undefined functions with a user header", {
+  stan_file <- testing_stan_file("bernoulli_external")
+  # both methods only run stanc, which never reads the user header, so an empty
+  # one is enough here. Compiling against a real header is tested in
+  # test-model-compile-user_header.R
+  user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
+  mod <- cmdstan_model(stan_file, user_header = user_header, compile = FALSE)
+
+  expect_true(mod$check_syntax(quiet = TRUE))
+  expect_output(mod$format(), "make_odds", fixed = TRUE)
+})
+
 test_that("compile() and check_syntax() error on removed syntax", {
   model_code <- "
   transformed data {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -835,6 +835,14 @@ test_that("check_syntax() and format() allow undefined functions with a user hea
 
   expect_true(mod$check_syntax(quiet = TRUE))
   expect_output(mod$format(), "make_odds", fixed = TRUE)
+
+  # A compile that failed because the header is missing still counts as using one.
+  mod_missing <- cmdstan_model(stan_file, compile = FALSE)
+  expect_error(
+    mod_missing$compile(user_header = "not_a_real_header.hpp"),
+    "does not exist"
+  )
+  expect_true(mod_missing$check_syntax(quiet = TRUE))
 })
 
 test_that("compile() and check_syntax() error on removed syntax", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -581,7 +581,6 @@ test_that("a leftover backup doesn't unwind a compile when warnings are errors",
       # Separators are normalized first: on Windows the backup path arrives as
       # "<dir>\exe-old-1234", since tempfile() joins with a backslash.
       transform = function(lines) {
-        lines <- gsub("\\\\", "/", lines)
         for (dir in unique(c(model_dir, repair_path(model_dir)))) {
           lines <- gsub(dir, "<dir>", lines, fixed = TRUE)
         }

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -582,7 +582,9 @@ test_that("a leftover backup doesn't unwind a compile when warnings are errors",
       # "<dir>\exe-old-1234", since tempfile() joins with a backslash.
       transform = function(lines) {
         lines <- gsub("\\\\", "/", lines)
-        lines <- gsub(gsub("\\\\", "/", model_dir), "<dir>", lines, fixed = TRUE)
+        for (dir in unique(c(model_dir, repair_path(model_dir)))) {
+          lines <- gsub(dir, "<dir>", lines, fixed = TRUE)
+        }
         gsub("exe-old-[0-9a-f]+", "exe-old-<random>", lines)
       }
     )
@@ -1106,6 +1108,31 @@ test_that("cmdstan_model cpp_options dont captialize cxxflags ", {
   )
   expect_output(print(out), "-Dsomething_not_used")
 })
+
+test_that("format(overwrite_file = TRUE) refreshes cached variables", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- write_stan_file(
+    "parameters { real alpha; } model { alpha ~ std_normal(); }",
+    dir = model_dir,
+    basename = "reformat.stan"
+  )
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  expect_equal(names(model$variables()$parameters), "alpha")
+
+  # The program is edited behind the object's back, then formatted in place.
+  # $format() reloads $code() from disk, so a cached $variables() would go on
+  # describing a different program than $code() does -- and the fitting methods
+  # validate data and initial values against $variables(). (#1228)
+  writeLines(
+    "parameters { real beta; } model { beta ~ std_normal(); }",
+    stan_file
+  )
+  model$format(overwrite_file = TRUE, quiet = TRUE)
+
+  expect_equal(names(model$variables()$parameters), "beta")
+  expect_match(paste(model$code(), collapse = " "), "beta")
+})
+
 
 test_that("format() works", {
   code <- "

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -382,9 +382,8 @@ test_that("name in STANCFLAGS is set correctly", {
 test_that("switching threads on and off works without rebuild", {
   main_path_o <- file.path(cmdstan_path(), "src", "cmdstan", "main.o")
   main_path_threads_o <- file.path(cmdstan_path(), "src", "cmdstan", "main_threads.o")
-  backup <- cmdstan_make_local()
-  no_threads <- grep("STAN_THREADS", backup, invert = TRUE, value = TRUE)
-  cmdstan_make_local(cpp_options = list(no_threads), append = FALSE)
+  no_threads <- grep("STAN_THREADS", cmdstan_make_local(), invert = TRUE, value = TRUE)
+  local_cmdstan_make_local(cpp_options = list(no_threads), append = FALSE)
   if (file.exists(main_path_threads_o)) {
     file.remove(main_path_threads_o)
   }
@@ -408,8 +407,6 @@ test_that("switching threads on and off works without rebuild", {
   mod$compile(force_recompile = TRUE)
   after_mtime <- file.mtime(main_path_o)
   expect_equal(before_mtime, after_mtime)
-
-  cmdstan_make_local(cpp_options = backup, append = FALSE)
 })
 
 test_that("multiple cpp_options work", {
@@ -942,9 +939,8 @@ test_that("include_paths_stanc3_args() works", {
 })
 
 test_that("cpp_options work with settings in make/local", {
-  backup <- cmdstan_make_local()
-  no_threads <- grep("STAN_THREADS", backup, invert = TRUE, value = TRUE)
-  cmdstan_make_local(cpp_options = list(no_threads), append = FALSE)
+  no_threads <- grep("STAN_THREADS", cmdstan_make_local(), invert = TRUE, value = TRUE)
+  local_cmdstan_make_local(cpp_options = list(no_threads), append = FALSE)
 
   if (length(mod$exe_file()) > 0 && file.exists(mod$exe_file())) {
     file.remove(mod$exe_file())
@@ -963,9 +959,6 @@ test_that("cpp_options work with settings in make/local", {
   expect_true(mod$cpp_options()$STAN_THREADS)
 
   file.remove(mod$exe_file())
-
-  # restore
-  cmdstan_make_local(cpp_options = backup, append = FALSE)
 })
 
 test_that("a recompile records options inherited from make/local", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -403,6 +403,81 @@ test_that("a failed compile() doesn't refresh cached model state", {
   expect_false(model$functions$compiled)
 })
 
+# A compiled model whose compiler is mocked, so that stanc runs for real and
+# only the C++ stage can be made to fail. That is the case the tests above miss:
+# the generated C++ for the new program is already in hand, so any state derived
+# from it that is recorded before the executable is replaced would outlive a
+# failure and describe a program the executable was never built from.
+#
+# The copy is temporary because a mocked compile installs a real (empty)
+# executable, and the model here is the CmdStan installation's own example.
+local_mocked_bernoulli_model <- function(.local_envir = parent.frame()) {
+  stan_file <- file.path(
+    withr::local_tempdir(.local_envir = .local_envir),
+    "bernoulli.stan"
+  )
+  file.copy(cmdstan_example_file(), stan_file)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(stan_file)
+  )
+}
+
+test_that("a failed C++ compile doesn't refresh generated-code state", {
+  model <- local_mocked_bernoulli_model()
+  private <- model$.__enclos_env__$private
+
+  code_before <- model$code()
+  variables_before <- model$variables()
+  functions_before <- as.list(model$functions)
+  hpp_file_before <- model$hpp_file()
+  hpp_code_before <- private$model_methods_env_$hpp_code_
+  expect_true(any(nzchar(hpp_code_before)))
+
+  # The model-method environment is handed to every fit, so a stale pairing here
+  # means fit$init_model_methods() compiles log_prob() from a program the draws
+  # did not come from.
+  writeLines(
+    "parameters { real beta; } model { beta ~ std_normal(); }",
+    model$stan_file()
+  )
+  with_mocked_cli(
+    compile_ret = list(status = 1),
+    info_ret = list(status = 1),
+    code = expect_error(
+      model$compile(force_recompile = TRUE),
+      "An error occurred during compilation!",
+      fixed = TRUE
+    )
+  )
+
+  expect_identical(model$code(), code_before)
+  expect_identical(model$variables(), variables_before)
+  expect_identical(as.list(model$functions), functions_before)
+  expect_identical(model$hpp_file(), hpp_file_before)
+  expect_identical(private$model_methods_env_$hpp_code_, hpp_code_before)
+})
+
+test_that("a failed C++ compile doesn't move the executable path", {
+  model <- local_mocked_bernoulli_model()
+  exe_before <- model$exe_file()
+  other_dir <- withr::local_tempdir()
+
+  with_mocked_cli(
+    compile_ret = list(status = 1),
+    info_ret = list(status = 1),
+    code = expect_error(
+      model$compile(dir = other_dir, force_recompile = TRUE),
+      "An error occurred during compilation!",
+      fixed = TRUE
+    )
+  )
+
+  expect_identical(model$exe_file(), exe_before)
+  expect_true(file.exists(exe_before))
+})
+
 test_that("dir arg works for cmdstan_model and $compile()", {
   tmp_dir <- tempdir()
   tmp_dir_2 <- tempdir()

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -260,9 +260,13 @@ test_that("$compile() reuses include paths from the previous compilation", {
     code = expect_no_error(mod$compile(force_recompile = TRUE, quiet = TRUE))
   )
   expect_equal(mod$include_paths(), resolve_path(include_dir))
+  # Compared against the arguments stanc is actually handed, not the stored
+  # path: under WSL the model holds a Windows host path while the stanc
+  # argument is converted to /mnt/<drive>/..., so the two do not match.
+  include_args <- include_paths_stanc3_args(mod$include_paths(), direct_call = TRUE)
   expect_true(all(vapply(
     received_stancflags,
-    function(x) any(grepl(mod$include_paths(), x, fixed = TRUE)),
+    function(x) all(include_args %in% x),
     logical(1)
   )))
 })

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -478,6 +478,116 @@ test_that("a failed C++ compile doesn't move the executable path", {
   expect_true(file.exists(exe_before))
 })
 
+test_that("compile() errors if the executable cannot be replaced", {
+  model <- local_mocked_bernoulli_model()
+  exe <- model$exe_file()
+  writeLines("old executable", exe)
+
+  # Fail the first attempt to put a file at the destination. A replacement that
+  # fails unnoticed leaves the model with no executable at all.
+  real_file_copy <- base::file.copy
+  real_file_rename <- base::file.rename
+  installs <- 0
+  local_mocked_bindings(
+    file.copy = function(from, to, ...) {
+      if (identical(to, exe)) {
+        installs <<- installs + 1
+        if (installs == 1L) return(FALSE)
+      }
+      real_file_copy(from, to, ...)
+    },
+    file.rename = function(from, to) {
+      if (identical(to, exe)) {
+        installs <<- installs + 1
+        if (installs == 1L) return(FALSE)
+      }
+      real_file_rename(from, to)
+    },
+    .package = "base"
+  )
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_error(model$compile(force_recompile = TRUE))
+  )
+  expect_true(file.exists(exe))
+  expect_identical(readLines(exe), "old executable")
+})
+
+# Set up a model whose executable is about to be replaced by a program that can
+# be told apart from it, with removal of the old executable's backup failing.
+local_leftover_backup_model <- function(.local_envir = parent.frame()) {
+  model <- local_mocked_bernoulli_model(.local_envir = .local_envir)
+  writeLines("old executable", model$exe_file())
+  writeLines(
+    "parameters { real beta; } model { beta ~ std_normal(); }",
+    model$stan_file()
+  )
+  local_mocked_bindings(
+    unlink = function(...) 1L,
+    .package = "base",
+    .env = .local_envir
+  )
+  model
+}
+
+expect_describes_new_program <- function(model) {
+  private <- model$.__enclos_env__$private
+  expect_identical(
+    model$code(),
+    "parameters { real beta; } model { beta ~ std_normal(); }"
+  )
+  expect_equal(model$variables()$parameters$beta$dimensions, 0)
+  expect_match(paste(private$model_methods_env_$hpp_code_, collapse = "\n"), "beta")
+  expect_match(paste(readLines(model$hpp_file()), collapse = "\n"), "beta")
+  expect_true(model$cpp_options()$stan_threads)
+  # The mocked replacement is empty, the executable it replaced was not.
+  expect_equal(file.size(model$exe_file()), 0)
+}
+
+test_that("a leftover backup warns without discarding a successful compile", {
+  model <- local_leftover_backup_model()
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_warning(
+      model$compile(cpp_options = list(stan_threads = TRUE), force_recompile = TRUE),
+      "could not be removed"
+    )
+  )
+
+  expect_describes_new_program(model)
+})
+
+test_that("a leftover backup doesn't unwind a compile when warnings are errors", {
+  model <- local_leftover_backup_model()
+  model_dir <- dirname(model$exe_file())
+
+  # Signalling the cleanup failure before the state is committed would install
+  # the new executable while the object still described the old program -- the
+  # exact hybrid this all exists to prevent. The option is scoped to the call so
+  # that testthat's own snapshot warnings stay warnings.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_snapshot(
+      error = TRUE,
+      withr::with_options(
+        list(warn = 2),
+        model$compile(cpp_options = list(stan_threads = TRUE), force_recompile = TRUE)
+      ),
+      transform = function(lines) {
+        lines <- gsub(model_dir, "<dir>", lines, fixed = TRUE)
+        gsub("exe-old-[0-9a-f]+", "exe-old-<random>", lines)
+      }
+    )
+  )
+
+  expect_describes_new_program(model)
+})
+
 test_that("dir arg works for cmdstan_model and $compile()", {
   tmp_dir <- tempdir()
   tmp_dir_2 <- tempdir()

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -240,7 +240,11 @@ test_that("$compile() reuses include paths from the previous compilation", {
 })
 
 test_that("$compile() doesn't reuse cpp and stanc options from the previous compilation", {
-  stan_file <- testing_stan_file("bernoulli")
+  # A mocked compile installs a real (empty) executable, so this has to build a
+  # temporary copy rather than the shared test model.
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(testing_stan_file("bernoulli"), stan_file)
   model <- cmdstan_model(stan_file, compile = FALSE)
   received_stancflags <- list()
   local_mocked_bindings(
@@ -251,14 +255,79 @@ test_that("$compile() doesn't reuse cpp and stanc options from the previous comp
     }
   )
 
-  model$compile(
+  # Successful compiles rather than dry runs: the precompile state these options
+  # travel in is cleared only once an executable has been installed, so a pair
+  # of dry runs never reaches the transition this test is named for and passes
+  # merely because arguments to one call are absent from another.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(
+      cpp_options = list(stan_threads = TRUE),
+      stanc_options = list("warn-pedantic" = TRUE),
+      force_recompile = TRUE
+    )
+  )
+  expect_true(model$cpp_options()[["stan_threads"]])
+  expect_equal(
+    vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
+    rep(TRUE, 2)
+  )
+
+  received_stancflags <- list()
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(force_recompile = TRUE)
+  )
+
+  expect_null(model$cpp_options()[["stan_threads"]])
+  expect_equal(
+    vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
+    rep(FALSE, 2)
+  )
+})
+
+test_that("$compile() doesn't reuse cpp and stanc options supplied to cmdstan_model()", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(testing_stan_file("bernoulli"), stan_file)
+  # Options given to the constructor are held until the first compilation
+  # consumes them, unlike the include paths and user header, which persist.
+  model <- cmdstan_model(
+    stan_file,
+    compile = FALSE,
     cpp_options = list(stan_threads = TRUE),
-    stanc_options = list("warn-pedantic" = TRUE),
-    force_recompile = TRUE,
-    dry_run = TRUE
+    stanc_options = list("warn-pedantic" = TRUE)
   )
   received_stancflags <- list()
-  model$compile(force_recompile = TRUE, dry_run = TRUE)
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) character(),
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
+  )
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(force_recompile = TRUE)
+  )
+  expect_true(model$cpp_options()[["stan_threads"]])
+  expect_equal(
+    vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
+    rep(TRUE, 2)
+  )
+
+  # The held options are released only by a successful compilation, so this is
+  # the transition that a pair of dry runs cannot reach.
+  received_stancflags <- list()
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(force_recompile = TRUE)
+  )
 
   expect_null(model$cpp_options()[["stan_threads"]])
   expect_equal(

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -464,7 +464,7 @@ test_that("compile() with dry_run = TRUE doesn't refresh cached model state", {
 
   expect_identical(model$code(), code_before)
   expect_identical(model$variables(), variables_before)
-  expect_equal(ls(model$functions), "compiled")
+  expect_equal(ls(model$functions), c("compiled", "existing_exe"))
   expect_false(model$functions$compiled)
 })
 
@@ -488,7 +488,7 @@ test_that("a failed compile() doesn't refresh cached model state", {
 
   expect_identical(model$code(), code_before)
   expect_identical(model$variables(), variables_before)
-  expect_equal(ls(model$functions), "compiled")
+  expect_equal(ls(model$functions), c("compiled", "existing_exe"))
   expect_false(model$functions$compiled)
 })
 

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -555,7 +555,7 @@ test_that("$expose_functions() after a dry run reports why it cannot", {
   ")
   mod <- cmdstan_model(stan_file, compile = FALSE)
   mod$compile(dry_run = TRUE)
-  # The wording is wrong for a model that was never compiled at all.
+  # The wording is wrong for a model that was never compiled at all (#1245).
   expect_error(
     mod$expose_functions(),
     "Exporting standalone functions is not possible with a pre-compiled Stan model!",

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -311,6 +311,55 @@ test_that("Functions can be compiled with model", {
   )
 })
 
+test_that("recompiling drops previously exposed functions", {
+  model_dir <- withr::local_tempdir()
+  write_model <- function(code) {
+    write_stan_file(code, dir = model_dir, basename = "issue1228.stan")
+  }
+  code_two_functions <- "
+    functions {
+      real times_two(real x) { return 2 * x; }
+      real times_three(real x) { return 3 * x; }
+    }
+    parameters {
+      real y;
+    }
+    model {
+      y ~ std_normal();
+    }
+  "
+  stan_file <- write_model(code_two_functions)
+  mod <- cmdstan_model(stan_file)
+  mod$expose_functions()
+  expect_equal(mod$functions$times_two(1), 2)
+  expect_equal(mod$functions$times_three(1), 3)
+
+  # change one function and remove the other, then recompile
+  write_model("
+    functions {
+      real times_two(real x) { return 20 * x; }
+    }
+    parameters {
+      real y;
+    }
+    model {
+      y ~ std_normal();
+    }
+  ")
+  mod$compile()
+  expect_false(mod$functions$compiled)
+  expect_false("times_three" %in% ls(mod$functions))
+  mod$expose_functions()
+  expect_equal(mod$functions$times_two(1), 20)
+  expect_false("times_three" %in% ls(mod$functions))
+
+  # compile_standalone exposes the functions of the recompiled model
+  write_model(code_two_functions)
+  mod$compile(compile_standalone = TRUE)
+  expect_equal(mod$functions$times_two(1), 2)
+  expect_equal(mod$functions$times_three(1), 3)
+})
+
 test_that("compile_standalone warns but doesn't error if no functions", {
   stan_no_funs_block <- write_stan_file("
     parameters {

--- a/tests/testthat/test-model-expose-functions.R
+++ b/tests/testthat/test-model-expose-functions.R
@@ -547,6 +547,22 @@ test_that("Exposing functions with precompiled model gives meaningful error", {
   )
 })
 
+test_that("$expose_functions() after a dry run reports why it cannot", {
+  stan_file <- write_stan_file("
+    functions { real a_plus_b(real a, real b) { return a + b; } }
+    parameters { real x; }
+    model { x ~ std_normal(); }
+  ")
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+  mod$compile(dry_run = TRUE)
+  # The wording is wrong for a model that was never compiled at all.
+  expect_error(
+    mod$expose_functions(),
+    "Exporting standalone functions is not possible with a pre-compiled Stan model!",
+    fixed = TRUE
+  )
+})
+
 test_that("Functions with SUNDIALS/KINSOL methods link correctly", {
   modcode <- "
     functions {

--- a/tests/testthat/test-model-generate_quantities.R
+++ b/tests/testthat/test-model-generate_quantities.R
@@ -55,7 +55,12 @@ test_that("generate_quantities work for different chains and parallel_chains", {
   expect_gq_output(
     mod_gq$generate_quantities(data = data_list, fitted_params = fit, parallel_chains = 4)
   )
-  mod_gq <- cmdstan_model(testing_stan_file("bernoulli_ppc"), cpp_options = list(stan_threads = TRUE))
+  # The executable is already built without threading and is up to date, so this
+  # does not rebuild it and the request has no effect on the binary.
+  expect_warning(
+    mod_gq <- cmdstan_model(testing_stan_file("bernoulli_ppc"), cpp_options = list(stan_threads = TRUE)),
+    "was not built with the requested"
+  )
   expect_gq_output(
     mod_gq$generate_quantities(data = data_list, fitted_params = fit_1_chain, threads_per_chain = 2)
   )

--- a/tests/testthat/test-model-generate_quantities.R
+++ b/tests/testthat/test-model-generate_quantities.R
@@ -55,27 +55,22 @@ test_that("generate_quantities work for different chains and parallel_chains", {
   expect_gq_output(
     mod_gq$generate_quantities(data = data_list, fitted_params = fit, parallel_chains = 4)
   )
-  # The executable is already built without threading and is up to date, so this
-  # does not rebuild it and the request has no effect on the binary. The request
-  # is therefore not recorded either, so 'threads_per_chain' is refused rather
-  # than reported back as though it had taken effect. (#1019)
+  # The existing executable is unthreaded and is not rebuilt, so do not report
+  # the requested thread count (#1019).
   expect_warning(
     mod_gq <- cmdstan_model(testing_stan_file("bernoulli_ppc"), cpp_options = list(stan_threads = TRUE)),
     "do not match the ones requested"
   )
-  expect_warning(
-    expect_gq_output(
-      mod_gq$generate_quantities(data = data_list, fitted_params = fit_1_chain, threads_per_chain = 2)
-    ),
-    "'threads_per_chain' is set but the model was not compiled with"
-  )
-  # This used to report "2 thread(s) per chain" for a binary compiled without
-  # STAN_THREADS, which ran single-threaded regardless.
   threads_output <- capture.output(
     expect_warning(
       mod_gq$generate_quantities(data = data_list, fitted_params = fit_1_chain, threads_per_chain = 2),
       "'threads_per_chain' is set but the model was not compiled with"
     )
+  )
+  expect_match(
+    paste(threads_output, collapse = "\n"),
+    "Running standalone generated quantities after ",
+    fixed = TRUE
   )
   expect_false(any(grepl("thread(s) per chain", threads_output, fixed = TRUE)))
 })

--- a/tests/testthat/test-model-generate_quantities.R
+++ b/tests/testthat/test-model-generate_quantities.R
@@ -61,7 +61,7 @@ test_that("generate_quantities work for different chains and parallel_chains", {
   # than reported back as though it had taken effect. (#1019)
   expect_warning(
     mod_gq <- cmdstan_model(testing_stan_file("bernoulli_ppc"), cpp_options = list(stan_threads = TRUE)),
-    "was not built with the requested"
+    "do not match the ones requested"
   )
   expect_warning(
     expect_gq_output(

--- a/tests/testthat/test-model-generate_quantities.R
+++ b/tests/testthat/test-model-generate_quantities.R
@@ -56,19 +56,28 @@ test_that("generate_quantities work for different chains and parallel_chains", {
     mod_gq$generate_quantities(data = data_list, fitted_params = fit, parallel_chains = 4)
   )
   # The executable is already built without threading and is up to date, so this
-  # does not rebuild it and the request has no effect on the binary.
+  # does not rebuild it and the request has no effect on the binary. The request
+  # is therefore not recorded either, so 'threads_per_chain' is refused rather
+  # than reported back as though it had taken effect. (#1019)
   expect_warning(
     mod_gq <- cmdstan_model(testing_stan_file("bernoulli_ppc"), cpp_options = list(stan_threads = TRUE)),
     "was not built with the requested"
   )
-  expect_gq_output(
-    mod_gq$generate_quantities(data = data_list, fitted_params = fit_1_chain, threads_per_chain = 2)
+  expect_warning(
+    expect_gq_output(
+      mod_gq$generate_quantities(data = data_list, fitted_params = fit_1_chain, threads_per_chain = 2)
+    ),
+    "'threads_per_chain' is set but the model was not compiled with"
   )
-  expect_output(
-    mod_gq$generate_quantities(data = data_list, fitted_params = fit_1_chain, threads_per_chain = 2),
-    "2 thread(s) per chain",
-    fixed = TRUE
+  # This used to report "2 thread(s) per chain" for a binary compiled without
+  # STAN_THREADS, which ran single-threaded regardless.
+  threads_output <- capture.output(
+    expect_warning(
+      mod_gq$generate_quantities(data = data_list, fitted_params = fit_1_chain, threads_per_chain = 2),
+      "'threads_per_chain' is set but the model was not compiled with"
+    )
   )
+  expect_false(any(grepl("thread(s) per chain", threads_output, fixed = TRUE)))
 })
 
 test_that("generate_quantities works with draws_array", {

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -463,6 +463,46 @@ test_that("a successful compile records options only the executable reports", {
   expect_null(cpp_option_value(mod_blind$cpp_options(), "stan_threads"))
 })
 
+test_that("cmdstan_model() reads the executable metadata once, whatever the path", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+  info <- "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0"
+  real_model_compile_info <- model_compile_info
+  reads <- 0L
+  local_mocked_bindings(
+    model_compile_info = function(...) {
+      reads <<- reads + 1L
+      real_model_compile_info(...)
+    }
+  )
+
+  # Fresh compile.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = info),
+    code = mod <- cmdstan_model(stan_file)
+  )
+  expect_equal(reads, 1L)
+
+  # Executable already up to date.
+  reads <- 0L
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = info),
+    code = cmdstan_model(stan_file)
+  )
+  expect_equal(reads, 1L)
+
+  # Executable adopted without a Stan file.
+  reads <- 0L
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = info),
+    code = cmdstan_model(exe_file = mod$exe_file())
+  )
+  expect_equal(reads, 1L)
+})
+
 test_that("options inherited from make/local are learned, not warned about", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -379,6 +379,72 @@ test_that("option comparison ignores spelling, NULL and omission", {
   )
 })
 
+test_that("option comparison follows what make is actually given", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  mod <- with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(
+      stan_file,
+      cpp_options = list(stan_cpp_optims = TRUE),
+      force_recompile = TRUE
+    )
+  )
+  no_op <- function(requested, expectation) {
+    with_mocked_cli(
+      compile_ret = list(status = 0),
+      info_ret = list(status = 1),
+      code = expect_no_mock_compile(expectation(mod$compile(cpp_options = requested)))
+    )
+  }
+  warns <- function(requested) {
+    no_op(requested, function(code) {
+      expect_warning(code, "was not built with the requested")
+    })
+  }
+  quietly <- function(requested) no_op(requested, expect_no_warning)
+
+  # FALSE is not omission. It reaches make as STAN_CPP_OPTIMS=FALSE, and CmdStan
+  # enables some options whenever their make variable is non-empty, so asking
+  # for it would build a different executable than the recorded TRUE did.
+  warns(list(stan_cpp_optims = FALSE))
+  warns(list(stan_cpp_optims = TRUE, stan_threads = FALSE))
+
+  # Every duplicate reaches make, and a makefile takes the last.
+  quietly(list(stan_cpp_optims = FALSE, stan_cpp_optims = TRUE))
+  warns(list(stan_cpp_optims = TRUE, stan_cpp_optims = FALSE))
+
+  # An unnamed entry is a raw make argument rather than something to skip.
+  warns(list("STAN_THREADS=TRUE"))
+})
+
+test_that("a raw make argument round-trips through the option comparison", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  mod <- with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(
+      stan_file,
+      cpp_options = list("STAN_CPP_OPTIMS=TRUE"),
+      force_recompile = TRUE
+    )
+  )
+
+  # Re-supplying exactly what the executable was built with is ordinary reuse,
+  # even when the option never had a name to compare by.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(
+      expect_no_warning(mod$compile(cpp_options = list("STAN_CPP_OPTIMS=TRUE")))
+    )
+  )
+})
+
 test_that("an adopted executable stays silent about options it cannot report", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -139,13 +139,16 @@ test_that("adopting an executable keeps the options the call asked for", {
   # cmdstanr rebuilds on a cpp_options mismatch, dropping the request would
   # make assert_valid_threads() discard 'threads' and run single-threaded
   # without the caller ever asking for that.
-  mod <- with_mocked_cli(
+  with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(
       status = 0,
       stdout = "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\nSTAN_THREADS=false"
     ),
-    code = cmdstan_model(stan_file, cpp_options = list(stan_threads = TRUE))
+    code = expect_warning(
+      mod <- cmdstan_model(stan_file, cpp_options = list(stan_threads = TRUE)),
+      "was not built with the requested"
+    )
   )
 
   expect_true(mod$cpp_options()$stan_threads)
@@ -168,12 +171,42 @@ test_that("a no-op compile records options supplied to that same call", {
   # options the caller just supplied is not.
   with_mocked_cli(
     compile_ret = list(status = 0),
-    info_ret = list(status = 1),
+    info_ret = list(
+      status = 0,
+      stdout = "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\nSTAN_THREADS=false"
+    ),
     code = expect_no_mock_compile(
-      mod$compile(cpp_options = list(stan_threads = TRUE))
+      expect_warning(
+        mod$compile(cpp_options = list(stan_threads = TRUE)),
+        "was not built with the requested"
+      )
     )
   )
   expect_true(mod$cpp_options()$stan_threads)
+})
+
+test_that("no mismatch warning when the executable already has the options", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = mod <- cmdstan_model(stan_file, force_recompile = TRUE)
+  )
+
+  # The executable reports exactly what is being asked for, so re-stating it
+  # must stay quiet -- otherwise the warning fires on ordinary reuse.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(
+      status = 0,
+      stdout = "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\nSTAN_THREADS=true"
+    ),
+    code = expect_no_warning(
+      mod$compile(cpp_options = list(stan_threads = TRUE))
+    )
+  )
 })
 
 test_that("a no-op compile tolerates an executable it cannot query", {

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -60,6 +60,113 @@ test_that("a mocked successful compile installs an executable", {
   expect_true(file.exists(exe))
 })
 
+test_that("a no-op compile preserves what the previous compilation recorded", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = mod$compile(
+      cpp_options = list(stan_threads = TRUE),
+      force_recompile = TRUE
+    )
+  )
+  expect_true(mod$cpp_options()$stan_threads)
+  expect_false(mod$functions$existing_exe)
+
+  # The second call finds the executable up to date and compiles nothing, so it
+  # must not discard the options the executable was actually built with: an
+  # erased stan_threads makes assert_valid_threads() drop 'threads' and run a
+  # threaded executable single-threaded. It must not claim the executable is
+  # pre-compiled either, or $expose_functions() fails on a model that built
+  # itself.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(mod$compile())
+  )
+  expect_true(mod$cpp_options()$stan_threads)
+  expect_false(mod$functions$existing_exe)
+  expect_warning(mod$expose_functions(), "No standalone functions found")
+})
+
+test_that("a no-op compile adopts an executable the object did not build", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+  exe <- cmdstan_ext(strip_ext(stan_file))
+
+  # Build the executable through one object, then let a second, freshly
+  # constructed object find it up to date.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(stan_file, force_recompile = TRUE)
+  )
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+  expect_length(mod$exe_file(), 0)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(
+      status = 0,
+      stdout = "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\nSTAN_THREADS=true\nSTAN_OPENCL=false"
+    ),
+    code = expect_no_mock_compile(mod$compile())
+  )
+
+  expect_equal(mod$exe_file(), exe)
+  expect_true(mod$functions$existing_exe)
+  # Hydrated from the executable itself: STAN_THREADS is reported, STAN_OPENCL
+  # is reported as FALSE (i.e. never set) and STAN_VERSION is not a make option.
+  expect_true(mod$cpp_options()$STAN_THREADS)
+  expect_null(mod$cpp_options()$STAN_OPENCL)
+  expect_null(mod$cpp_options()$STAN_VERSION)
+})
+
+test_that("a no-op compile tolerates an executable it cannot query", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(stan_file, force_recompile = TRUE)
+  )
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+
+  # The mocked executable is empty, so running it errors rather than returning
+  # a non-zero status. Adopting it is best-effort and must still succeed.
+  expect_no_error(mod$compile())
+  expect_true(mod$functions$existing_exe)
+})
+
+test_that("compiling into a directory with a different executable recompiles", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = mod <- cmdstan_model(stan_file)
+  )
+
+  # A current executable already sits in the target directory. Adopting it would
+  # leave the object describing this program's C++ while running that binary, so
+  # the model is rebuilt there instead.
+  other_dir <- withr::local_tempdir()
+  other_exe <- cmdstan_ext(file.path(other_dir, "bernoulli"))
+  file.create(other_exe)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_mock_compile(mod$compile(dir = other_dir))
+  )
+  expect_equal(mod$exe_file(), other_exe)
+})
+
 test_that("a mocked failed compile installs no executable", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -105,7 +105,7 @@ test_that("a no-op compile does not record cpp_options the executable lacks", {
       testing_stan_file("bernoulli"),
       cpp_options = list(stan_threads = TRUE)
     ),
-    "was not built with the requested"
+    "do not match the ones requested"
   )
 
   # Nothing was rebuilt, so the request describes no executable that exists.
@@ -232,7 +232,7 @@ test_that("adopting an executable describes the binary, not the request", {
     ),
     code = expect_warning(
       mod <- cmdstan_model(stan_file, cpp_options = list(stan_threads = TRUE)),
-      "was not built with the requested"
+      "do not match the ones requested"
     )
   )
 
@@ -263,7 +263,7 @@ test_that("a no-op compile does not adopt options the executable lacks", {
     code = expect_no_mock_compile(
       expect_warning(
         mod$compile(cpp_options = list(stan_threads = TRUE)),
-        "was not built with the requested"
+        "do not match the ones requested"
       )
     )
   )
@@ -299,7 +299,7 @@ test_that("a no-op compile warns about options the executable cannot report", {
       code = expect_no_mock_compile(
         expect_warning(
           mod$compile(cpp_options = requested),
-          "was not built with the requested"
+          "do not match the ones requested"
         )
       )
     )
@@ -371,7 +371,7 @@ test_that("option comparison ignores spelling but not an empty assignment", {
     code = expect_no_mock_compile(
       expect_warning(
         mod$compile(cpp_options = list(stan_cpp_optims = TRUE, stan_threads = NULL)),
-        "was not built with the requested"
+        "do not match the ones requested"
       )
     )
   )
@@ -384,7 +384,7 @@ test_that("option comparison ignores spelling but not an empty assignment", {
     code = expect_no_mock_compile(
       expect_warning(
         mod$compile(cpp_options = list(stan_threads = TRUE)),
-        "was not built with the requested"
+        "do not match the ones requested"
       )
     )
   )
@@ -412,7 +412,7 @@ test_that("option comparison follows what make is actually given", {
   }
   warns <- function(requested) {
     no_op(requested, function(code) {
-      expect_warning(code, "was not built with the requested")
+      expect_warning(code, "do not match the ones requested")
     })
   }
   quietly <- function(requested) no_op(requested, expect_no_warning)
@@ -472,6 +472,122 @@ test_that("a raw make argument round-trips through the option comparison", {
     info_ret = list(status = 1),
     code = expect_no_mock_compile(
       expect_no_warning(mod$compile(cpp_options = list("STAN_CPP_OPTIMS=TRUE")))
+    )
+  )
+})
+
+test_that("options inherited from make/local are learned, not warned about", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+  # make/local supplies STAN_THREADS=true, so the executable is threaded even
+  # though nothing was passed to $compile() and nothing could be recorded.
+  threaded <- paste0(
+    "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
+    "STAN_THREADS=true"
+  )
+
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = threaded),
+    code = mod$compile(force_recompile = TRUE)
+  )
+  expect_null(mod$cpp_options()$stan_threads)
+
+  # Comparing against the record alone reported a mismatch for a binary that
+  # does have threading. The binary's own account fills the gap, and is kept:
+  # suppressing the warning without recording what it revealed would leave
+  # assert_valid_threads() still dropping 'threads_per_chain'.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = threaded),
+    code = expect_no_mock_compile(
+      expect_no_warning(mod$compile(cpp_options = list(stan_threads = TRUE)))
+    )
+  )
+  expect_true(cpp_option_value(mod$cpp_options(), "stan_threads"))
+
+  # An option only the record knows about still combines with one only the
+  # metadata knows about.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = threaded),
+    code = mod$compile(
+      cpp_options = list(stan_cpp_optims = TRUE),
+      force_recompile = TRUE
+    )
+  )
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = threaded),
+    code = expect_no_mock_compile(
+      expect_no_warning(
+        mod$compile(cpp_options = list(stan_cpp_optims = TRUE, stan_threads = TRUE))
+      )
+    )
+  )
+  # ...and changing the unreportable one is still caught.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = threaded),
+    code = expect_no_mock_compile(
+      expect_warning(
+        mod$compile(cpp_options = list(stan_cpp_optims = FALSE, stan_threads = TRUE)),
+        "do not match the ones requested"
+      )
+    )
+  )
+
+  # With no metadata to be had, the record is all there is and still answers
+  # for the option it holds.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(
+      expect_no_warning(mod$compile(cpp_options = list(stan_cpp_optims = TRUE)))
+    )
+  )
+})
+
+test_that("an executable built with an explicit NULL accepts NULL again", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = mod$compile(
+      cpp_options = list(stan_threads = NULL),
+      force_recompile = TRUE
+    )
+  )
+
+  # An empty STAN_THREADS= is what was built with, so re-stating it matches.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(
+      expect_no_warning(mod$compile(cpp_options = list(stan_threads = NULL)))
+    )
+  )
+
+  # Omission is a different request: it would leave make/local in force rather
+  # than overriding it, so it does not match a build that overrode it.
+  mod_omitted <- cmdstan_model(stan_file, compile = FALSE)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = mod_omitted$compile(force_recompile = TRUE)
+  )
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(
+      expect_warning(
+        mod_omitted$compile(cpp_options = list(stan_threads = NULL)),
+        "do not match the ones requested"
+      )
     )
   )
 })

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -152,6 +152,30 @@ test_that("adopting an executable keeps the options the call asked for", {
   expect_true(mod$functions$existing_exe)
 })
 
+test_that("a no-op compile records options supplied to that same call", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  mod <- with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(stan_file)
+  )
+  expect_null(mod$cpp_options()$stan_threads)
+
+  # Same object, same executable, but this call explicitly asks for threading.
+  # Preserving the recorded options is right for a bare $compile(); ignoring
+  # options the caller just supplied is not.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(
+      mod$compile(cpp_options = list(stan_threads = TRUE))
+    )
+  )
+  expect_true(mod$cpp_options()$stan_threads)
+})
+
 test_that("a no-op compile tolerates an executable it cannot query", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -336,7 +336,7 @@ test_that("a no-op compile stays quiet about options it was built with", {
   )
 })
 
-test_that("option comparison ignores spelling, NULL and omission", {
+test_that("option comparison ignores spelling but not an empty assignment", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
 
@@ -362,8 +362,19 @@ test_that("option comparison ignores spelling, NULL and omission", {
   # Same option, other spelling, and the string a makefile would carry.
   quietly(list(stan_cpp_optims = TRUE))
   quietly(list(stan_cpp_optims = "TRUE"))
-  # NULL asks make for nothing, so it is omission, not a request to unset.
-  quietly(list(stan_cpp_optims = TRUE, stan_threads = NULL))
+
+  # NULL is not omission either: it reaches make as an empty STAN_THREADS=,
+  # which overrides whatever make/local sets rather than leaving it alone.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(
+      expect_warning(
+        mod$compile(cpp_options = list(stan_cpp_optims = TRUE, stan_threads = NULL)),
+        "was not built with the requested"
+      )
+    )
+  )
 
   # Dropping a recorded option is still a change: cpp_options are one-shot, so
   # recompiling with this list would build without STAN_CPP_OPTIMS.
@@ -418,6 +429,26 @@ test_that("option comparison follows what make is actually given", {
 
   # An unnamed entry is a raw make argument rather than something to skip.
   warns(list("STAN_THREADS=TRUE"))
+
+  # Order survives normalization: these reach make as the same two assignments
+  # in opposite orders, so exactly one of them matches the recorded TRUE.
+  quietly(list("STAN_CPP_OPTIMS=FALSE", "STAN_CPP_OPTIMS=TRUE"))
+  warns(list("STAN_CPP_OPTIMS=TRUE", "STAN_CPP_OPTIMS=FALSE"))
+
+  # The same, across the boundary between a named entry and a raw one.
+  quietly(structure(
+    list(FALSE, "STAN_CPP_OPTIMS=TRUE"),
+    names = c("stan_cpp_optims", "")
+  ))
+  warns(structure(
+    list("STAN_CPP_OPTIMS=TRUE", FALSE),
+    names = c("", "stan_cpp_optims")
+  ))
+
+  # A vector value expands into one assignment per element, so it is the last
+  # element that decides, not the vector as a whole.
+  quietly(list(stan_cpp_optims = c(FALSE, TRUE)))
+  warns(list(stan_cpp_optims = c(TRUE, FALSE)))
 })
 
 test_that("a raw make argument round-trips through the option comparison", {

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -1,14 +1,8 @@
-# A mocked compile produces a real (empty) executable at the destination, so the
-# model compiled here must be a temporary copy. Compiling the installed example
-# in place would replace the CmdStan installation's own executable.
-example_exe <- cmdstan_ext(strip_ext(cmdstan_example_file()))
-example_exe_before <- file.info(example_exe)[, c("size", "mtime")]
-
+# Use a temporary copy because mocked compiles install executables.
 model_dir <- withr::local_tempdir()
 stan_program <- file.path(model_dir, "bernoulli.stan")
 file.copy(cmdstan_example_file(), stan_program)
-# Keep the program older than the placeholder executables created below, so the
-# up-to-date check doesn't force a recompile on timestamp resolution alone.
+# Keep the source older than executables used by no-op tests.
 Sys.setFileTime(stan_program, Sys.time() - 60)
 
 file_that_doesnt_exist <- withr::local_tempfile(pattern = "placeholder_doesnt_exist")
@@ -35,30 +29,13 @@ test_that("warning when no recompile and no info", {
 test_that("recompiles when force_recompile flag set",
   with_mocked_cli(
     compile_ret = list(status = 0),
-    # The mocked compile now leaves an executable behind, so the constructor
-    # queries it for compilation info. Report a failure rather than an empty
-    # list, which model_compile_info() cannot interpret.
+    # Report executable metadata as unavailable.
     info_ret = list(status = 1),
     code = expect_mock_compile({
       mod <- cmdstan_model(stan_file = stan_program, force_recompile = TRUE)
     })
   )
 )
-
-test_that("a mocked successful compile installs an executable", {
-  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
-  file.copy(stan_program, stan_file)
-  exe <- cmdstan_ext(strip_ext(stan_file))
-
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = mod <- cmdstan_model(stan_file = stan_file, force_recompile = TRUE)
-  )
-
-  expect_equal(mod$exe_file(), exe)
-  expect_true(file.exists(exe))
-})
 
 test_that("a no-op compile preserves what the previous compilation recorded", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
@@ -76,12 +53,7 @@ test_that("a no-op compile preserves what the previous compilation recorded", {
   expect_true(mod$cpp_options()$stan_threads)
   expect_false(mod$functions$existing_exe)
 
-  # The second call finds the executable up to date and compiles nothing, so it
-  # must not discard the options the executable was actually built with: an
-  # erased stan_threads makes assert_valid_threads() drop 'threads' and run a
-  # threaded executable single-threaded. It must not claim the executable is
-  # pre-compiled either, or $expose_functions() fails on a model that built
-  # itself.
+  # A no-op must preserve build options and local-build provenance.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -89,11 +61,6 @@ test_that("a no-op compile preserves what the previous compilation recorded", {
   )
   expect_true(mod$cpp_options()$stan_threads)
   expect_false(mod$functions$existing_exe)
-  # Standalone functions are rejected outright on WSL, before existing_exe is
-  # consulted, so only there can this consequence not be observed.
-  if (!os_is_wsl()) {
-    expect_warning(mod$expose_functions(), "No standalone functions found")
-  }
 })
 
 test_that("a no-op compile does not record cpp_options the executable lacks", {
@@ -108,19 +75,16 @@ test_that("a no-op compile does not record cpp_options the executable lacks", {
     "do not match the ones requested"
   )
 
-  # Nothing was rebuilt, so the request describes no executable that exists.
-  # Recording it anyway left assert_valid_threads() trusting it, and a plain
-  # $sample() then failed with "The model executable was built with threading
-  # enabled but 'threads_per_chain' was not set!" -- an error that is both
-  # false and inescapable without recompiling. (#1019)
+  # The unapplied threading request must not affect ordinary sampling (#1019).
   expect_false(isTRUE(mod$cpp_options()$stan_threads))
   expect_no_error(
     mod$sample(
       data = testing_data("bernoulli"),
       chains = 1,
-      iter_warmup = 100,
-      iter_sampling = 100,
+      iter_warmup = 10,
+      iter_sampling = 10,
       refresh = 0,
+      diagnostics = NULL,
       show_messages = FALSE
     )
   )
@@ -146,11 +110,7 @@ test_that("changing include_paths forces recompilation", {
   )
   expect_equal(names(mod$variables()$parameters), "alpha")
 
-  # The same #include directive resolves to a different file under the other
-  # directory, so an executable built against one does not describe the program
-  # the other produces. Without this the object reported the new paths and the
-  # new $variables() while still running the old binary, which is the
-  # stale-validation failure #1228 is about.
+  # The same directive resolves to a different program in dir_b (#1228).
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -159,8 +119,6 @@ test_that("changing include_paths forces recompilation", {
   expect_equal(mod$include_paths(), resolve_path(dir_b))
   expect_equal(names(mod$variables()$parameters), "beta")
 
-  # The recorded paths are now the ones just built against, so a bare call has
-  # nothing new to build.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -182,8 +140,7 @@ test_that("a no-op compile adopts an executable the object did not build", {
   file.copy(stan_program, stan_file)
   exe <- cmdstan_ext(strip_ext(stan_file))
 
-  # Build the executable through one object, then let a second, freshly
-  # constructed object find it up to date.
+  # Build with one object, then adopt the executable with another.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -203,8 +160,7 @@ test_that("a no-op compile adopts an executable the object did not build", {
 
   expect_equal(mod$exe_file(), exe)
   expect_true(mod$functions$existing_exe)
-  # Hydrated from the executable itself: STAN_THREADS is reported, STAN_OPENCL
-  # is reported as FALSE (i.e. never set) and STAN_VERSION is not a make option.
+  # Record enabled flags only and omit STAN_VERSION (not a make option).
   expect_true(mod$cpp_options()$STAN_THREADS)
   expect_null(mod$cpp_options()$STAN_OPENCL)
   expect_null(mod$cpp_options()$STAN_VERSION)
@@ -251,9 +207,7 @@ test_that("a no-op compile does not adopt options the executable lacks", {
   )
   expect_null(mod$cpp_options()$stan_threads)
 
-  # Same object, same executable, but this call explicitly asks for threading.
-  # Nothing was rebuilt, so what is recorded still has to describe the binary
-  # on disk; the caller learns their request had no effect from the warning.
+  # A no-op warns without changing the options recorded for the executable.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(
@@ -280,11 +234,8 @@ test_that("a no-op compile warns about options the executable cannot report", {
     code = cmdstan_model(stan_file, force_recompile = TRUE)
   )
 
-  # CmdStan 2.39 reports no STAN_CPP_OPTIMS, and reports nothing at all about
-  # arbitrary make variables, so the binary's own metadata can neither confirm
-  # nor deny either request. This object compiled this executable, though, so
-  # what it was built with is known exactly and both requests plainly disagree
-  # with it. Detecting these through the metadata alone silently ignored them.
+  # The executable does not report STAN_CPP_OPTIMS or arbitrary make variables.
+  # Because this object built it, the recorded options can still detect mismatches.
   info <- paste0(
     "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
     "STAN_THREADS=false"
@@ -465,8 +416,6 @@ test_that("a raw make argument round-trips through the option comparison", {
     )
   )
 
-  # Re-supplying exactly what the executable was built with is ordinary reuse,
-  # even when the option never had a name to compare by.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -494,10 +443,8 @@ test_that("options inherited from make/local are learned, not warned about", {
   )
   expect_null(mod$cpp_options()$stan_threads)
 
-  # Comparing against the record alone reported a mismatch for a binary that
-  # does have threading. The binary's own account fills the gap, and is kept:
-  # suppressing the warning without recording what it revealed would leave
-  # assert_valid_threads() still dropping 'threads_per_chain'.
+  # Metadata fills in options inherited from make/local and records them so
+  # assert_valid_threads() sees the executable's threading support.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 0, stdout = threaded),
@@ -526,7 +473,7 @@ test_that("options inherited from make/local are learned, not warned about", {
       )
     )
   )
-  # ...and changing the unreportable one is still caught.
+  # Changing the unreported option still warns.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 0, stdout = threaded),
@@ -538,8 +485,7 @@ test_that("options inherited from make/local are learned, not warned about", {
     )
   )
 
-  # With no metadata to be had, the record is all there is and still answers
-  # for the option it holds.
+  # Without metadata, compare the options recorded during compilation.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
@@ -570,10 +516,7 @@ test_that("an explicitly passed raw assignment is not taken for make/local", {
     )
   )
 
-  # The binary reports threading and this call did not name stan_threads, but it
-  # did pass STAN_THREADS=TRUE as a raw assignment, so the flag is not inherited
-  # from make/local and omitting it would drop it. Reading names() rather than
-  # what make was given missed that and stayed quiet.
+  # Raw STAN_THREADS=TRUE is explicit, not inherited from make/local.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 0, stdout = threaded),
@@ -590,9 +533,7 @@ test_that("an executable built with an explicit NULL accepts NULL again", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
 
-  # Metadata reporting threading off, rather than no metadata at all, so the
-  # merge is exercised: a reported FALSE is skipped, leaving the explicit NULL
-  # to stand as the empty assignment it is.
+  # Reported FALSE leaves the explicit NULL assignment intact.
   disabled <- paste0(
     "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
     "STAN_THREADS=false"
@@ -647,10 +588,8 @@ test_that("an adopted executable stays silent about options it cannot report", {
     code = cmdstan_model(stan_file, force_recompile = TRUE)
   )
 
-  # A second object adopts that executable and holds no generated C++ for it,
-  # so the binary's own metadata is the only description available and it
-  # reports nothing about STAN_CPP_OPTIMS. Unverifiable is not a mismatch, so
-  # this neither warns nor records the request. (#1238)
+  # An adopted executable cannot verify unreported options, so it neither warns
+  # nor records the request (#1238).
   info <- paste0(
     "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
     "STAN_THREADS=false"
@@ -684,11 +623,8 @@ test_that("no mismatch warning when the executable already has the options", {
     )
   )
 
-  # Adopted by a second object, so the binary's metadata is the only account of
-  # it available -- an object that compiled the executable is answered from what
-  # it recorded instead. The metadata reports exactly what is being asked for,
-  # so re-stating it must stay quiet, otherwise the warning fires on ordinary
-  # reuse.
+  # The adopted executable reports the requested threading option, so ordinary
+  # reuse must not warn.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(
@@ -699,8 +635,7 @@ test_that("no mismatch warning when the executable already has the options", {
       mod <- cmdstan_model(stan_file, cpp_options = list(stan_threads = TRUE))
     )
   )
-  # Hydrated from metadata, so it carries the metadata's spelling; the accessor
-  # the fitting methods use is case-insensitive.
+  # cpp_option_value() handles the metadata's uppercase spelling.
   expect_true(cpp_option_value(mod$cpp_options(), "stan_threads"))
 })
 
@@ -715,8 +650,7 @@ test_that("a no-op compile tolerates an executable it cannot query", {
   )
   mod <- cmdstan_model(stan_file, compile = FALSE)
 
-  # The mocked executable is empty, so running it errors rather than returning
-  # a non-zero status. Adopting it is best-effort and must still succeed.
+  # The mocked executable cannot answer info queries, but adoption is best-effort.
   expect_no_error(mod$compile())
   expect_true(mod$functions$existing_exe)
 })
@@ -731,9 +665,7 @@ test_that("compiling into a directory with a different executable recompiles", {
     code = mod <- cmdstan_model(stan_file)
   )
 
-  # A current executable already sits in the target directory. Adopting it would
-  # leave the object describing this program's C++ while running that binary, so
-  # the model is rebuilt there instead.
+  # Do not adopt an unrelated executable from a new directory.
   other_dir <- withr::local_tempdir()
   other_exe <- cmdstan_ext(file.path(other_dir, "bernoulli"))
   file.create(other_exe)
@@ -834,16 +766,5 @@ test_that("recompile when cpp args don't match binary", {
         cpp_options = list(stan_threads = TRUE)
       )
     })
-  )
-})
-
-# Deliberately the last test in this file: it checks that none of the mocked
-# compiles above installed anything over the CmdStan installation's own example
-# executable. A git diff would not catch this, since that executable is not part
-# of the repository, and a truncating overwrite changes no tracked file at all.
-test_that("mocked compiles leave the CmdStan installation untouched", {
-  expect_equal(
-    file.info(example_exe)[, c("size", "mtime")],
-    example_exe_before
   )
 })

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -425,11 +425,11 @@ test_that("a raw make argument round-trips through the option comparison", {
   )
 })
 
-test_that("options inherited from make/local are learned, not warned about", {
+test_that("a successful compile records options only the executable reports", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
-  # make/local supplies STAN_THREADS=true, so the executable is threaded even
-  # though nothing was passed to $compile() and nothing could be recorded.
+  # Stands in for STAN_THREADS=true in make/local: nothing was passed to
+  # $compile(), but the binary reports threading.
   threaded <- paste0(
     "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
     "STAN_THREADS=true"
@@ -441,10 +441,48 @@ test_that("options inherited from make/local are learned, not warned about", {
     info_ret = list(status = 0, stdout = threaded),
     code = mod$compile(force_recompile = TRUE)
   )
-  expect_null(mod$cpp_options()$stan_threads)
+  expect_true(cpp_option_value(mod$cpp_options(), "stan_threads"))
+  expect_silent(assert_valid_threads(2, mod$cpp_options(), multiple_chains = TRUE))
 
-  # Metadata fills in options inherited from make/local and records them so
-  # assert_valid_threads() sees the executable's threading support.
+  # What was passed to Make keeps only the request, so a later no-op can tell
+  # inherited options from explicit ones.
+  built <- mod$.__enclos_env__$private$built_cpp_options_
+  expect_null(cpp_option_value(built, "stan_threads"))
+
+  # Unreadable metadata leaves the request in place rather than erroring.
+  mod_blind <- cmdstan_model(stan_file, compile = FALSE)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = mod_blind$compile(
+      cpp_options = list(stan_cpp_optims = TRUE),
+      force_recompile = TRUE
+    )
+  )
+  expect_true(cpp_option_value(mod_blind$cpp_options(), "stan_cpp_optims"))
+  expect_null(cpp_option_value(mod_blind$cpp_options(), "stan_threads"))
+})
+
+test_that("options inherited from make/local are learned, not warned about", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+  # make/local supplies STAN_THREADS=true, so the executable is threaded even
+  # though nothing was passed to $compile().
+  threaded <- paste0(
+    "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
+    "STAN_THREADS=true"
+  )
+
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = threaded),
+    code = mod$compile(force_recompile = TRUE)
+  )
+  expect_true(cpp_option_value(mod$cpp_options(), "stan_threads"))
+
+  # A no-op keeps them recorded, and asking for what the executable already has
+  # is not a mismatch.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 0, stdout = threaded),

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -125,6 +125,33 @@ test_that("a no-op compile adopts an executable the object did not build", {
   expect_null(mod$cpp_options()$STAN_VERSION)
 })
 
+test_that("adopting an executable keeps the options the call asked for", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(stan_file, force_recompile = TRUE)
+  )
+
+  # The executable is up to date but was not built with threading. Until
+  # cmdstanr rebuilds on a cpp_options mismatch, dropping the request would
+  # make assert_valid_threads() discard 'threads' and run single-threaded
+  # without the caller ever asking for that.
+  mod <- with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(
+      status = 0,
+      stdout = "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\nSTAN_THREADS=false"
+    ),
+    code = cmdstan_model(stan_file, cpp_options = list(stan_threads = TRUE))
+  )
+
+  expect_true(mod$cpp_options()$stan_threads)
+  expect_true(mod$functions$existing_exe)
+})
+
 test_that("a no-op compile tolerates an executable it cannot query", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -135,6 +135,81 @@ test_that("changing include_paths forces recompilation", {
   )
 })
 
+test_that("constructor include_paths are the baseline for the first compile", {
+  model_dir <- withr::local_tempdir()
+  dir_a <- file.path(model_dir, "a")
+  dir_b <- file.path(model_dir, "b")
+  dir.create(dir_a)
+  dir.create(dir_b)
+  writeLines("parameters { real alpha; }", file.path(dir_a, "params.stan"))
+  writeLines("parameters { real beta; }", file.path(dir_b, "params.stan"))
+  stan_file <- file.path(model_dir, "included.stan")
+  writeLines(c("#include params.stan", "model { target += 0; }"), stan_file)
+  Sys.setFileTime(stan_file, Sys.time() - 60)
+  exe <- cmdstan_ext(strip_ext(stan_file))
+  writeLines("executable built with A", exe)
+  Sys.chmod(exe, "0755", use_umask = FALSE)
+
+  mod <- cmdstan_model(
+    stan_file,
+    include_paths = dir_a,
+    compile = FALSE
+  )
+  expect_equal(names(mod$variables()$parameters), "alpha")
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_mock_compile(mod$compile(include_paths = dir_b))
+  )
+
+  expect_match(readLines(exe), "^mock executable [0-9]+$")
+  expect_equal(mod$include_paths(), resolve_path(dir_b))
+  expect_equal(names(mod$variables()$parameters), "beta")
+})
+
+test_that("failed include_paths changes remain dirty for a bare retry", {
+  model_dir <- withr::local_tempdir()
+  dir_a <- file.path(model_dir, "a")
+  dir_b <- file.path(model_dir, "b")
+  dir.create(dir_a)
+  dir.create(dir_b)
+  writeLines("parameters { real alpha; }", file.path(dir_a, "params.stan"))
+  writeLines("parameters { real beta; }", file.path(dir_b, "params.stan"))
+  stan_file <- file.path(model_dir, "included.stan")
+  writeLines(c("#include params.stan", "model { target += 0; }"), stan_file)
+  Sys.setFileTime(stan_file, Sys.time() - 60)
+  exe <- cmdstan_ext(strip_ext(stan_file))
+  writeLines("executable built with A", exe)
+  Sys.chmod(exe, "0755", use_umask = FALSE)
+
+  mod <- cmdstan_model(
+    stan_file,
+    include_paths = dir_a,
+    compile = FALSE
+  )
+  expect_equal(names(mod$variables()$parameters), "alpha")
+
+  with_mocked_cli(
+    compile_ret = list(status = 1),
+    info_ret = list(status = 1),
+    code = expect_error(
+      mod$compile(include_paths = dir_b, force_recompile = TRUE),
+      "An error occurred during compilation"
+    )
+  )
+  expect_identical(readLines(exe), "executable built with A")
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_mock_compile(mod$compile())
+  )
+  expect_match(readLines(exe), "^mock executable [0-9]+$")
+  expect_equal(mod$include_paths(), resolve_path(dir_b))
+  expect_equal(names(mod$variables()$parameters), "beta")
+})
+
 test_that("a no-op compile adopts an executable the object did not build", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
@@ -492,6 +567,33 @@ test_that("cmdstan_model() reads the executable metadata once, whatever the path
     code = cmdstan_model(stan_file)
   )
   expect_equal(reads, 1L)
+
+  # Explicit, up-to-date executable with a Stan file.
+  reads <- 0L
+  reported_options <- paste0(
+    info,
+    "\nSTAN_THREADS=true\nSTAN_OPENCL=true"
+  )
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = reported_options),
+    code = mod_explicit <- cmdstan_model(
+      stan_file,
+      exe_file = mod$exe_file(),
+      compile = TRUE
+    )
+  )
+  expect_equal(reads, 1L)
+  expect_true(mod_explicit$cpp_options()$STAN_THREADS)
+  expect_true(mod_explicit$cpp_options()$STAN_OPENCL)
+  expect_silent(
+    assert_valid_threads(
+      2,
+      mod_explicit$cpp_options(),
+      multiple_chains = TRUE
+    )
+  )
+  expect_silent(assert_valid_opencl(c(0, 0), mod_explicit$cpp_options()))
 
   # Executable adopted without a Stan file.
   reads <- 0L

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -132,8 +132,11 @@ test_that("changing include_paths forces recompilation", {
   dir_b <- file.path(model_dir, "b")
   dir.create(dir_a)
   dir.create(dir_b)
-  stan_file <- file.path(model_dir, "bernoulli.stan")
-  file.copy(stan_program, stan_file)
+  # One directive, two directories, two different programs.
+  writeLines("parameters { real alpha; }", file.path(dir_a, "params.stan"))
+  writeLines("parameters { real beta; }", file.path(dir_b, "params.stan"))
+  stan_file <- file.path(model_dir, "included.stan")
+  writeLines(c("#include params.stan", "model { target += 0; }"), stan_file)
   Sys.setFileTime(stan_file, Sys.time() - 60)
 
   mod <- with_mocked_cli(
@@ -141,18 +144,20 @@ test_that("changing include_paths forces recompilation", {
     info_ret = list(status = 1),
     code = cmdstan_model(stan_file, include_paths = dir_a, force_recompile = TRUE)
   )
+  expect_equal(names(mod$variables()$parameters), "alpha")
 
-  # The same #include directive can resolve to a different file under a
-  # different include directory, so an executable built against one does not
-  # describe the program the other produces. Without this the object reported
-  # the new paths and the new $variables() while still running the old binary,
-  # which is the stale-validation failure #1228 is about.
+  # The same #include directive resolves to a different file under the other
+  # directory, so an executable built against one does not describe the program
+  # the other produces. Without this the object reported the new paths and the
+  # new $variables() while still running the old binary, which is the
+  # stale-validation failure #1228 is about.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
     code = expect_mock_compile(mod$compile(include_paths = dir_b))
   )
   expect_equal(mod$include_paths(), resolve_path(dir_b))
+  expect_equal(names(mod$variables()$parameters), "beta")
 
   # The recorded paths are now the ones just built against, so a bare call has
   # nothing new to build.
@@ -265,6 +270,148 @@ test_that("a no-op compile does not adopt options the executable lacks", {
   expect_null(mod$cpp_options()$stan_threads)
 })
 
+test_that("a no-op compile warns about options the executable cannot report", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  mod <- with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(stan_file, force_recompile = TRUE)
+  )
+
+  # CmdStan 2.39 reports no STAN_CPP_OPTIMS, and reports nothing at all about
+  # arbitrary make variables, so the binary's own metadata can neither confirm
+  # nor deny either request. This object compiled this executable, though, so
+  # what it was built with is known exactly and both requests plainly disagree
+  # with it. Detecting these through the metadata alone silently ignored them.
+  info <- paste0(
+    "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
+    "STAN_THREADS=false"
+  )
+  for (requested in list(
+    list(stan_cpp_optims = TRUE),
+    list(my_custom_make_flag = "1")
+  )) {
+    with_mocked_cli(
+      compile_ret = list(status = 0),
+      info_ret = list(status = 0, stdout = info),
+      code = expect_no_mock_compile(
+        expect_warning(
+          mod$compile(cpp_options = requested),
+          "was not built with the requested"
+        )
+      )
+    )
+    expect_null(cpp_option_value(mod$cpp_options(), names(requested)))
+  }
+})
+
+test_that("a no-op compile stays quiet about options it was built with", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  mod <- with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(
+      stan_file,
+      cpp_options = list(stan_cpp_optims = TRUE, my_custom_make_flag = "1"),
+      force_recompile = TRUE
+    )
+  )
+
+  # Same unreportable options, but this executable really was built with them,
+  # so re-supplying them is ordinary reuse and must not warn.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(
+      expect_no_warning(
+        mod$compile(
+          cpp_options = list(stan_cpp_optims = TRUE, my_custom_make_flag = "1")
+        )
+      )
+    )
+  )
+})
+
+test_that("option comparison ignores spelling, NULL and omission", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  mod <- with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(
+      stan_file,
+      cpp_options = list(STAN_CPP_OPTIMS = TRUE),
+      force_recompile = TRUE
+    )
+  )
+
+  quietly <- function(requested) {
+    with_mocked_cli(
+      compile_ret = list(status = 0),
+      info_ret = list(status = 1),
+      code = expect_no_mock_compile(
+        expect_no_warning(mod$compile(cpp_options = requested))
+      )
+    )
+  }
+  # Same option, other spelling, and the string a makefile would carry.
+  quietly(list(stan_cpp_optims = TRUE))
+  quietly(list(stan_cpp_optims = "TRUE"))
+  # NULL asks make for nothing, so it is omission, not a request to unset.
+  quietly(list(stan_cpp_optims = TRUE, stan_threads = NULL))
+
+  # Dropping a recorded option is still a change: cpp_options are one-shot, so
+  # recompiling with this list would build without STAN_CPP_OPTIMS.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(
+      expect_warning(
+        mod$compile(cpp_options = list(stan_threads = TRUE)),
+        "was not built with the requested"
+      )
+    )
+  )
+})
+
+test_that("an adopted executable stays silent about options it cannot report", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(stan_file, force_recompile = TRUE)
+  )
+
+  # A second object adopts that executable and holds no generated C++ for it,
+  # so the binary's own metadata is the only description available and it
+  # reports nothing about STAN_CPP_OPTIMS. Unverifiable is not a mismatch, so
+  # this neither warns nor records the request. (#1238)
+  info <- paste0(
+    "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
+    "STAN_THREADS=false"
+  )
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = info),
+    code = expect_no_mock_compile(
+      expect_no_warning(
+        mod <- cmdstan_model(
+          stan_file,
+          cpp_options = list(stan_cpp_optims = TRUE)
+        )
+      )
+    )
+  )
+  expect_null(mod$cpp_options()$stan_cpp_optims)
+})
+
 test_that("no mismatch warning when the executable already has the options", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
@@ -272,11 +419,18 @@ test_that("no mismatch warning when the executable already has the options", {
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
-    code = mod <- cmdstan_model(stan_file, force_recompile = TRUE)
+    code = cmdstan_model(
+      stan_file,
+      cpp_options = list(stan_threads = TRUE),
+      force_recompile = TRUE
+    )
   )
 
-  # The executable reports exactly what is being asked for, so re-stating it
-  # must stay quiet -- otherwise the warning fires on ordinary reuse.
+  # Adopted by a second object, so the binary's metadata is the only account of
+  # it available -- an object that compiled the executable is answered from what
+  # it recorded instead. The metadata reports exactly what is being asked for,
+  # so re-stating it must stay quiet, otherwise the warning fires on ordinary
+  # reuse.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(
@@ -284,9 +438,12 @@ test_that("no mismatch warning when the executable already has the options", {
       stdout = "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\nSTAN_THREADS=true"
     ),
     code = expect_no_warning(
-      mod$compile(cpp_options = list(stan_threads = TRUE))
+      mod <- cmdstan_model(stan_file, cpp_options = list(stan_threads = TRUE))
     )
   )
+  # Hydrated from metadata, so it carries the metadata's spelling; the accessor
+  # the fitting methods use is case-insensitive.
+  expect_true(cpp_option_value(mod$cpp_options(), "stan_threads"))
 })
 
 test_that("a no-op compile tolerates an executable it cannot query", {

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -89,7 +89,11 @@ test_that("a no-op compile preserves what the previous compilation recorded", {
   )
   expect_true(mod$cpp_options()$stan_threads)
   expect_false(mod$functions$existing_exe)
-  expect_warning(mod$expose_functions(), "No standalone functions found")
+  # Standalone functions are rejected outright on WSL, before existing_exe is
+  # consulted, so only there can this consequence not be observed.
+  if (!os_is_wsl()) {
+    expect_warning(mod$expose_functions(), "No standalone functions found")
+  }
 })
 
 test_that("a no-op compile adopts an executable the object did not build", {

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -15,7 +15,7 @@ file_that_doesnt_exist <- withr::local_tempfile(pattern = "placeholder_doesnt_ex
 file_that_exists <- withr::local_tempfile(pattern = "placeholder_exists")
 file.create(file_that_exists)
 
-skip_message <- "To be fixed in a later version."
+skip_message <- "To be fixed in a later version. See #1019."
 
 test_that("warning when no recompile and no info", {
   skip(skip_message)
@@ -96,6 +96,36 @@ test_that("a no-op compile preserves what the previous compilation recorded", {
   }
 })
 
+test_that("a no-op compile does not record cpp_options the executable lacks", {
+  # A real executable, up to date and built without threading.
+  testing_model("bernoulli")
+
+  expect_warning(
+    mod <- cmdstan_model(
+      testing_stan_file("bernoulli"),
+      cpp_options = list(stan_threads = TRUE)
+    ),
+    "was not built with the requested"
+  )
+
+  # Nothing was rebuilt, so the request describes no executable that exists.
+  # Recording it anyway left assert_valid_threads() trusting it, and a plain
+  # $sample() then failed with "The model executable was built with threading
+  # enabled but 'threads_per_chain' was not set!" -- an error that is both
+  # false and inescapable without recompiling. (#1019)
+  expect_false(isTRUE(mod$cpp_options()$stan_threads))
+  expect_no_error(
+    mod$sample(
+      data = testing_data("bernoulli"),
+      chains = 1,
+      iter_warmup = 100,
+      iter_sampling = 100,
+      refresh = 0,
+      show_messages = FALSE
+    )
+  )
+})
+
 test_that("a no-op compile adopts an executable the object did not build", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
@@ -129,7 +159,7 @@ test_that("a no-op compile adopts an executable the object did not build", {
   expect_null(mod$cpp_options()$STAN_VERSION)
 })
 
-test_that("adopting an executable keeps the options the call asked for", {
+test_that("adopting an executable describes the binary, not the request", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
 
@@ -140,9 +170,9 @@ test_that("adopting an executable keeps the options the call asked for", {
   )
 
   # The executable is up to date but was not built with threading. Until
-  # cmdstanr rebuilds on a cpp_options mismatch, dropping the request would
-  # make assert_valid_threads() discard 'threads' and run single-threaded
-  # without the caller ever asking for that.
+  # cmdstanr rebuilds on a cpp_options mismatch (#1019), the request describes
+  # an executable that does not exist, so it is reported as a warning rather
+  # than recorded as fact.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(
@@ -155,11 +185,11 @@ test_that("adopting an executable keeps the options the call asked for", {
     )
   )
 
-  expect_true(mod$cpp_options()$stan_threads)
+  expect_null(mod$cpp_options()$stan_threads)
   expect_true(mod$functions$existing_exe)
 })
 
-test_that("a no-op compile records options supplied to that same call", {
+test_that("a no-op compile does not adopt options the executable lacks", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
 
@@ -171,8 +201,8 @@ test_that("a no-op compile records options supplied to that same call", {
   expect_null(mod$cpp_options()$stan_threads)
 
   # Same object, same executable, but this call explicitly asks for threading.
-  # Preserving the recorded options is right for a bare $compile(); ignoring
-  # options the caller just supplied is not.
+  # Nothing was rebuilt, so what is recorded still has to describe the binary
+  # on disk; the caller learns their request had no effect from the warning.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(
@@ -186,7 +216,7 @@ test_that("a no-op compile records options supplied to that same call", {
       )
     )
   )
-  expect_true(mod$cpp_options()$stan_threads)
+  expect_null(mod$cpp_options()$stan_threads)
 })
 
 test_that("no mismatch warning when the executable already has the options", {

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -1,4 +1,16 @@
-stan_program <- cmdstan_example_file()
+# A mocked compile produces a real (empty) executable at the destination, so the
+# model compiled here must be a temporary copy. Compiling the installed example
+# in place would replace the CmdStan installation's own executable.
+example_exe <- cmdstan_ext(strip_ext(cmdstan_example_file()))
+example_exe_before <- file.info(example_exe)[, c("size", "mtime")]
+
+model_dir <- withr::local_tempdir()
+stan_program <- file.path(model_dir, "bernoulli.stan")
+file.copy(cmdstan_example_file(), stan_program)
+# Keep the program older than the placeholder executables created below, so the
+# up-to-date check doesn't force a recompile on timestamp resolution alone.
+Sys.setFileTime(stan_program, Sys.time() - 60)
+
 file_that_doesnt_exist <- withr::local_tempfile(pattern = "placeholder_doesnt_exist")
 file_that_exists <- withr::local_tempfile(pattern = "placeholder_exists")
 file.create(file_that_exists)
@@ -23,12 +35,47 @@ test_that("warning when no recompile and no info", {
 test_that("recompiles when force_recompile flag set",
   with_mocked_cli(
     compile_ret = list(status = 0),
-    info_ret = list(),
+    # The mocked compile now leaves an executable behind, so the constructor
+    # queries it for compilation info. Report a failure rather than an empty
+    # list, which model_compile_info() cannot interpret.
+    info_ret = list(status = 1),
     code = expect_mock_compile({
       mod <- cmdstan_model(stan_file = stan_program, force_recompile = TRUE)
     })
   )
 )
+
+test_that("a mocked successful compile installs an executable", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+  exe <- cmdstan_ext(strip_ext(stan_file))
+
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = mod <- cmdstan_model(stan_file = stan_file, force_recompile = TRUE)
+  )
+
+  expect_equal(mod$exe_file(), exe)
+  expect_true(file.exists(exe))
+})
+
+test_that("a mocked failed compile installs no executable", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+  exe <- cmdstan_ext(strip_ext(stan_file))
+
+  with_mocked_cli(
+    compile_ret = list(status = 1),
+    info_ret = list(status = 1),
+    code = expect_error(
+      cmdstan_model(stan_file = stan_file, force_recompile = TRUE),
+      "An error occurred during compilation"
+    )
+  )
+
+  expect_false(file.exists(exe))
+})
 
 test_that("no mismatch results in no recompile", with_mocked_cli(
   compile_ret = list(status = 0),
@@ -101,5 +148,16 @@ test_that("recompile when cpp args don't match binary", {
         cpp_options = list(stan_threads = TRUE)
       )
     })
+  )
+})
+
+# Deliberately the last test in this file: it checks that none of the mocked
+# compiles above installed anything over the CmdStan installation's own example
+# executable. A git diff would not catch this, since that executable is not part
+# of the repository, and a truncating overwrite changes no tracked file at all.
+test_that("mocked compiles leave the CmdStan installation untouched", {
+  expect_equal(
+    file.info(example_exe)[, c("size", "mtime")],
+    example_exe_before
   )
 })

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -126,6 +126,52 @@ test_that("a no-op compile does not record cpp_options the executable lacks", {
   )
 })
 
+test_that("changing include_paths forces recompilation", {
+  model_dir <- withr::local_tempdir()
+  dir_a <- file.path(model_dir, "a")
+  dir_b <- file.path(model_dir, "b")
+  dir.create(dir_a)
+  dir.create(dir_b)
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+  Sys.setFileTime(stan_file, Sys.time() - 60)
+
+  mod <- with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = cmdstan_model(stan_file, include_paths = dir_a, force_recompile = TRUE)
+  )
+
+  # The same #include directive can resolve to a different file under a
+  # different include directory, so an executable built against one does not
+  # describe the program the other produces. Without this the object reported
+  # the new paths and the new $variables() while still running the old binary,
+  # which is the stale-validation failure #1228 is about.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_mock_compile(mod$compile(include_paths = dir_b))
+  )
+  expect_equal(mod$include_paths(), resolve_path(dir_b))
+
+  # The recorded paths are now the ones just built against, so a bare call has
+  # nothing new to build.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(mod$compile())
+  )
+
+  # Same directory, different spelling: not a change.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(
+      mod$compile(include_paths = file.path(dir_b, "."))
+    )
+  )
+})
+
 test_that("a no-op compile adopts an executable the object did not build", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -549,14 +549,59 @@ test_that("options inherited from make/local are learned, not warned about", {
   )
 })
 
-test_that("an executable built with an explicit NULL accepts NULL again", {
+test_that("an explicitly passed raw assignment is not taken for make/local", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
+  threaded <- paste0(
+    "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
+    "STAN_THREADS=true"
+  )
 
   mod <- cmdstan_model(stan_file, compile = FALSE)
   with_mocked_cli(
     compile_ret = list(status = 0),
-    info_ret = list(status = 1),
+    info_ret = list(status = 0, stdout = threaded),
+    code = mod$compile(
+      cpp_options = structure(
+        list("STAN_THREADS=TRUE", TRUE),
+        names = c("", "stan_cpp_optims")
+      ),
+      force_recompile = TRUE
+    )
+  )
+
+  # The binary reports threading and this call did not name stan_threads, but it
+  # did pass STAN_THREADS=TRUE as a raw assignment, so the flag is not inherited
+  # from make/local and omitting it would drop it. Reading names() rather than
+  # what make was given missed that and stayed quiet.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = threaded),
+    code = expect_no_mock_compile(
+      expect_warning(
+        mod$compile(cpp_options = list(stan_cpp_optims = TRUE)),
+        "do not match the ones requested"
+      )
+    )
+  )
+})
+
+test_that("an executable built with an explicit NULL accepts NULL again", {
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+
+  # Metadata reporting threading off, rather than no metadata at all, so the
+  # merge is exercised: a reported FALSE is skipped, leaving the explicit NULL
+  # to stand as the empty assignment it is.
+  disabled <- paste0(
+    "stan_version_major=2\nstan_version_minor=39\nstan_version_patch=0\n",
+    "STAN_THREADS=false"
+  )
+
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 0, stdout = disabled),
     code = mod$compile(
       cpp_options = list(stan_threads = NULL),
       force_recompile = TRUE
@@ -566,7 +611,7 @@ test_that("an executable built with an explicit NULL accepts NULL again", {
   # An empty STAN_THREADS= is what was built with, so re-stating it matches.
   with_mocked_cli(
     compile_ret = list(status = 0),
-    info_ret = list(status = 1),
+    info_ret = list(status = 0, stdout = disabled),
     code = expect_no_mock_compile(
       expect_no_warning(mod$compile(cpp_options = list(stan_threads = NULL)))
     )

--- a/tests/testthat/test-model-variables.R
+++ b/tests/testthat/test-model-variables.R
@@ -70,6 +70,57 @@ test_that("$variables() work correctly with multidimensional variables", {
   expect_equal(mod$variables()$transformed_parameters$pp$dimensions, 3)
 })
 
+test_that("$variables() is refreshed when the model is recompiled", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- write_stan_file(
+    "
+    parameters {
+      real alpha;
+    }
+    model {
+      alpha ~ std_normal();
+    }
+    ",
+    dir = model_dir,
+    basename = "issue1228.stan"
+  )
+  mod <- cmdstan_model(stan_file)
+  expect_equal(names(mod$variables()$parameters), "alpha")
+
+  write_stan_file(
+    "
+    parameters {
+      real beta;
+    }
+    model {
+      beta ~ std_normal();
+    }
+    ",
+    dir = model_dir,
+    basename = "issue1228.stan"
+  )
+  # editing the file alone doesn't invalidate the cached variables
+  expect_equal(names(mod$variables()$parameters), "alpha")
+
+  # the edited file is newer than the executable, so this recompiles
+  mod$compile()
+  expect_equal(names(mod$variables()$parameters), "beta")
+
+  # the fitting methods validate inits against the refreshed variables
+  expect_no_message(
+    utils::capture.output(
+      mod$sample(
+        chains = 1,
+        iter_warmup = 100,
+        iter_sampling = 100,
+        refresh = 0,
+        init = list(list(beta = 0))
+      )
+    ),
+    message = "Init values were only set for a subset of parameters"
+  )
+})
+
 test_that("$variables() errors on no stan_file", {
   code <- "
   parameters {

--- a/tests/testthat/test-model-variables.R
+++ b/tests/testthat/test-model-variables.R
@@ -111,10 +111,12 @@ test_that("$variables() is refreshed when the model is recompiled", {
     utils::capture.output(
       mod$sample(
         chains = 1,
-        iter_warmup = 100,
-        iter_sampling = 100,
+        iter_warmup = 10,
+        iter_sampling = 10,
         refresh = 0,
-        init = list(list(beta = 0))
+        init = list(list(beta = 0)),
+        diagnostics = NULL,
+        show_messages = FALSE
       )
     ),
     message = "Init values were only set for a subset of parameters"

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -759,3 +759,56 @@ test_that("get_cmdstan_flags() handles line-continuation STANCFLAGS in make/loca
     }
   )
 })
+
+test_that("local_cmdstan_make_local() heals residue and nests", {
+  make_local_path <- file.path(cmdstan_path(), "make", "local")
+  original <- if (file.exists(make_local_path)) {
+    readBin(make_local_path, "raw", file.size(make_local_path))
+  } else {
+    NULL
+  }
+  withr::defer({
+    if (is.null(original)) {
+      unlink(make_local_path)
+    } else {
+      writeBin(original, make_local_path)
+    }
+    unlink(make_local_backup_path())
+  })
+  contents <- function() {
+    if (file.exists(make_local_path)) readLines(make_local_path) else character()
+  }
+
+  # A run killed before its restore leaves residue in make/local and its backup
+  # behind. The next call must heal from the backup, not adopt the residue.
+  if (is.null(original)) {
+    file.create(make_local_backup_path())
+  } else {
+    writeBin(original, make_local_backup_path())
+  }
+  cat("KILLED_RUN_RESIDUE=true\n", file = make_local_path, append = TRUE)
+
+  local({
+    local_cmdstan_make_local(cpp_options = list(OUTER_OPTION = "true"))
+    expect_false(any(grepl("KILLED_RUN_RESIDUE", contents())))
+    expect_true(any(grepl("OUTER_OPTION", contents())))
+
+    # A nested call restores to the outer state, not to the original.
+    local({
+      local_cmdstan_make_local(cpp_options = list(INNER_OPTION = "true"))
+      expect_true(any(grepl("INNER_OPTION", contents())))
+    })
+    expect_false(any(grepl("INNER_OPTION", contents())))
+    expect_true(any(grepl("OUTER_OPTION", contents())))
+    # The inner call must not have released the backup the outer one holds.
+    expect_true(file.exists(make_local_backup_path()))
+  })
+
+  expect_false(file.exists(make_local_backup_path()))
+  restored <- if (file.exists(make_local_path)) {
+    readBin(make_local_path, "raw", file.size(make_local_path))
+  } else {
+    NULL
+  }
+  expect_identical(restored, original)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -298,6 +298,30 @@ test_that("install_executable() replaces an executable and removes the backup", 
   expect_setequal(list.files(fixture$dir), basename(c(fixture$from, fixture$to)))
 })
 
+test_that("install_executable() refuses to install over a directory", {
+  fixture <- local_exe_fixture(destination_exists = FALSE)
+  dir.create(fixture$to)
+  writeLines("important", file.path(fixture$to, "data.txt"))
+
+  # file.exists() is true of directories, so a destination that is one used to
+  # be renamed aside as though it were the previous executable, leaving a
+  # regular file in its place and the directory displaced under a name the
+  # leftover-backup warning describes as an executable. $exe_file(path) and
+  # exe_file= both reach here without a directory check.
+  expect_error(
+    install_executable(fixture$from, fixture$to),
+    "is a directory",
+    fixed = TRUE
+  )
+  expect_true(dir.exists(fixture$to))
+  expect_identical(readLines(file.path(fixture$to, "data.txt")), "important")
+  # Nothing staged, nothing moved aside.
+  expect_setequal(
+    list.files(fixture$dir),
+    basename(c(fixture$from, fixture$to))
+  )
+})
+
 test_that("install_executable() leaves the destination alone if staging fails", {
   fixture <- local_exe_fixture()
   local_mocked_bindings(file.copy = function(...) FALSE, .package = "base")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -813,3 +813,128 @@ test_that("local_make_local_backup() heals residue and nests", {
   }
   expect_identical(restored, original)
 })
+
+test_that("local_make_local_backup() stops when file backup creation fails", {
+  fake_cmdstan <- withr::local_tempdir()
+  dir.create(file.path(fake_cmdstan, "make"))
+  make_local_path <- file.path(fake_cmdstan, "make", "local")
+  writeLines("ORIGINAL=true", make_local_path)
+  make_local_backup$held <- FALSE
+  withr::defer(make_local_backup$held <- FALSE)
+  local_mocked_bindings(cmdstan_path = function() fake_cmdstan)
+  local_mocked_bindings(file.copy = function(...) FALSE, .package = "base")
+
+  expect_snapshot(
+    error = TRUE,
+    local({
+      local_make_local_backup()
+    }),
+    transform = function(lines) {
+      gsub(fake_cmdstan, "<fake-cmdstan>", lines, fixed = TRUE)
+    }
+  )
+
+  expect_identical(readLines(make_local_path), "ORIGINAL=true")
+  expect_false(file.exists(make_local_backup_path()))
+  expect_false(make_local_backup$held)
+})
+
+test_that("local_make_local_backup() stops when sentinel creation fails", {
+  fake_cmdstan <- withr::local_tempdir()
+  dir.create(file.path(fake_cmdstan, "make"))
+  make_local_path <- file.path(fake_cmdstan, "make", "local")
+  make_local_backup$held <- FALSE
+  withr::defer(make_local_backup$held <- FALSE)
+  local_mocked_bindings(cmdstan_path = function() fake_cmdstan)
+  local_mocked_bindings(file.create = function(...) FALSE, .package = "base")
+
+  expect_snapshot(
+    error = TRUE,
+    local({
+      local_make_local_backup()
+    }),
+    transform = function(lines) {
+      gsub(fake_cmdstan, "<fake-cmdstan>", lines, fixed = TRUE)
+    }
+  )
+
+  expect_false(file.exists(make_local_path))
+  expect_false(file.exists(make_local_backup_path()))
+  expect_false(make_local_backup$held)
+})
+
+test_that("local_make_local_backup() retains a failed recovery backup", {
+  fake_cmdstan <- withr::local_tempdir()
+  dir.create(file.path(fake_cmdstan, "make"))
+  make_local_path <- file.path(fake_cmdstan, "make", "local")
+  writeLines("ORIGINAL=true", make_local_path)
+  make_local_backup$held <- FALSE
+  withr::defer(make_local_backup$held <- FALSE)
+  local_mocked_bindings(cmdstan_path = function() fake_cmdstan)
+  real_file_copy <- file.copy
+  copies <- 0L
+  with_mocked_bindings(
+    expect_snapshot(
+      error = TRUE,
+      local({
+        local_make_local_backup()
+        writeLines("MUTATED=true", make_local_path)
+      }),
+      transform = function(lines) {
+        gsub(fake_cmdstan, "<fake-cmdstan>", lines, fixed = TRUE)
+      }
+    ),
+    file.copy = function(...) {
+      copies <<- copies + 1L
+      if (copies == 1L) real_file_copy(...) else FALSE
+    },
+    .package = "base"
+  )
+
+  expect_identical(readLines(make_local_path), "MUTATED=true")
+  expect_true(file.exists(make_local_backup_path()))
+  expect_identical(readLines(make_local_backup_path()), "ORIGINAL=true")
+  expect_false(make_local_backup$held)
+
+  local({
+    local_make_local_backup()
+  })
+  expect_identical(readLines(make_local_path), "ORIGINAL=true")
+  expect_false(file.exists(make_local_backup_path()))
+})
+
+test_that("restore_cmdstan_make_local() preserves the backup when verification fails", {
+  fake_cmdstan <- withr::local_tempdir()
+  dir.create(file.path(fake_cmdstan, "make"))
+  make_local_path <- file.path(fake_cmdstan, "make", "local")
+  backup_path <- file.path(
+    fake_cmdstan,
+    "make",
+    "local.cmdstanr-test-backup"
+  )
+  writeLines("MUTATED=true", make_local_path)
+  writeLines("ORIGINAL=true", backup_path)
+  local_mocked_bindings(cmdstan_path = function() fake_cmdstan)
+  real_file_size <- file.size
+  local_mocked_bindings(
+    file.size = function(path) {
+      if (length(path) == 1 && path %in% c(make_local_path, backup_path)) {
+        return(NA_real_)
+      }
+      real_file_size(path)
+    },
+    file.copy = function(...) FALSE,
+    .package = "base"
+  )
+
+  expect_snapshot(
+    error = TRUE,
+    restore_cmdstan_make_local(),
+    transform = function(lines) {
+      gsub(fake_cmdstan, "<fake-cmdstan>", lines, fixed = TRUE)
+    }
+  )
+
+  expect_identical(readLines(make_local_path), "MUTATED=true")
+  expect_identical(file.exists(backup_path), TRUE)
+})

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -482,7 +482,9 @@ test_that("list_to_array fails for non-numeric values", {
 })
 
 test_that("cmdstan_make_local() works", {
-  exisiting_make_local <- cmdstan_make_local()
+  # Backup only, cmdstan_make_local() is the thing being tested.
+  local_make_local_backup()
+
   make_local_path <- file.path(cmdstan_path(), "make", "local")
   if (file.exists(make_local_path)) {
     file.remove(make_local_path)
@@ -511,7 +513,6 @@ test_that("cmdstan_make_local() works", {
                ))
   expect_equal(cmdstan_make_local(cpp_options = list("TEST4" = TRUE), append = FALSE),
                c("TEST4=true"))
-  cmdstan_make_local(cpp_options = as.list(exisiting_make_local), append = FALSE)
 })
 
 test_that("cmdstan_make_local() preserves empty make/local behavior", {
@@ -760,7 +761,7 @@ test_that("get_cmdstan_flags() handles line-continuation STANCFLAGS in make/loca
   )
 })
 
-test_that("local_cmdstan_make_local() heals residue and nests", {
+test_that("local_make_local_backup() heals residue and nests", {
   make_local_path <- file.path(cmdstan_path(), "make", "local")
   original <- if (file.exists(make_local_path)) {
     readBin(make_local_path, "raw", file.size(make_local_path))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -226,12 +226,7 @@ local_exe_fixture <- function(destination_exists = TRUE,
   fixture
 }
 
-# Windows R never creates a POSIX mode for installation to preserve or lose:
-# Sys.chmod() there toggles the read-only attribute, and default DrvFs derives
-# Linux permissions from Windows ones rather than storing mode metadata. That
-# covers WSL too, where R itself is Windows R. A genuine WSL permission test
-# would need a fixture on the Linux filesystem and would have to prove its own
-# setup can tell an executable file from a non-executable one first.
+# POSIX execute permissions are not available through Windows R, including WSL.
 expect_installed_executable <- function(path) {
   expect_identical(readLines(path), "new executable")
   if (!os_is_windows()) {
@@ -239,25 +234,14 @@ expect_installed_executable <- function(path) {
   }
 }
 
-# Normalize the random staging and backup names out of a snapshot, keeping the
-# structure of the paths the diagnostics name.
-#
-# Separators are normalized first because on Windows these paths arrive with a
-# mixture: dirname() converts to forward slashes, while withr::local_tempdir()
-# and tempfile() use backslashes, so tempfile(tmpdir = dirname(to)) yields
-# "C:/a/b\exe-new-1234".
+# Replace platform-specific directory spellings and random filenames without
+# hiding separator regressions in paths created by install_executable().
 exe_path_transform <- function(fixture) {
-  # Every spelling the directory can appear in: withr::local_tempdir() can
-  # return "/tmp//Rtmpx", file.path() keeps that, and install_executable()
-  # passes its own paths through repair_path(), which collapses it.
   dirs <- unique(c(
     fixture$dir,
     repair_path(fixture$dir),
     gsub("\\\\", "/", fixture$dir)
   ))
-  # Deliberately not normalizing separators in the message itself:
-  # install_executable() repairs the paths it builds, so a backslash reaching a
-  # diagnostic is a regression these snapshots should catch, not hide.
   function(lines) {
     for (dir in dirs) {
       lines <- gsub(dir, "<dir>", lines, fixed = TRUE)
@@ -307,11 +291,8 @@ test_that("install_executable() refuses to install over a directory", {
   dir.create(fixture$to)
   writeLines("important", file.path(fixture$to, "data.txt"))
 
-  # file.exists() is true of directories, so a destination that is one used to
-  # be renamed aside as though it were the previous executable, leaving a
-  # regular file in its place and the directory displaced under a name the
-  # leftover-backup warning describes as an executable. $exe_file(path) and
-  # exe_file= both reach here without a directory check.
+  # Directories satisfy file.exists(), so reject them before staging or renaming.
+  # Both $exe_file(path) and exe_file= can pass a directory here.
   expect_error(
     install_executable(fixture$from, fixture$to),
     "is a directory",
@@ -319,7 +300,6 @@ test_that("install_executable() refuses to install over a directory", {
   )
   expect_true(dir.exists(fixture$to))
   expect_identical(readLines(file.path(fixture$to, "data.txt")), "important")
-  # Nothing staged, nothing moved aside.
   expect_setequal(
     list.files(fixture$dir),
     basename(c(fixture$from, fixture$to))
@@ -383,9 +363,7 @@ test_that("install_executable() keeps the backup if it cannot be restored", {
 
 test_that("install_executable() rolls back when warnings are errors", {
   fixture <- local_exe_fixture()
-  # base warns and returns FALSE; under warn = 2 the warning alone would throw
-  # from inside file.rename(), skipping the rollback and stranding the only good
-  # executable at the backup path.
+  # file.rename() warnings must not interrupt rollback when warn = 2.
   local_failing_file_rename(fail_on = 2, warn = TRUE)
   withr::local_options(warn = 2)
 
@@ -401,9 +379,7 @@ test_that("install_executable() reports a backup it could not remove", {
   fixture <- local_exe_fixture()
   local_mocked_bindings(unlink = function(...) 1L, .package = "base")
 
-  # Reporting rather than signalling is the whole point: a warning here would,
-  # under options(warn = 2), unwind before the caller could record the state
-  # describing the executable that was just installed.
+  # Return the backup without warning so the caller can commit state first.
   expect_no_warning(leftover <- install_executable(fixture$from, fixture$to))
   expect_identical(readLines(fixture$to), "new executable")
   expect_true(file.exists(leftover))

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -232,10 +232,19 @@ local_exe_fixture <- function(destination_exists = TRUE,
 # and tempfile() use backslashes, so tempfile(tmpdir = dirname(to)) yields
 # "C:/a/b\exe-new-1234".
 exe_path_transform <- function(fixture) {
-  dir <- gsub("\\\\", "/", fixture$dir)
+  # Every spelling the directory can appear in: withr::local_tempdir() can
+  # return "/tmp//Rtmpx", file.path() keeps that, and install_executable()
+  # passes its own paths through repair_path(), which collapses it.
+  dirs <- unique(c(
+    fixture$dir,
+    repair_path(fixture$dir),
+    gsub("\\\\", "/", fixture$dir)
+  ))
   function(lines) {
     lines <- gsub("\\\\", "/", lines)
-    lines <- gsub(dir, "<dir>", lines, fixed = TRUE)
+    for (dir in dirs) {
+      lines <- gsub(dir, "<dir>", lines, fixed = TRUE)
+    }
     gsub("exe-(new|old)-[0-9a-f]+", "exe-\\1-<random>", lines)
   }
 }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -218,10 +218,21 @@ local_exe_fixture <- function(destination_exists = TRUE,
     to = file.path(dir, "model-exe")
   )
   writeLines("new executable", fixture$from)
+  # Compiled by make, so executable. Installation has to preserve that.
+  Sys.chmod(fixture$from, "0755", use_umask = FALSE)
   if (destination_exists) {
     writeLines("old executable", fixture$to)
   }
   fixture
+}
+
+# Windows does not carry a POSIX executable bit, so the check is meaningful only
+# where one exists. WSL runs the Linux side, where it does.
+expect_installed_executable <- function(path) {
+  expect_identical(readLines(path), "new executable")
+  if (!os_is_windows() || os_is_wsl()) {
+    expect_identical(file.access(path, mode = 1)[[1]], 0L)
+  }
 }
 
 # Normalize the random staging and backup names out of a snapshot, keeping the
@@ -275,7 +286,7 @@ test_that("install_executable() installs when there is no existing executable", 
   fixture <- local_exe_fixture(destination_exists = FALSE)
 
   expect_null(install_executable(fixture$from, fixture$to))
-  expect_identical(readLines(fixture$to), "new executable")
+  expect_installed_executable(fixture$to)
   expect_setequal(list.files(fixture$dir), basename(c(fixture$from, fixture$to)))
 })
 
@@ -283,7 +294,7 @@ test_that("install_executable() replaces an executable and removes the backup", 
   fixture <- local_exe_fixture()
 
   expect_null(install_executable(fixture$from, fixture$to))
-  expect_identical(readLines(fixture$to), "new executable")
+  expect_installed_executable(fixture$to)
   expect_setequal(list.files(fixture$dir), basename(c(fixture$from, fixture$to)))
 })
 

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -209,6 +209,150 @@ test_that("copy_temp_files retains sources if any copy fails", {
   expect_identical(file.exists(source_paths), c(TRUE, TRUE))
 })
 
+local_exe_fixture <- function(destination_exists = TRUE,
+                              .local_envir = parent.frame()) {
+  dir <- withr::local_tempdir(.local_envir = .local_envir)
+  fixture <- list(
+    dir = dir,
+    from = file.path(dir, "compiled-exe"),
+    to = file.path(dir, "model-exe")
+  )
+  writeLines("new executable", fixture$from)
+  if (destination_exists) {
+    writeLines("old executable", fixture$to)
+  }
+  fixture
+}
+
+# Normalize the random staging and backup names out of a snapshot, keeping the
+# structure of the paths the diagnostics name.
+exe_path_transform <- function(fixture) {
+  function(lines) {
+    lines <- gsub(fixture$dir, "<dir>", lines, fixed = TRUE)
+    gsub("exe-(new|old)-[0-9a-f]+", "exe-\\1-<random>", lines)
+  }
+}
+
+# Make the n-th file.rename() call fail, optionally warning first, as base does.
+local_failing_file_rename <- function(fail_on,
+                                      warn = FALSE,
+                                      .local_envir = parent.frame()) {
+  real_file_rename <- base::file.rename
+  calls <- 0
+  local_mocked_bindings(
+    file.rename = function(from, to) {
+      calls <<- calls + 1
+      if (calls %in% fail_on) {
+        if (warn) warning("cannot rename file")
+        return(FALSE)
+      }
+      real_file_rename(from, to)
+    },
+    .package = "base",
+    .env = .local_envir
+  )
+}
+
+test_that("install_executable() installs when there is no existing executable", {
+  fixture <- local_exe_fixture(destination_exists = FALSE)
+
+  expect_null(install_executable(fixture$from, fixture$to))
+  expect_identical(readLines(fixture$to), "new executable")
+  expect_setequal(list.files(fixture$dir), basename(c(fixture$from, fixture$to)))
+})
+
+test_that("install_executable() replaces an executable and removes the backup", {
+  fixture <- local_exe_fixture()
+
+  expect_null(install_executable(fixture$from, fixture$to))
+  expect_identical(readLines(fixture$to), "new executable")
+  expect_setequal(list.files(fixture$dir), basename(c(fixture$from, fixture$to)))
+})
+
+test_that("install_executable() leaves the destination alone if staging fails", {
+  fixture <- local_exe_fixture()
+  local_mocked_bindings(file.copy = function(...) FALSE, .package = "base")
+
+  expect_snapshot(
+    error = TRUE,
+    install_executable(fixture$from, fixture$to),
+    transform = exe_path_transform(fixture)
+  )
+  expect_identical(readLines(fixture$to), "old executable")
+  expect_setequal(list.files(fixture$dir), basename(c(fixture$from, fixture$to)))
+})
+
+test_that("install_executable() leaves the destination alone if the backup fails", {
+  fixture <- local_exe_fixture()
+  local_failing_file_rename(fail_on = 1)
+
+  expect_snapshot(
+    error = TRUE,
+    install_executable(fixture$from, fixture$to),
+    transform = exe_path_transform(fixture)
+  )
+  expect_identical(readLines(fixture$to), "old executable")
+  expect_setequal(list.files(fixture$dir), basename(c(fixture$from, fixture$to)))
+})
+
+test_that("install_executable() restores the backup if the install fails", {
+  fixture <- local_exe_fixture()
+  local_failing_file_rename(fail_on = 2)
+
+  expect_snapshot(
+    error = TRUE,
+    install_executable(fixture$from, fixture$to),
+    transform = exe_path_transform(fixture)
+  )
+  expect_identical(readLines(fixture$to), "old executable")
+  expect_setequal(list.files(fixture$dir), basename(c(fixture$from, fixture$to)))
+})
+
+test_that("install_executable() keeps the backup if it cannot be restored", {
+  fixture <- local_exe_fixture()
+  local_failing_file_rename(fail_on = c(2, 3))
+
+  expect_snapshot(
+    error = TRUE,
+    install_executable(fixture$from, fixture$to),
+    transform = exe_path_transform(fixture)
+  )
+  # The destination is gone, so the error has to name a real recovery path.
+  expect_false(file.exists(fixture$to))
+  leftover <- setdiff(list.files(fixture$dir), basename(fixture$from))
+  expect_match(leftover, "^exe-old-")
+  expect_identical(readLines(file.path(fixture$dir, leftover)), "old executable")
+})
+
+test_that("install_executable() rolls back when warnings are errors", {
+  fixture <- local_exe_fixture()
+  # base warns and returns FALSE; under warn = 2 the warning alone would throw
+  # from inside file.rename(), skipping the rollback and stranding the only good
+  # executable at the backup path.
+  local_failing_file_rename(fail_on = 2, warn = TRUE)
+  withr::local_options(warn = 2)
+
+  expect_error(
+    install_executable(fixture$from, fixture$to),
+    "previously compiled executable has been restored",
+    fixed = TRUE
+  )
+  expect_identical(readLines(fixture$to), "old executable")
+})
+
+test_that("install_executable() reports a backup it could not remove", {
+  fixture <- local_exe_fixture()
+  local_mocked_bindings(unlink = function(...) 1L, .package = "base")
+
+  # Reporting rather than signalling is the whole point: a warning here would,
+  # under options(warn = 2), unwind before the caller could record the state
+  # describing the executable that was just installed.
+  expect_no_warning(leftover <- install_executable(fixture$from, fixture$to))
+  expect_identical(readLines(fixture$to), "new executable")
+  expect_true(file.exists(leftover))
+  expect_identical(readLines(leftover), "old executable")
+})
+
 test_that("repair_path() fixes slashes", {
   # all slashes should be single "/", and no trailing slash
   expect_equal(repair_path("a//b\\c/"), "a/b/c")

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -226,11 +226,15 @@ local_exe_fixture <- function(destination_exists = TRUE,
   fixture
 }
 
-# Windows does not carry a POSIX executable bit, so the check is meaningful only
-# where one exists. WSL runs the Linux side, where it does.
+# Windows R never creates a POSIX mode for installation to preserve or lose:
+# Sys.chmod() there toggles the read-only attribute, and default DrvFs derives
+# Linux permissions from Windows ones rather than storing mode metadata. That
+# covers WSL too, where R itself is Windows R. A genuine WSL permission test
+# would need a fixture on the Linux filesystem and would have to prove its own
+# setup can tell an executable file from a non-executable one first.
 expect_installed_executable <- function(path) {
   expect_identical(readLines(path), "new executable")
-  if (!os_is_windows() || os_is_wsl()) {
+  if (!os_is_windows()) {
     expect_identical(file.access(path, mode = 1)[[1]], 0L)
   }
 }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -226,9 +226,16 @@ local_exe_fixture <- function(destination_exists = TRUE,
 
 # Normalize the random staging and backup names out of a snapshot, keeping the
 # structure of the paths the diagnostics name.
+#
+# Separators are normalized first because on Windows these paths arrive with a
+# mixture: dirname() converts to forward slashes, while withr::local_tempdir()
+# and tempfile() use backslashes, so tempfile(tmpdir = dirname(to)) yields
+# "C:/a/b\exe-new-1234".
 exe_path_transform <- function(fixture) {
+  dir <- gsub("\\\\", "/", fixture$dir)
   function(lines) {
-    lines <- gsub(fixture$dir, "<dir>", lines, fixed = TRUE)
+    lines <- gsub("\\\\", "/", lines)
+    lines <- gsub(dir, "<dir>", lines, fixed = TRUE)
     gsub("exe-(new|old)-[0-9a-f]+", "exe-\\1-<random>", lines)
   }
 }

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -240,8 +240,10 @@ exe_path_transform <- function(fixture) {
     repair_path(fixture$dir),
     gsub("\\\\", "/", fixture$dir)
   ))
+  # Deliberately not normalizing separators in the message itself:
+  # install_executable() repairs the paths it builds, so a backslash reaching a
+  # diagnostic is a regression these snapshots should catch, not hide.
   function(lines) {
-    lines <- gsub("\\\\", "/", lines)
     for (dir in dirs) {
       lines <- gsub(dir, "<dir>", lines, fixed = TRUE)
     }


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Fixes #1228 
Fixes #1234 
Fixes #1236 

This PR was generated in collaboration with Claude code, some code was written by me and some by Claude. All code was reviewed by me. I had Claude generate the summary below. The goal is the fix the issues listed above and various issues found along the way that interfered. 

I did many rounds of (human) code review on Claude's changes, which Claude summarizes below. 


### Issue 1228 — source-derived state is refreshed on recompilation

private$stan_code_ was read once in initialize() and private$variables_ was cached on the first $variables() call; $compile() invalidated neither. Editing the .stan file and recompiling through the same object left $code() and $variables() describing the old program. That isn't only cosmetic — the fitting methods pass self$variables() into the data and init checks, so a recompiled model validated against the old parameter set and warned about parameters that no longer exist.

Successful replacement of the executable is now the synchronization point. In one block after the exe copy: the code snapshot is re-read from the temp file that was actually compiled, variables_ is cleared so the next $variables() reparses, the functions environment is emptied in place (preserving its identity) and repopulated. (using_user_header_ was committed here too; it is now assigned eagerly — see the follow-up section below.) The standalone hpp and the external/existing_exe values moved to locals, and the compile_standalone exposure moved to after that block — that's what makes a dry run or a failed compilation leave the previously compiled state untouched.

Two user-visible consequences:

- a real recompilation drops previously exposed standalone functions; they must be exposed again with $expose_functions() (or compile_standalone = TRUE)
- $compile(dry_run = TRUE) no longer writes into self$functions

$code() is still a snapshot: editing or deleting the source file alone doesn't change it. $variables() still parses the file on disk, so the two can diverge after an edit until the next compile — that's deliberate, since $variables() is useful on uncompiled models.

### Issue 1234 — include paths and the user header persist

The precompile_* fields were cleared at the end of $compile() and nothing fed include_paths_ back in, so a second $compile() ran with no include paths and no user header. A model with #include directives or a user header could not be recompiled at all, and a header that overrides an existing definition rather than supplying an undeclared one would silently produce a different executable.

Include paths and a user header aren't build options — they're inputs the program needs in order to translate — so they now persist for the life of the object and are replaced whenever new ones are supplied:

- $compile() falls back to include_paths_, then precompile_include_paths_
- the stored header is reused when neither the argument nor a cpp_options entry is given, without firing the "specified both via…" warnings (this chain has since been replaced by a shared resolver — see the follow-up section below)
- cmdstan_model() now stores its user_header argument, which was previously only passed through to $compile() — so with compile = FALSE it was lost entirely and even the first $compile() failed
- the three precompile_* <- NULL assignments moved inside if (!dry_run); clearing them ran even when nothing was compiled
- $include_paths() no longer gates on the executable existing, so it stops returning NULL after a dry run or once the exe is removed

cpp_options and stanc_options deliberately keep their one-shot behavior. A bare $compile() producing an unconfigured build is a tested workflow ("switching threads on and off works without rebuild"), and sticky stanc options would leak values such as name= into every later compilation of the same object. A test pins that asymmetry.

**Also**

$check_syntax() and $format() never consulted using_user_header_, so any model with an external C++ function was reported as a syntax error — even one that was never compiled. $compile() and $variables() both already derive --allow-undefined; these two were the only methods that didn't.

### Testing

New regression tests in test-model-variables.R (the issue's reproduction, including that inits for the new parameter no longer trigger the "subset of parameters" message), test-model-code-print.R, test-model-expose-functions.R, test-model-compile.R (commit timing under dry_run and a failed compile, include-path reuse, and the cpp/stanc asymmetry) and test-model-compile-user_header.R (header reuse, and a header supplied to cmdstan_model()). Each was confirmed to fail before the corresponding fix.

Run locally on macOS: test-model-compile.R, test-model-compile-user_header.R, test-model-variables.R, test-model-code-print.R, test-model-recompile-logic.R, test-model-expose-functions.R, test-model-methods.R, plus the include-path test in test-fit-shared.R — all pass, with only pre-existing skips. The full suite will be run on CI and wasn't run locally because test-install.R rebuilds CmdStan from source. 

### Not included 

After a real compilation, $check_syntax() and $format() still lose the stanc_options supplied to cmdstan_model(), since precompile_stanc_options_ is their only source. Fixing that means giving them a persistent copy rather than sharing the field $compile() consumes; noted in #1234.

---

## Follow-up: applying the invariant everywhere

Review found the invariant above — *successful replacement of the executable is
the point at which state describing the compiled artifact is committed* — was
right but incompletely applied. State now splits four ways:

* **Source configuration** — what the *next* stanc/make invocation should use
  (`include_paths_`, `user_header_`, `using_user_header_`). Assigned **eagerly**:
  a failed compile must not invalidate it, and `$variables()`, `$check_syntax()`
  and `$format()` consume it without compiling. Shape is validated wherever a
  value is accepted; existence only when compiling, so a header created between
  `cmdstan_model(..., compile = FALSE)` and `$compile()` still works. This also
  closes a hole above: a failed `$compile(user_header = h)` used to leave
  `using_user_header_` `FALSE`, reintroducing the bogus "declared without
  specifying a definition" error. (Eager enough for stanc and C++ failures, but
  the existence check still returned ahead of the assignment — corrected in the
  fourth round below.)
* **Artifact description** — what the current executable *is* (`stan_code_`,
  `variables_`, `functions`, `model_methods_env_`, `hpp_file_`, `cpp_options_`).
  Committed only after verified replacement. `exe_file_` and `cmdstan_version_`
  are commented exceptions: during a dry run they are also the configured
  destination and toolchain version, so they are assigned on dry runs and on
  success, never on failure.
* **Divergence markers** — `user_header_dirty_` and `include_paths_dirty_`, which
  are neither: they record that configuration and artifact have drifted apart.
  Latched rather than assigned, because on a retry after a failed compile the
  configuration resolves back to itself and nothing looks changed.
* **Command-line provenance** — `built_cpp_options_`, the `cpp_options` actually
  passed to `make` for the current executable. Distinct from `cpp_options_`,
  which also carries what the binary reports about itself, because only the
  options this object passed would be dropped by a rebuild that omitted them;
  anything else the binary has came from `make/local` and would be inherited
  again. Written only in the commit block, so a no-op may augment
  `cpp_options_` from metadata while leaving this untouched.

### State transitions

The rule above, made concrete. `exe_file_` and `cmdstan_version_` are the
commented exceptions described in the previous section.

| Transition | Source config | Artifact description | Dirty markers | `exe_file_` |
|---|---|---|---|---|
| `cmdstan_model(compile = FALSE)` | stored | untouched | stay `FALSE` — first configuration is not a change | unset |
| `cmdstan_model(exe_file = )` | stored | untouched | stay `FALSE` | set |
| No-op, object built this executable | updated | carried forward | unchanged | reasserted |
| No-op, object adopting an executable | updated | hydrated from `<exe> info`; `existing_exe = TRUE` | unchanged | set |
| No-op, `cpp_options` the binary lacks | updated | **not** recorded; warning instead | unchanged | reasserted |
| No-op, binary reports options never passed | updated | `cpp_options_` augmented from metadata; `built_cpp_options_` untouched | unchanged | reasserted |
| Changed header / include paths | updated | — forced to compile — | latched `TRUE` | — |
| Changed destination (`dir =`) | updated | — forced to compile — | unchanged | — |
| Dry run | updated | untouched | retained | assigned |
| Failed stanc or C++ compile | updated | untouched | retained | untouched |
| Failed executable install | updated | untouched | retained | untouched (errors) |
| Successful compile | updated, `precompile_*` cleared | committed as a block | cleared | assigned |

Two rows carry most of the bugs here. *Failed compile* previously replaced
`$code()`, `$variables()` and the model-method C++ while leaving the old
executable in place (#1228). *No-op* previously erased `$cpp_options()` and
marked a self-built model as pre-compiled (#1234).

The up-to-date check reads the mtimes of the Stan program and the user header
only. Files reached by `#include` are not checked at any depth, and nothing
records which header or include paths produced an existing executable, so a
fresh object cannot verify the provenance of a binary it did not build. Both
limits are now documented under `force_recompile`.

### Edge cases introduced by the new persistence

Persisting the header is what fixes #1234, and it raises two questions the old
code never had to answer.

* **A relative header supplied with `compile = FALSE` was left unresolved**, so a
  later `$compile()` from a different working directory looked for it in the
  wrong place. Headers now resolve to absolute paths at construction, matching the
  include-path convention from #1229.
* **There was no way back to no header once one was persisted.** `$compile()` now
  accepts `user_header = NULL`, which clears a header supplied through any of the
  three routes (`user_header`, `cpp_options$USER_HEADER`,
  `cpp_options$user_header`). Because clearing changes what would be built, it
  forces recompilation rather than taking the up-to-date path — as does changing
  from one header to another. Duplicate spellings in `cpp_options` are reduced to
  the one actually used — the **last**, as make takes it (see the third review
  round below) — so `$cpp_options()` no longer reports the ignored duplicate
  after a successful compile.

The same precedence now runs at construction, not just in `$compile()`: previously
`cmdstan_model(f, compile = FALSE, user_header = NULL, cpp_options =
list(USER_HEADER = h))` silently ignored the explicit `NULL` and built with `h`.
The user-header chain is now a single pure resolver called from both
`initialize()` and `compile()`. `character(0)` is rejected with a message naming
the argument instead of failing later with "invalid 'file' argument".

### A quiet lie this surfaced

Supplying `cpp_options` to a compile that finds the executable up to date records
them without rebuilding anything. So `cpp_options = list(stan_threads = TRUE)`
over an existing unthreaded executable made `$cpp_options()` report threading and
printed `", with 2 thread(s) per chain..."` — a message cmdstanr emits itself —
while the binary, compiled without `STAN_THREADS`, ran single-threaded. Results
were correct; the performance the user asked for silently never happened.

Worse than a missed optimisation, it also produced a false *error*: with
`stan_threads` recorded, a plain `$sample()` with no `threads_per_chain` hit
`assert_valid_threads()`'s "the model executable was built with threading enabled
but 'threads_per_chain' was not set!" — untrue, and inescapable without
recompiling. The two failure modes chained, since the only way past the error was
to set `threads_per_chain` and land back in the silent lie.

`$compile()` now warns in that case **and does not record the request**. What is
already recorded still describes the binary on disk and is carried forward, so a
bare `$compile()` still cannot erase it. `assert_valid_threads()` then refuses
`threads_per_chain` with its existing warning rather than trusting a claim
nothing verified.

The warning is **best effort**, and which of two routes it takes matters:

* **The object compiled this executable.** Then the options passed to `make` are
  recorded, so the request is compared against those — which catches options the
  binary cannot report (`STAN_CPP_OPTIMS` is absent from CmdStan 2.39's output;
  arbitrary make variables never appear). The record is not the whole artifact,
  though: options inherited from `make/local` never reach `$compile()` and so
  were never recorded. Anything the binary reports that the record does not hold
  is therefore treated as inherited, applied to both sides of the comparison
  since a rebuild would inherit it again, and added to `$cpp_options()` so that
  `threads_per_chain` is no longer refused for an executable that does have
  threading. The comparison is symmetric, because `cpp_options` are one-shot: an
  option the executable has and the request omits would be dropped by a
  recompilation, so that is a difference too. Rather than re-reading the
  `cpp_options` list — a second implementation of make's semantics, which drifts
  — the comparison canonicalizes the output of
  `cpp_options_to_compile_flags()`, so what is compared is literally what `make`
  is handed. Assignments reduce last-wins by lower-cased name, as a makefile
  does; anything that is not an assignment keeps its order relative to the other
  opaque arguments, though not its position among the assignments; and duplicate
  names, vector values that expand into several assignments, and header entries
  are all resolved before the comparison sees them.

  Two shapes that look like omission are not. `FALSE` reaches make as
  `STAN_THREADS=FALSE`, and CmdStan enables some options whenever their variable
  is non-empty. `NULL` reaches make as an empty `STAN_THREADS=` — and since
  these are command-line assignments they override `make/local`, so `NULL`
  disables the option whatever `make/local` says, while omitting it leaves
  `make/local` in force. The `cpp_options` documentation, which offered the two
  as interchangeable, now says so.
* **The executable was adopted from an earlier session.** Then the binary's own
  metadata is the only account available, and it covers a handful of `STAN_*`
  flags. Anything outside that set passes unremarked rather than being reported
  as a mismatch — unverifiable is not the same as wrong, and warning whenever
  provenance is unknown would fire on ordinary reuse. #1238 is what fixes this
  properly.

`force_recompile = TRUE` remains the way to guarantee a supplied option takes
effect.

Rebuilding automatically on a mismatch is the real fix and remains outstanding
(#1019, and the three `skip()`ped tests in `test-model-recompile-logic.R`, which
now name that issue). This change is a step toward it rather than a detour:
`cpp_options_` now means exactly one thing — what the current executable was
built with — which is the baseline such a check needs. Recording the request
would have defeated it, since the recorded request matches the next identical
request and a rebuild would never fire.

This wires up `exe_info_reflects_cpp_options()`, which existed and was tested but
had **no production caller** — so although the function predates this branch, its
behaviour ships here for the first time, and its input handling was corrected as
part of that rather than inherited. It compared lower-case option names against
`model_compile_info()`'s upper-case output, which is why it had never once fired;
it also read the `cpp_options` list directly, so an unnamed raw assignment was
invisible to it, duplicate names took the first rather than the last, and a
vector value errored outright. It now reads through the same parse as everything
else and is case-insensitive about metadata names.

### Pre-existing coherence defects found while tightening the boundary

None of these are regressions from this PR; they are cases where the object could
end up describing a program its executable was not built from.

* **Model-method and HPP state were replaced before the compiler ran.** A failure
  at the C++ stage left the old executable paired with model-method code generated
  from the *new* source, and that environment is handed to every fit — so
  `fit$init_model_methods()` would compile `log_prob()` from a program the draws
  did not come from. Both are now staged in locals and committed with everything
  else.
* **The executable replacement was unchecked.** `file.remove(exe)` followed by
  `file.copy(tmp_exe, exe)` discarded both return values, so a copy failing after a
  successful remove left the model with *no* executable and no error. Replacement
  now stages the new executable beside the destination, moves the old one aside,
  renames into place, and rolls back on failure. Every filesystem call is wrapped
  in `suppressWarnings()` and checked by value, because `file.rename()` warns on
  failure and under `options(warn = 2)` would otherwise throw before the rollback
  could run. A backup that cannot be cleaned up afterwards is *returned* rather
  than signalled, and warned about only once the optional exposure work is done —
  signalling earlier would unwind before the state describing the newly installed
  executable was recorded.
* **An up-to-date `$compile()` erased `$cpp_options()`.** The recorded options were
  replaced with whatever that call supplied — usually nothing. Erasing
  `stan_threads` makes `assert_valid_threads()` warn and drop `threads`, so a
  threaded executable silently ran single-threaded. Masked for `cmdstan_model()`
  by the constructor's metadata merge, so it only bit direct `$compile()` calls.
* **An up-to-date `$compile()` asserted `existing_exe` unconditionally**, so
  `$expose_functions()` failed with "not possible with a pre-compiled Stan model"
  on a model that had compiled itself. The flag now means what it says: we do not
  hold the generated C++ for this executable.
* **An up-to-date `$compile()` cleared the precompile options**, so a later forced
  recompilation lost the `cpp_options`, `stanc_options` and `include_paths`
  supplied to `cmdstan_model()`.
* **`$compile(dir = ...)` pointing at a different current executable adopted it**
  while keeping this object's generated C++ and metadata. It now rebuilds there.
  Paths are compared canonically, so symlink aliases, `..` components and Windows
  casing do not cause needless rebuilds.
* **Changing `include_paths` did not rebuild.** A `#include` directive resolves
  against the include paths, so two path vectors can build two different programs
  from one Stan file. `$compile()` replaced the stored paths eagerly but never
  consulted them when deciding whether to rebuild, so `$compile(include_paths =
  b)` on a compiled model reported the new paths and the new `$variables()` while
  still running the binary built from the old ones — initial values were then
  validated against a program that was not running, and the chains failed inside
  CmdStan. Comparison is ordered, since order decides which directory a directive
  resolves from. The first configuration of an object is not a change: treating
  it as one would rebuild an up-to-date executable in every new R session.

`$compile(dry_run = TRUE)` also no longer records `$cpp_options()` or moves
`$hpp_file()`, which previously pointed at a temporary file the dry run never
wrote. Two existing tests asserted on `$cpp_options()` after a dry run and now use
a mocked successful compile instead.

One implementation note a reviewer may want: the resolver strips **both** header
spellings from `cpp_options` and only `$compile()` reinserts the selected one, so
`precompile_cpp_options_` deliberately never carries a header. Storing it there
would mean storing a WSL-safe path, which the next `$compile()` would then select
as its `user_header` — a host path by design, since `file.exists()` on it breaks
under WSLv1. `user_header_` is the single source instead.

### Testing the follow-up

`tests/testthat/helper-mock-cli.R` previously returned `status = 0` without
producing the executable `make` was asked for, which is why the unchecked
replacement was invisible to the test suite. It now creates the artifact when and
only when the mocked compile succeeds. That in turn required moving the mocked
compiles in `test-model-recompile-logic.R` onto temporary copies: they targeted
`<cmdstan>/examples/bernoulli/bernoulli.stan`, so a faithful mock overwrites the
CmdStan installation's own example executable. That file is not in the repository
and a truncating overwrite leaves no diff at all, so the file carries a guard test
checking its size and mtime before and after.

New tests cover the staged replacement and each of its failure modes (snapshotted,
including the recovery paths the diagnostics name), the `warn = 2` behaviour at
both the helper and `$compile()` level, header clearing and identity changes
through all three supply routes, construction-time precedence, and the no-op
path's preservation of `cpp_options()` and `$expose_functions()`. Each was
confirmed to fail before the corresponding fix.

---

## Second review round

Six items, all addressed. Three notes where the outcome differs from what was
asked, with the evidence behind each.

* **Changed `include_paths` did not rebuild** — fixed, as described above. Not a
  regression: reproduced identically against the PR base, which had the same
  eager assignment and no include clause in the decision.
* **C++ options the binary lacks are no longer recorded** — described above. The
  suggested alternative, rebuilding automatically on a mismatch, is deliberately
  *not* done here. `exe_info_reflects_cpp_options()` had never executed in
  production before this branch (the case mismatch above meant it always compared
  an empty overlap), and the metadata keys it depends on vary by CmdStan version —
  2.39 reports no `STAN_CPP_OPTIMS` at all, so a request for it cannot be checked
  against the binary either way. Switching a rebuild onto a comparator with no
  field history, over a key set that changes between releases, risks recompiling
  on every call for anyone whose requested option is reported but not changed by
  the rebuild. #1019 tracks it.
* **A user header configured over an up-to-date executable still does not
  rebuild** — documented rather than changed, and pinned by a test across all
  three supply routes. Provenance cannot be established: the binary does not
  report its header, so "rebuild unless provenance is proven" reduces to "always
  rebuild", once per R session, for exactly the users with the most expensive C++
  builds. It would also close only one direction — an executable built *with* a
  header and adopted by an object configured without one is the same gap
  reversed. Exposure is narrower than it appears: a model that needs a user
  header **cannot build without one** (`make` fails on the missing
  `user_header.hpp` and leaves no executable), so an existing up-to-date binary
  for such a model was built with *some* header; the remaining case is a
  *different* header older than the executable, and the mtime check already
  catches every case where it is newer. The durable fix is recording build
  provenance beside the executable, which would also retire the metadata
  guesswork entirely.
* **Regression tests that did not cross the transition they name** — the two
  flagged tests ran two dry runs each, and the precompile state they concern is
  cleared inside the commit block, which a dry run never enters. Fixed, but
  "begin with a successful compilation" was not sufficient on its own: options
  handed straight to `$compile()` are locals that never enter `precompile_*`, so
  a second test covers the constructor route that actually exercises the
  clearing. Verified by deleting the two clears — it fails on both assertions.
* **The transitive-include limitation** — documented under `force_recompile`,
  with the framing corrected. It is not only *nested* includes: a **directly**
  included file is not checked either, since only the top-level program and the
  user header are stat'ed.
* **PR scope** — kept as one PR, with the transition matrix above supplied
  instead. Splitting would spread one state machine across four PRs that each
  edit the same `compile()` decision block and each need a full CI run, and the
  proposed fourth slice already exists as #1019. The commits are sequenced and
  individually tested, so `git bisect` works across them.

Also in this round: `$format(overwrite_file = TRUE)` gained its missing NEWS
entry, and the skipped mismatch tests now name #1019 so they read as tracked
rather than abandoned.

A second pass raised two more, both taken:

* **Options the binary cannot report were still ignored in silence.** Detecting a
  mismatch only through executable metadata meant a request for
  `stan_cpp_optims` — or any arbitrary make variable — was neither applied nor
  mentioned, contradicting what NEWS claimed. An executable the object compiled
  itself is now answered from what was recorded rather than from metadata, which
  catches those exactly. See the two routes described above.
* **The include-path tests did not cross the transition they named.** One used a
  model with no `#include` at all, so it showed `make` ran but not that the
  program changed; it now resolves a single directive against two directories and
  asserts `$variables()` moves with it. The other ran two dry runs, which leave
  `precompile_include_paths_` in place, so reuse through the compiled state was
  never exercised.





---

## Third review round

An independent reviewer, brought in because the previous reviewer had co-authored
the option-comparison design over five rounds and so could not audit it. Two
passes, seven findings, all taken. Two of the fixes differ from what was
prescribed; the evidence for both is below.

### Production fixes

* **Installing an executable over a directory destroyed data.** `file.exists()`
  is true of directories, and neither `$exe_file(path)` nor
  `cmdstan_model(exe_file = )` checks what it was given, so a path naming a
  directory reached the installer unexamined: the directory was renamed aside as
  though it were the previous executable, a regular file was put in its place,
  and the leftover-backup warning then described the displaced directory as an
  executable. Now refused before anything is staged or moved.

* **The commit block could fail after the executable was already installed.**
  Everything fallible is meant to happen before installation, and the block that
  follows is assignments only — with one exception: the `functions` environment
  is cleared *in place*, to keep its identity for any fit holding a reference.
  `functions` is a public field and R6 permits replacing it, so
  `mod$functions <- NULL` reached `rm(envir = NULL)` with the new executable
  already on disk, leaving the object describing the previous program. That is
  the #1228 failure this ordering exists to prevent, reached through a side door.
  The block's preconditions are now checked before the swap.

* **Duplicated header entries took the first, where make takes the last.**
  `resolve_user_header()` read with `cpp_options[["USER_HEADER"]]` and removed by
  assigning `NULL` to that name. Both act on the first match, but every duplicate
  reaches make and a makefile takes the last assignment — so the header compiled
  with was not the one that would have been used, and removal by name left the
  remaining duplicates to reach make alongside it. Now resolved by position.

* **A `NULL` header entry was ignored instead of clearing.** Presence was decided
  by testing the value for `NULL`, but `NULL` is a value an entry can hold, not a
  way of being absent: `cpp_options = list(USER_HEADER = NULL)` stands for an
  explicit `USER_HEADER=`, which make takes as clearing anything set before it.
  Reading presence off the value made that indistinguishable from supplying
  nothing, so a persisted header was carried forward and the model compiled with
  no header while continuing to report the old one. Presence now comes from the
  entry's position, independently of its value.

  Reported for one shape — a duplicate whose last occurrence is `NULL` — but it
  affected a plain single entry in both spellings too, and that part predates
  this branch: `cpp_options[["USER_HEADER"]]` returned `NULL` for it just as the
  positional read did. A `NULL` entry now also raises the existing "specified
  both" warning against an explicit `user_header`, since asking to clear a header
  conflicts with supplying one.

### Test infrastructure

Called out because low mock fidelity is *how this class of defect survives* — the
mocked CLI has now hidden two separate bugs, and both were found by review rather
than by a failing test.

* Every mocked build wrote the same zero-byte file, so no test could distinguish
  "the new artifact was installed" from "the old one was retained" — the
  invariant this PR is largely about. Each build now writes distinct contents,
  and a new test compiles twice and requires them to differ. This immediately
  invalidated an existing assertion that the installed file was *empty*, which
  had been standing in for "the new artifact was installed" using emptiness as
  the only available proxy.
* The mock matched the literal `"make"`, while production resolves the command
  through `make_cmd()`, which honours `$MAKE`. With `$MAKE` set the mock was
  bypassed and the tests shelled out to the real command.
* The mock now sets an executable mode, so installation losing it is something
  the suite can notice rather than something the mock never modelled.

### Where the fixes differ from what was prescribed

* **No `bindingIsLocked()` check.** The natural reading of the commit-block
  finding suggests testing it alongside `environmentIsLocked()`. That check was
  written and then removed: a locked *binding* does not prevent `rm()` from
  removing it, and the assignments that follow create bindings afresh, so a
  locked binding compiles correctly today and rejecting it would have introduced
  the failure the check was meant to prevent. Pinned by a test.

* **The executable-mode assertion is skipped on Windows, not redirected through
  WSL.** The first version of that check ran under WSL on the reasoning that WSL
  runs the Linux side; it does not — R itself is Windows R there, so
  `file.access(mode = 1)` applies Windows semantics, which call a non-directory
  executable only when its extension is `.exe`, `.com`, `.bat` or `.cmd`. It took
  the WSL job red. The suggested fix was to observe from the Linux side with
  `wsl test -x`, but the problem is upstream of the observer: Windows
  `Sys.chmod()` toggles the read-only attribute rather than setting a POSIX mode,
  and default DrvFs derives Linux permissions from Windows ones instead of
  storing mode metadata, so there is no execute bit for installation to preserve
  or lose. The reviewer agreed. Checked on macOS and Linux only.

Also surfaced in this round and tracked separately: `local_cmdstan_make_local()`
restores the real CmdStan `make/local` via `withr::defer` on test-file exit, so a
run killed before exit leaves its entry behind — and the next run snapshots the
polluted file as its baseline, so the residue compounds rather than recovering.
Pre-existing and untouched here.


## Fourth review round

The same independent reviewer, second pass. Three findings, all taken, plus a
fourth change that falls out of the second. Two of the three contradict claims
this description makes, which is what raised them above housekeeping.

### The user header was recorded after the check that it exists

`$compile(user_header = "typo.hpp")` resolved the path, checked that the file
existed, and errored — all before assigning `user_header_` and
`using_user_header_`. So the eager-assignment claim above held for stanc and C++
failures but not for this one: the model went on reporting that it used no user
header, so `$check_syntax()` and `$format()` flagged the program's own undefined
functions, and a bare retry after creating the file compiled with no header at
all.

The check now runs after the assignment. Storing a path that does not exist is
deliberate rather than a workaround — it is the same contract as
`cmdstan_model(compile = FALSE)`, where existence is a compile-time question so
that a header written between construction and `$compile()` still works.

### `$cpp_options()` dropped options inherited from `make/local` after a rebuild

The follow-up section says options inherited from `make/local` are added to
`$cpp_options()` "so that `threads_per_chain` is no longer refused for an
executable that does have threading." True on the no-op and construction paths,
which both merge what `<exe> info` reports. A *successful* compile assigned only
the bare request, so building a threaded model and sampling it immediately warned
that `threads_per_chain` "will have no effect" and dropped to one thread.

The merge now also runs after a successful build. Three constraints fixed where:

* Not inside the commit block, which is assignments only — a subprocess call
  there is fallible and would reintroduce the hybrid state the ordering exists to
  prevent.
* Before the optional exposures rather than after. `expose_stan_functions()`
  returns early on WSL, both exposures can fail in Rcpp, and the trailing
  leftover-backup warning throws under `options(warn = 2)`. Placed after them,
  whether `$cpp_options()` reported threading would depend on whether the user
  happened to ask for standalone functions.
* `built_cpp_options_` keeps the bare request. That asymmetry is what lets a
  later no-op tell an option inherited from `make/local` from one passed
  explicitly, which is what the mismatch warning rests on.

If the metadata cannot be read the request stands unchanged, which is how the
no-op path already treats an executable it cannot query.

### `cmdstan_model()` ran the executable twice — Fixes #1236

`initialize()` calls `$compile()` and then merges the metadata unconditionally,
and `$compile()` reads it on both of its exits. The merge above would have taken
a fresh compile from one query to two; gating `initialize()`'s merge on whether
it compiled takes every path to exactly one instead, which is #1236 in full.

| `cmdstan_model()` path | Before | After |
|---|---|---|
| Stan file, fresh compile | 1 | 1 |
| Stan file, executable up to date | **2** | 1 |
| `exe_file = ` | 1 | 1 |

### `$expose_functions()` on a model with no executable

`initialize()` set `functions$compiled` but not `functions$existing_exe`, which
is written only by a compile that reaches one of its exits. After
`$compile(dry_run = TRUE)`, `expose_stan_functions()` read `NULL` and failed with
`argument is of length zero`.

Defaulted to `TRUE`. `FALSE` would be worse than the cryptic error: the call
would fall past the `hpp_code` guard into the compile branch with no generated
C++ to compile. The resulting message — "not possible with a pre-compiled Stan
model" — is still wrong for a model that was never compiled; that is #1245,
along with the trap in the obvious fix: `functions$compiled` is `FALSE` inside
the commit block and `expose_stan_functions()` is called from the compile path,
so a guard keyed on it would break `compile_standalone = TRUE`. The only clean
discriminator is whether an executable exists on disk, which puts any guard in
the `$expose_functions()` wrapper rather than in `expose_stan_functions()`.

### Where this differs from what was prescribed

* **No warning when the post-build metadata read fails.** The reviewer suggested
  one, and it was written and then removed. The mocked CLI uses a failing `info`
  response as its "don't care" default, so the warning fired in about thirty
  existing tests across two files that have nothing to do with this change.
  Silencing them means giving every one of those call sites a realistic `info`
  payload — a worthwhile mock-fidelity change, but a separate one. The deciding
  argument is that an executable which cannot report its metadata will fail
  loudly at `$sample()` — this read is not the last line of defence. The cost of
  staying quiet is a *misleading* `threads_per_chain` warning, not a silently
  wrong answer, and it belongs with the other consequences of having no build
  provenance beside the executable (#1238).

  Checking that reasoning turned up a real asymmetry, filed as #1246: the two
  compile paths degrade quietly, but the third reader of the same metadata —
  `initialize()`, at `R/model.R:324` — is unguarded, so
  `cmdstan_model(exe_file = <not runnable>)` surfaces a raw `processx` error with
  a C source location in it. Pre-existing and untouched here, since the fix is a
  better error rather than a `tryCatch`. Note also that
  `test-model-recompile-logic.R` carries a `skip()`ped test expecting a
  `"Recompiling is recommended."` warning for unreadable metadata, parked behind
  #1019 — so there is an existing intent to warn here, and it should be settled
  as one decision rather than piecemeal.

Also noted and filed rather than fixed: `$cpp_options()` can now list an option
under both spellings (`stan_threads` from the request, `STAN_THREADS` from the
metadata), since `model_compile_info()` upper-cases its keys. Cosmetic —
`cpp_option_value()` matches case-insensitively and takes the last match,
`parsed_cpp_options()` reduces to last-wins before anything reaches Make, and
`built_cpp_options_` never holds the merged copy, so the mismatch detection does
not see it. Pre-existing via `initialize()` and the no-op path, but the merge
above makes it appear after a recompile too. #1247.

### Test infrastructure

`local_cmdstan_make_local()` mutates the real CmdStan installation and restored
it only via `withr::defer`, so a run killed before that ran left its entry behind
— and the next run snapshotted the polluted file as its baseline, compounding the
residue rather than recovering. Flagged at the end of the previous round and
fixed here, because the inheritance coverage above depends on it.

The protection now lives in its own helper, `local_make_local_backup()`. Its
outermost call copies `make/local` aside on disk and heals from that copy before
taking its own snapshot; nested calls restore to the enclosing state and leave the
backup to its owner, which is what lets a single test set an option inside a file
that already sets one at the top level.

Three call sites mutated `<cmdstan>/make/local` with a hand-written restore as the
last line of the test, which is skipped by any error above it — not only by a
kill. All three now go through the helper:

* `test-model-compile.R:387` and `:947`, via `local_cmdstan_make_local()`, which
  gained an `append` passthrough for them.
* `test-utils.R:484`, via `local_make_local_backup()` directly, since
  `cmdstan_make_local()` is the function under test there and the writes have to
  stay the test's own. That one wrote `CXX=clang++`, so its residue would have
  overridden the compiler for every later build in the installation. Its manual
  restore also could not reproduce an originally-absent `make/local`:
  `as.list(NULL)` reaches `write(NULL, ...)`, which creates an empty file rather
  than removing it. The byte-level restore handles that.

Worth knowing for #1025: the nesting bookkeeping is a per-process flag, so this
makes the suite robust against being killed, not against being run concurrently
against one CmdStan installation.

That coverage is real rather than mocked. `cpp_options work with settings in
make/local` already exercised the `cmdstan_model()` route end to end — and, with
the `initialize()` gate above, now depends on the post-commit merge to pass. The
route the reviewer actually described, a recompile through an existing object,
was untested, and is what the new test covers: `STAN_THREADS=true` in a real
`make/local`, a real `$compile(force_recompile = TRUE)`, and
`assert_valid_threads()` asked directly whether it still objects. Confirmed to
fail without the merge, on both assertions.
