### PR TITLE
v1.0 stage1: make-option correctness

### DIFF
--- a/.github/workflows/R-CMD-check-wsl.yaml
+++ b/.github/workflows/R-CMD-check-wsl.yaml
@@ -11,6 +11,7 @@ name: Unit tests - WSL Backend
   pull_request:
     branches:
       - master
+      - v1.0
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/R-CMD-check.yaml
+++ b/.github/workflows/R-CMD-check.yaml
@@ -11,6 +11,7 @@ name: Unit tests
   pull_request:
     branches:
       - master
+      - v1.0
   workflow_dispatch:
     inputs:
       tarball_url:

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: cmdstanr
 Title: R Interface to 'CmdStan'
-Version: 0.9.0.9002
+Version: 0.9.0.9003
 Date: 2025-03-30
 Authors@R:
     c(person(given = "Jonah", family = "Gabry", role = c("aut", "cre"),

--- a/NEWS.md
+++ b/NEWS.md
@@ -25,8 +25,8 @@ names. An unnamed entry gets an error naming the route for what was written:
 `list(NAME = value)` for a plain assignment, `cmdstan_make_local()` for `+=` and
 the other makefile operators. Previously unnamed entries reached `make` but were
 invisible to everything that keys on names. (#1250)
-* `cpp_options = list(stan_threads = FALSE)` now disables threading. A logical
-`FALSE` reaches `make` as `STAN_THREADS=`, which also overrides `make/local`.
+* `cpp_options = list(stan_threads = FALSE)` now disables threading, and a
+`FALSE` for any option turns it off even when `make/local` turns it on.
 Previously `FALSE` was passed as a value and enabled the option. (#1251)
 * `$cpp_options()` now reports names in their Make spelling, so
 `list(stan_threads = TRUE)` comes back as `STAN_THREADS`. (#1258)

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,50 @@
 # cmdstanr (development version)
 
+* `include_paths` is now the only way to give `stanc` include paths. An
+`include-paths` entry in `stanc_options`, a `STANCFLAGS` entry in `cpp_options`
+and an include path in `make/local`'s `STANCFLAGS` are all errors that point at
+the argument. (#1258)
+* `user_header` is now the only way to supply a user header. A `USER_HEADER` or
+`user_header` entry in `cpp_options` is an error that points at the argument.
+The header no longer appears in `$cpp_options()`; the new `$user_header()`
+method returns its path. (#1258)
+* `stanc_options` now rejects the flags cmdstanr sets from its own arguments:
+`include-paths` (`include_paths`), `warn-pedantic` (`pedantic`),
+`allow-undefined` (`user_header`), `use-opencl`
+(`cpp_options = list(stan_opencl = TRUE)`) and `name`, which comes from the name
+of the Stan file. Every spelling is caught, named or unnamed, with or without a
+value. `$check_syntax()` checks its own `stanc_options` the same way; it
+previously did not check them at all. (#1258)
+* `$check_syntax()`, `$format()` and `$variables()` now always pass
+`--allow-undefined` to `stanc`. They read a program and link nothing, so whether
+an external function has a definition is a question for `$compile()`. Previously
+a model with an external function and no header could not be checked or
+formatted without passing the flag by hand. (#1258)
+* Every `cpp_options` entry must now be named, and names must be Make variable
+names. An unnamed entry gets an error naming the route for what was written:
+`list(NAME = value)` for a plain assignment, `cmdstan_make_local()` for `+=` and
+the other makefile operators. Previously unnamed entries reached `make` but were
+invisible to everything that keys on names. (#1250)
+* `cpp_options = list(stan_threads = FALSE)` now disables threading. A logical
+`FALSE` reaches `make` as `STAN_THREADS=`, which also overrides `make/local`.
+Previously `FALSE` was passed as a value and enabled the option. (#1251)
+* `$cpp_options()` now reports names in their Make spelling, so
+`list(stan_threads = TRUE)` comes back as `STAN_THREADS`. (#1258)
+* When a `$compile()` call sets a `stanc` flag that `make/local`'s `STANCFLAGS`
+also sets, the call's flag wins. The flag from `make/local` is dropped before
+`stanc` runs, together with any value written after it as a separate word.
+Previously both reached `stanc`. (#1258)
+* `make/local`'s `STANCFLAGS` are now read the way the shell splits them, so a
+quoted value with a space, such as `--filename-in-msg='/my dir/model.stan'`,
+reaches `stanc` as one argument. Previously the direct `stanc` calls in
+`$compile()` received it as two and stanc refused the second. (#1232)
+* Include paths passed to `make` are now shell-quoted, so a quote or a dollar
+sign in a path no longer breaks the build. (#1230)
+* `cmdstan_model(exe_file = )` with no `stan_file` now rejects `cpp_options`,
+`stanc_options`, `include_paths`, `user_header`, `force_recompile` and
+`pedantic`. With no Stan file there is nothing to build, so the executable is
+used as it is. The `cmdstanr_force_recompile` option has no effect on such a
+model. (#1258)
 * Chain IDs in generated filenames are now zero-padded to at least two digits, 
 for example `01` instead of `1`. (#1244)
 * When using CmdStan through WSL, paths for output, diagnostic, profile, config, 
@@ -24,10 +69,6 @@ as of CmdStanR 1.0.0; use the lowercase `cmdstanr_no_ver_check` forms instead.
 * `$compile()` now works with named `stanc_options` values such as
 `canonicalize`. The values were shell-quoted for Make and the same quoted
 strings were also passed to `stanc` directly, which rejected them. (#1227)
-* `$compile()` now enables `allow-undefined` for user headers supplied through
-`cpp_options`, not just through the `user_header` argument. `$check_syntax()`
-and `$format()` also now correctly enable `allow-undefined` for models that use
-a user header. (#1227, #1234)
 * `stanc` failures during `$compile()` are now reported immediately, with the
 `stanc` error message. Previously they surfaced several steps later. (#1227)
 * Errors for include paths that do not exist now report the resolved absolute
@@ -54,9 +95,6 @@ immediately. (#1234)
 header. Previously a header, once supplied, could not be removed. (#1235)
 * `$compile()` now recompiles when the user header changes. Previously a
 different header was ignored if the executable was otherwise up to date. (#1235)
-* `$compile()` now reduces duplicate `USER_HEADER`/`user_header` entries in
-`cpp_options` to the one actually used, so `$cpp_options()` no longer reports
-the ignored spelling after a successful compilation. (#1235)
 * A `$compile()` call that finds the executable up to date no longer erases
 `$cpp_options()`. (#1235)
 * `$expose_functions()` now works after a `$compile()` call that found the
@@ -105,14 +143,6 @@ its place. (#1235)
 * `$compile()` now checks that it can record the compiled model before replacing
 the executable, so a failure at that point can no longer leave a new executable
 on disk that the model object knows nothing about. (#1235)
-* A duplicated `USER_HEADER` or `user_header` entry in `cpp_options` now selects
-the last one, matching what `Make` does with repeated assignments. Previously
-the first was compiled with and the rest were left in `cpp_options`. (#1235)
-* A `USER_HEADER` or `user_header` entry in `cpp_options` set to `NULL` now
-clears a previously configured user header instead of being ignored. It stands
-for an explicit `USER_HEADER=`, which `Make` takes as clearing anything set
-before it, so the model previously compiled with no header while continuing to
-report the old one. (#1235)
 * A `$compile()` that fails because the user header does not exist now still
 records the header. Previously the request was discarded, so `$check_syntax()`
 and `$format()` reported the model's own undefined functions as errors and a

--- a/NEWS.md
+++ b/NEWS.md
@@ -38,8 +38,10 @@ Previously both reached `stanc`. (#1258)
 quoted value with a space, such as `--filename-in-msg='/my dir/model.stan'`,
 reaches `stanc` as one argument. Previously the direct `stanc` calls in
 `$compile()` received it as two and stanc refused the second. (#1232)
-* Include paths passed to `make` are now shell-quoted, so a quote or a dollar
-sign in a path no longer breaks the build. (#1230)
+* Include paths handed to `make` are now quoted for Make and the shell, so a
+quote or a dollar sign in a path no longer splits or expands inside the
+`STANCFLAGS` value. On WSL a dollar sign is still lost before `make` runs.
+(#1230)
 * `cmdstan_model(exe_file = )` with no `stan_file` now rejects `cpp_options`,
 `stanc_options`, `include_paths`, `user_header`, `force_recompile` and
 `pedantic`. With no Stan file there is nothing to build, so the executable is

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -248,9 +248,9 @@ unnamed_cpp_option_message <- function(value) {
       paste0(
         "Make flags cannot be passed through `cpp_options`. ",
         "To read another makefile add `include %s` to `make/local`, for example ",
-        "`cmdstan_make_local(cpp_options = list(\"include %s\"))`."
+        "`cmdstan_make_local(cpp_options = list(%s))`."
       ),
-      path, path
+      path, encodeString(paste0("include ", path), quote = '"')
     ))
   }
   if (startsWith(entry, "-")) {

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -73,12 +73,12 @@ model_compile_info <- function(exe_file, version) {
   info
 }
 
-# Merge build options reported by the executable. Ignore STAN_VERSION and false
-# flags (passing FLAG=FALSE back to CmdStan can enable the flag).
+# Merge build options reported by the executable. Skip STAN_VERSION and the
+# flags reported off, so only the options the build turned on are recorded.
 merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
   for (option_name in names(exe_info)) {
     value <- exe_info[[option_name]]
-    if (tolower(option_name) != "stan_version" &&
+    if (option_name != "STAN_VERSION" &&
         (!is.logical(value) || isTRUE(value))) {
       cpp_options[[option_name]] <- value
     }
@@ -86,36 +86,27 @@ merge_exe_info_cpp_options <- function(cpp_options, exe_info) {
   cpp_options
 }
 
-# Normalize the flags sent to make. Assignment names are case-insensitive and
-# the last value wins. Nonassignments keep their order. Headers are handled
-# separately.
+# Normalize the flags sent to make. The last value for a name wins. Go through
+# the emitted flags rather than the list because a vector value expands into one
+# assignment per element.
 parsed_cpp_options <- function(cpp_options) {
   assignments <- list()
-  opaque <- character()
   for (flag in cpp_options_to_compile_flags(cpp_options)) {
-    if (!grepl("^[A-Za-z_][A-Za-z0-9_]*=", flag)) {
-      opaque <- c(opaque, flag)
-      next
-    }
-    option_name <- tolower(sub("=.*$", "", flag))
-    if (option_name %in% c("user_header", "stan_version")) {
-      next
-    }
+    option_name <- sub("=.*$", "", flag)
     assignments[[option_name]] <- sub("^[^=]*=", "", flag)
   }
-  list(assignments = assignments, opaque = opaque)
+  assignments
 }
 
 normalized_cpp_options <- function(cpp_options) {
-  parsed <- parsed_cpp_options(cpp_options)
-  reduced <- character()
-  if (length(parsed$assignments) > 0) {
-    reduced <- paste0(
-      names(parsed$assignments), "=",
-      unlist(parsed$assignments, use.names = FALSE)
-    )
+  assignments <- parsed_cpp_options(cpp_options)
+  if (length(assignments) == 0) {
+    return(character())
   }
-  c(sort(reduced), parsed$opaque)
+  sort(paste0(
+    names(assignments), "=",
+    unlist(assignments, use.names = FALSE)
+  ))
 }
 
 # Omitted recorded options count as changes because cpp_options are one-shot.
@@ -127,63 +118,37 @@ cpp_options_disagree <- function(requested, recorded) {
 }
 
 # convert to compile flags --------------------
-# from list(flag1=TRUE, flag2=FALSE) to "FLAG1=TRUE\nFLAG2=FALSE"
+# from list(FLAG1 = TRUE, FLAG2 = FALSE) to c("FLAG1=TRUE", "FLAG2=")
 cpp_options_to_compile_flags <- function(cpp_options) {
   if (length(cpp_options) == 0) {
     return(NULL)
   }
   cpp_built_options <- c()
   for (i in seq_along(cpp_options)) {
-    option_name <- names(cpp_options)[i]
-    if (is.null(option_name) || !nzchar(option_name)) {
-      cpp_built_options <- c(cpp_built_options, cpp_options[[i]])
-    } else {
-      cpp_built_options <- c(cpp_built_options, paste0(toupper(option_name), "=", cpp_options[[i]]))
+    value <- cpp_options[[i]]
+    # FALSE asks for the option off, which make spells as an empty assignment.
+    if (is.logical(value)) {
+      value <- as.character(value)
+      value[value %in% "FALSE"] <- ""
     }
+    cpp_built_options <- c(
+      cpp_built_options,
+      paste0(names(cpp_options)[i], "=", value)
+    )
   }
   cpp_built_options
 }
 
 
 # check options overall for validity ---------------------------------
-# takes list of options as input and returns list of options
-# returns list with names standardized to lowercase
-validate_cpp_options <- function(cpp_options) {
-  if (is.null(cpp_options) || length(cpp_options) == 0) return(list())
-
-  if (
-    !is.null(cpp_options[["user_header"]]) &&
-      !is.null(cpp_options[["USER_HEADER"]])
-  ) {
-    warning(
-      "User header specified both via cpp_options[[\"USER_HEADER\"]] ",
-      "and cpp_options[[\"user_header\"]]. Please only specify your user header in one location",
-      call. = FALSE
-    )
-  }
-
-  names(cpp_options) <- tolower(names(cpp_options))
-  flags_set_if_defined <- c(
-    # cmdstan
-    "stan_threads", "stan_mpi", "stan_opencl",
-    "stan_no_range_checks", "stan_cpp_optims",
-    # stan math
-    "integrated_opencl", "tbb_lib", "tbb_inc", "tbb_interface_new"
-  )
-  for (flag in flags_set_if_defined)   {
-    if (isFALSE(cpp_options[[flag]])) warning(
-      toupper(flag), " set to ", cpp_options[flag],
-      " Since this is a non-empty value, ",
-      "it will result in the corresponding ccp option being turned ON. To turn this",
-      " option off, use cpp_options = list(", flag, " = NULL)."
-    )
-  }
-  cpp_options
-}
+make_variable_name_pattern <- "[A-Za-z_][A-Za-z0-9_]*"
 
 #' Check the `cpp_options` a caller supplied and return them
 #'
-#' The user header has its own argument, so a header here is an error.
+#' Every entry must be named and every name must be a Make variable name. The
+#' names are uppercased here so that one spelling reaches everything downstream.
+#' The user header and the stanc flags have their own arguments, so setting them
+#' here is an error.
 #'
 #' @noRd
 assert_valid_cpp_options <- function(cpp_options) {
@@ -191,20 +156,113 @@ assert_valid_cpp_options <- function(cpp_options) {
     return(list())
   }
   checkmate::assert_list(cpp_options, .var.name = "cpp_options")
-  header_at <- which(toupper(names(cpp_options)) == "USER_HEADER")
-  if (length(header_at) > 0) {
-    value <- cpp_options[[header_at[[1]]]]
-    example <- ""
-    if (checkmate::test_string(value)) {
-      example <- paste0(": `user_header = \"", value, "\"`")
+  option_names <- names(cpp_options)
+  for (i in seq_along(cpp_options)) {
+    if (is.null(option_names) || !nzchar(option_names[[i]])) {
+      stop(unnamed_cpp_option_message(cpp_options[[i]]), call. = FALSE)
     }
+    if (!grepl(paste0("^", make_variable_name_pattern, "$"), option_names[[i]])) {
+      stop(
+        "`cpp_options` names must be Make variable names, made of letters, ",
+        "digits and underscores and not starting with a digit. `",
+        option_names[[i]], "` is not one.",
+        call. = FALSE
+      )
+    }
+  }
+  if (!is.null(option_names)) {
+    names(cpp_options) <- toupper(option_names)
+  }
+  header_at <- which(names(cpp_options) == "USER_HEADER")
+  if (length(header_at) > 0) {
     stop(
-      "The user header cannot be set through `cpp_options`. ",
-      "Pass it with the `user_header` argument", example, ".",
+      user_header_cpp_option_message(cpp_options[[header_at[[1]]]]),
       call. = FALSE
     )
   }
+  if ("STANCFLAGS" %in% names(cpp_options)) {
+    stop(stancflags_cpp_option_message(), call. = FALSE)
+  }
   cpp_options
+}
+
+#' Explain why an unnamed `cpp_options` entry cannot be used
+#'
+#' Callers reach for makefile syntax here, so name the route that accepts the
+#' entry they wrote rather than repeating the rule.
+#'
+#' @noRd
+unnamed_cpp_option_message <- function(value) {
+  entry <- if (checkmate::test_string(value)) trimws(value) else ""
+  assignment <- paste0("^(", make_variable_name_pattern, ")[ \t]*=(.*)$")
+  operator <- paste0(
+    "^(", make_variable_name_pattern, ")[ \t]*(\\+=|\\?=|::=|:=|!=).*$"
+  )
+  is_assignment <- grepl(assignment, entry)
+  is_operator <- !is_assignment && grepl(operator, entry)
+  option_name <- ""
+  if (is_assignment) {
+    option_name <- toupper(sub(assignment, "\\1", entry))
+  } else if (is_operator) {
+    option_name <- toupper(sub(operator, "\\1", entry))
+  }
+  if (option_name == "USER_HEADER") {
+    header <- if (is_assignment) trimws(sub(assignment, "\\2", entry)) else NULL
+    return(user_header_cpp_option_message(header))
+  }
+  if (option_name == "STANCFLAGS") {
+    return(stancflags_cpp_option_message())
+  }
+  if (is_assignment) {
+    return(sprintf(
+      paste0(
+        "`cpp_options` entries must be named. ",
+        "Write `list(%s = \"%s\")` instead of `\"%s\"`."
+      ),
+      option_name, trimws(sub(assignment, "\\2", entry)), entry
+    ))
+  }
+  if (is_operator) {
+    return(sprintf(
+      paste0(
+        "`\"%s\"` is makefile syntax and cannot be passed through `cpp_options`. ",
+        "To set it in `make/local` use `cmdstan_make_local(cpp_options = list(\"%s\"))`."
+      ),
+      entry, entry
+    ))
+  }
+  if (startsWith(entry, "-")) {
+    return(paste0(
+      "Make flags cannot be passed through `cpp_options`. ",
+      "Set them in `make/local` with `cmdstan_make_local()`, ",
+      "for example `MAKEFLAGS += -j4`."
+    ))
+  }
+  "`cpp_options` entries must be named: `list(NAME = value)`."
+}
+
+#' The error for a user header supplied through `cpp_options`
+#'
+#' @noRd
+user_header_cpp_option_message <- function(value) {
+  example <- ""
+  if (checkmate::test_string(value)) {
+    example <- paste0(": `user_header = \"", value, "\"`")
+  }
+  paste0(
+    "The user header cannot be set through `cpp_options`. ",
+    "Pass it with the `user_header` argument", example, "."
+  )
+}
+
+#' The error for STANCFLAGS supplied through `cpp_options`
+#'
+#' @noRd
+stancflags_cpp_option_message <- function() {
+  paste0(
+    "`STANCFLAGS` cannot be set through `cpp_options`. ",
+    "Pass stanc flags with the `stanc_options` argument."
+  )
 }
 
 # check specific options for validity ---------------------------------
@@ -259,16 +317,15 @@ assert_valid_threads <- function(threads, cpp_options, multiple_chains = FALSE) 
 }
 
 # For two functions below
-# both styles are lists which should have flag names in lower case as names of the list
 # cpp_options style means is NULL or empty string
 # exe_info style means off is FALSE
 
 exe_info_style_cpp_options <- function(cpp_options) {
   if (is.null(cpp_options)) cpp_options <- list()
-  names(cpp_options) <- tolower(names(cpp_options))
+  names(cpp_options) <- toupper(names(cpp_options))
   flags_reported_in_exe_info <- c(
-    "stan_threads", "stan_mpi", "stan_opencl",
-    "stan_no_range_checks", "stan_cpp_optims"
+    "STAN_THREADS", "STAN_MPI", "STAN_OPENCL",
+    "STAN_NO_RANGE_CHECKS", "STAN_CPP_OPTIMS"
   )
   for (flag in flags_reported_in_exe_info) {
     cpp_options[[flag]] <- !(
@@ -286,9 +343,9 @@ exe_info_reflects_cpp_options <- function(exe_info, cpp_options) {
   if (is.null(cpp_options)) return(TRUE)
 
   # Compare only options reported by the executable. Other options are unknown.
-  # Parse the emitted flags so duplicates and unnamed assignments match make.
-  assignments <- parsed_cpp_options(cpp_options)$assignments
-  reported <- intersect(names(assignments), tolower(names(exe_info)))
+  # Parse the emitted flags so duplicates and vector values match make.
+  assignments <- parsed_cpp_options(cpp_options)
+  reported <- intersect(names(assignments), names(exe_info))
 
   for (option_name in reported) {
     # CmdStan treats any nonempty make value as enabled.

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -214,21 +214,43 @@ unnamed_cpp_option_message <- function(value) {
     return(stancflags_cpp_option_message())
   }
   if (is_assignment) {
+    value <- trimws(sub(assignment, "\\2", entry))
     return(sprintf(
       paste0(
         "`cpp_options` entries must be named. ",
-        "Write `list(%s = \"%s\")` instead of `\"%s\"`."
+        "Write `list(%s = %s)` instead of `%s`."
       ),
-      option_name, trimws(sub(assignment, "\\2", entry)), entry
+      option_name, encodeString(value, quote = '"'), encodeString(entry, quote = '"')
     ))
   }
   if (is_operator) {
     return(sprintf(
       paste0(
-        "`\"%s\"` is makefile syntax and cannot be passed through `cpp_options`. ",
-        "To set it in `make/local` use `cmdstan_make_local(cpp_options = list(\"%s\"))`."
+        "`%s` is makefile syntax and cannot be passed through `cpp_options`. ",
+        "To set it in `make/local` use `cmdstan_make_local(cpp_options = list(%s))`."
       ),
-      entry, entry
+      encodeString(entry, quote = '"'), encodeString(entry, quote = '"')
+    ))
+  }
+  if (grepl("^(-B|--always-make)$", entry)) {
+    return(sprintf(
+      paste0(
+        "Make flags cannot be passed through `cpp_options`. ",
+        "`%s` rebuilds everything; pass `force_recompile = TRUE` instead."
+      ),
+      entry
+    ))
+  }
+  makefile_flag_pattern <- "^(?:-f[ \t]*|--(?:file|makefile)=)(.+)$"
+  if (grepl(makefile_flag_pattern, entry)) {
+    path <- sub(makefile_flag_pattern, "\\1", entry)
+    return(sprintf(
+      paste0(
+        "Make flags cannot be passed through `cpp_options`. ",
+        "To read another makefile add `include %s` to `make/local`, for example ",
+        "`cmdstan_make_local(cpp_options = list(\"include %s\"))`."
+      ),
+      path, path
     ))
   }
   if (startsWith(entry, "-")) {
@@ -245,9 +267,13 @@ unnamed_cpp_option_message <- function(value) {
 #'
 #' @noRd
 user_header_cpp_option_message <- function(value) {
-  example <- ""
-  if (checkmate::test_string(value)) {
-    example <- paste0(": `user_header = \"", value, "\"`")
+  is_empty_string <- checkmate::test_string(value) && !nzchar(trimws(value))
+  if (is.null(value) || isFALSE(value) || is_empty_string) {
+    example <- ": `user_header = NULL`"
+  } else if (checkmate::test_string(value)) {
+    example <- paste0(": `user_header = ", encodeString(value, quote = '"'), "`")
+  } else {
+    example <- ""
   }
   paste0(
     "The user header cannot be set through `cpp_options`. ",

--- a/R/cpp_opts.R
+++ b/R/cpp_opts.R
@@ -181,76 +181,30 @@ validate_cpp_options <- function(cpp_options) {
   cpp_options
 }
 
-# user headers ---------------------------------------------------------
-# Resolve one header and remove both header spellings from cpp_options.
-# Precedence is explicit user_header (including NULL), USER_HEADER,
-# user_header, then previous. `supplied` distinguishes NULL from omission.
-# `cpp_options_supplied` limits conflict warnings to this call.
-resolve_user_header <- function(user_header,
-                                supplied,
-                                cpp_options,
-                                cpp_options_supplied = TRUE,
-                                previous = NULL) {
-  # Use positions so duplicate options follow make's last-value-wins behavior.
-  upper_at <- which(names(cpp_options) == "USER_HEADER")
-  lower_at <- which(names(cpp_options) == "user_header")
-  last_of <- function(positions) {
-    if (length(positions) == 0) {
-      NULL
-    } else {
-      cpp_options[[positions[[length(positions)]]]]
-    }
+#' Check the `cpp_options` a caller supplied and return them
+#'
+#' The user header has its own argument, so a header here is an error.
+#'
+#' @noRd
+assert_valid_cpp_options <- function(cpp_options) {
+  if (is.null(cpp_options)) {
+    return(list())
   }
-  # NULL is still present here because it emits an empty USER_HEADER= assignment.
-  has_upper <- length(upper_at) > 0
-  has_lower <- length(lower_at) > 0
-  from_upper <- last_of(upper_at)
-  from_lower <- last_of(lower_at)
-  conflict <- NULL
-  spelling <- "USER_HEADER"
-
-  if (supplied) {
-    if (cpp_options_supplied && (has_upper || has_lower)) {
-      conflict <- "argument"
-    }
-    header <- user_header
-  } else if (has_upper) {
-    if (has_lower) {
-      conflict <- "cpp_options"
-    }
-    header <- from_upper
-  } else if (has_lower) {
-    header <- from_lower
-    spelling <- "user_header"
-  } else {
-    header <- previous
-  }
-
-  # Validate the value now and check file existence when compiling.
-  if (!is.null(header)) {
-    checkmate::assert_string(header, .var.name = "user_header")
-  }
-  # Guarded because x[-integer(0)] is empty.
-  header_at <- c(upper_at, lower_at)
+  checkmate::assert_list(cpp_options, .var.name = "cpp_options")
+  header_at <- which(toupper(names(cpp_options)) == "USER_HEADER")
   if (length(header_at) > 0) {
-    cpp_options <- cpp_options[-header_at]
+    value <- cpp_options[[header_at[[1]]]]
+    example <- ""
+    if (checkmate::test_string(value)) {
+      example <- paste0(": `user_header = \"", value, "\"`")
+    }
+    stop(
+      "The user header cannot be set through `cpp_options`. ",
+      "Pass it with the `user_header` argument", example, ".",
+      call. = FALSE
+    )
   }
-
-  list(
-    user_header = header,
-    spelling = spelling,
-    cpp_options = cpp_options,
-    conflict = conflict
-  )
-}
-
-warn_user_header_conflict <- function(conflict) {
-  if (identical(conflict, "argument")) {
-    warning("User header specified both via user_header argument and via cpp_options arguments")
-  } else if (identical(conflict, "cpp_options")) {
-    warning('User header specified both via cpp_options[["USER_HEADER"]] and cpp_options[["user_header"]].', call. = FALSE)
-  }
-  invisible(NULL)
+  cpp_options
 }
 
 # check specific options for validity ---------------------------------

--- a/R/model.R
+++ b/R/model.R
@@ -827,9 +827,17 @@ compile <- function(quiet = TRUE,
   stancflags_combined <- stanc_options_to_args(stanc_options, quote_values = TRUE)
   stancflags_direct <- stanc_options_to_args(stanc_options)
   cpp_flags <- cpp_options_to_compile_flags(cpp_options)
+
+  # CmdStan reads the header from the USER_HEADER make variable.
+  user_header_flag <- NULL
+  if (using_user_header) {
+    user_header_flag <- paste0("USER_HEADER=", wsl_safe_path(user_header))
+  }
+
+  make_vars <- c(cpp_flags, user_header_flag)
   # CmdStan's makefiles add stanc flags such as --use-opencl when a variable is
-  # set, so the query has to see this build's variables.
-  stancflags_local <- get_cmdstan_flags("STANCFLAGS", cpp_flags)
+  # set, so the query has to see every variable this build passes to make.
+  stancflags_local <- get_cmdstan_flags("STANCFLAGS", make_vars)
   is_include_path <- grepl("--include-paths", stancflags_local, fixed = TRUE) |
     startsWith(stancflags_local, "-I")
   if (any(is_include_path)) {
@@ -858,12 +866,6 @@ compile <- function(quiet = TRUE,
 
   stancflags_val <- paste0("STANCFLAGS += ", stancflags_val, paste0(" ", stancflags_combined, collapse = " "))
 
-  # CmdStan reads the header from the USER_HEADER make variable.
-  user_header_flag <- NULL
-  if (using_user_header) {
-    user_header_flag <- paste0("USER_HEADER=", wsl_safe_path(user_header))
-  }
-
   if (!dry_run) {
 
     withr::with_envvar(
@@ -876,8 +878,7 @@ compile <- function(quiet = TRUE,
         run_log <- wsl_compatible_run(
           command = make_cmd(),
           args = c(wsl_safe_path(repair_path(tmp_exe)),
-                  cpp_flags,
-                  user_header_flag,
+                  make_vars,
                   stancflags_val),
           wd = cmdstan_path(),
           echo = !quiet || is_verbose_mode(),

--- a/R/model.R
+++ b/R/model.R
@@ -838,7 +838,9 @@ compile <- function(quiet = TRUE,
   stancflags_direct <- stanc_options_to_args(stanc_options)
   stancflags_local <- get_cmdstan_flags("STANCFLAGS")
   if (length(stancflags_local) > 0) {
-    stancflags_combined <- c(stancflags_combined, stancflags_local)
+    # get_cmdstan_flags() split the local flags into words. Requote them for
+    # the STANCFLAGS value handed back to make.
+    stancflags_combined <- c(stancflags_combined, make_shell_quote(stancflags_local))
     stancflags_direct <- c(stancflags_direct, stancflags_local)
   }
   stanc_inc_paths <- include_paths_stanc3_args(include_paths, direct_call = TRUE)
@@ -2620,10 +2622,11 @@ stanc_options_to_args <- function(stanc_options, quote_values = FALSE) {
 
 #' Build stanc include-path arguments
 #'
-#' Make receives include paths through `STANCFLAGS` and needs paths containing
-#' spaces to be shell-quoted within a single `--include-paths=` flag. Direct
-#' calls through processx instead need the flag and comma-separated paths as
-#' separate, unquoted arguments.
+#' Make receives include paths through `STANCFLAGS`, expands the value and hands
+#' it to the shell, so `make_shell_quote()` quotes each path for both (#1230)
+#' inside a single `--include-paths=` flag. Direct calls through processx
+#' instead need the flag and comma-separated paths as separate, unquoted
+#' arguments.
 #'
 #' @param include_paths A character vector of directories containing files used
 #'   in Stan `#include` directives, or `NULL`.
@@ -2640,8 +2643,7 @@ include_paths_stanc3_args <- function(include_paths = NULL, direct_call = FALSE)
     include_paths <- sapply(absolute_path(include_paths), wsl_safe_path)
     # Calling stanc3 directly through processx::run does not need quoting
     if (!isTRUE(direct_call)) {
-      paths_w_space <- grep(" ", include_paths)
-      include_paths[paths_w_space] <- paste0("'", include_paths[paths_w_space], "'")
+      include_paths <- make_shell_quote(include_paths)
     }
     include_paths <- paste0(include_paths, collapse = ",")
     include_paths_flag <- "--include-paths="

--- a/R/model.R
+++ b/R/model.R
@@ -244,7 +244,6 @@ CmdStanModel <- R6::R6Class(
     stanc_options_ = list(),
     include_paths_ = NULL,
     user_header_ = NULL,
-    using_user_header_ = FALSE,
     # Build inputs that have changed since the current executable was produced.
     user_header_dirty_ = FALSE,
     include_paths_dirty_ = FALSE,
@@ -280,7 +279,6 @@ CmdStanModel <- R6::R6Class(
         # detection. Keep only the host path here. Persisting the WSL path would
         # break reuse on WSL1.
         private$user_header_ <- resolve_path(args$user_header)
-        private$using_user_header_ <- !is.null(args$user_header)
         if (is.null(args$include_paths) && any(grepl("#include" , private$stan_code_))) {
           private$precompile_include_paths_ <- dirname(private$stan_file_)
         } else {
@@ -522,7 +520,11 @@ NULL
 #'   when compiling the model. See the **Examples** section below as well as the
 #'   [`stanc` chapter of the CmdStan User's
 #'   Guide](https://mc-stan.org/docs/cmdstan-guide/stanc.html) for more details
-#'   on available options.
+#'   on available options. Options that cmdstanr sets from its own arguments
+#'   cannot be passed here: `include-paths` (use `include_paths`),
+#'   `warn-pedantic` (`pedantic`), `allow-undefined` (`user_header`),
+#'   `use-opencl` (`cpp_options = list(stan_opencl = TRUE)`) and `name` (taken
+#'   from the name of the Stan file).
 #' @param force_recompile (logical) Should the model be recompiled even if it
 #'   has not been modified since it was last compiled? The default is `FALSE`.
 #'   Can also be set via a global `cmdstanr_force_recompile` option.
@@ -689,7 +691,6 @@ compile <- function(quiet = TRUE,
   private$user_header_dirty_ <- isTRUE(private$user_header_dirty_) ||
     !same_path(user_header, private$user_header_)
   private$user_header_ <- user_header
-  private$using_user_header_ <- using_user_header
 
   if (using_user_header && !file.exists(user_header)) {
     stop(paste0("User header file '", user_header, "' does not exist."), call. = FALSE)
@@ -818,9 +819,7 @@ compile <- function(quiet = TRUE,
 
   stancflags_val <- include_paths_stanc3_args(include_paths)
 
-  if (is.null(stanc_options[["name"]])) {
-    stanc_options[["name"]] <- paste0(self$model_name(), "_model")
-  }
+  stanc_options[["name"]] <- paste0(self$model_name(), "_model")
   stancflags_combined <- stanc_options_to_args(stanc_options, quote_values = TRUE)
   stancflags_direct <- stanc_options_to_args(stanc_options)
   stancflags_local <- get_cmdstan_flags("STANCFLAGS")
@@ -1037,8 +1036,7 @@ variables <- function() {
   if (is.null(private$variables_) && file.exists(self$stan_file())) {
     private$variables_ <- model_variables(
       stan_file = self$stan_file(),
-      include_paths = self$include_paths(),
-      allow_undefined = private$using_user_header_
+      include_paths = self$include_paths()
     )
   }
   private$variables_
@@ -1109,15 +1107,15 @@ check_syntax <- function(pedantic = FALSE,
     stop("'$check_syntax()' cannot be used because the 'CmdStanModel' was not created with a Stan file.", call. = FALSE)
   }
   assert_stan_file_exists(self$stan_file())
-  if (length(stanc_options) == 0 && !is.null(private$precompile_stanc_options_)) {
+  if (length(stanc_options) > 0) {
+    stanc_options <- assert_valid_stanc_options(stanc_options)
+  } else if (!is.null(private$precompile_stanc_options_)) {
     stanc_options <- private$precompile_stanc_options_
   }
   if (is.null(include_paths) && !is.null(self$include_paths())) {
     include_paths <- self$include_paths()
   }
-  if (private$using_user_header_) {
-    stanc_options[["allow-undefined"]] <- TRUE
-  }
+  stanc_options[["allow-undefined"]] <- TRUE
 
   temp_hpp_file <- tempfile(pattern = "model-", fileext = ".hpp")
   stanc_options[["o"]] <- wsl_safe_path(temp_hpp_file)
@@ -1131,9 +1129,7 @@ check_syntax <- function(pedantic = FALSE,
     direct_call = TRUE
   )
 
-  if (is.null(stanc_options[["name"]])) {
-    stanc_options[["name"]] <- paste0(self$model_name(), "_model")
-  }
+  stanc_options[["name"]] <- paste0(self$model_name(), "_model")
   stanc_built_options <- stanc_options_to_args(stanc_options)
 
   withr::with_path(
@@ -1249,9 +1245,7 @@ format <- function(overwrite_file = FALSE,
     self$include_paths(),
     direct_call = TRUE
   )
-  if (private$using_user_header_) {
-    stanc_options[["allow-undefined"]] <- TRUE
-  }
+  stanc_options[["allow-undefined"]] <- TRUE
   stanc_options[["auto-format"]] <- TRUE
   if (!is.null(max_line_length)) {
     stanc_options[["max-line-length"]] <- max_line_length
@@ -2555,11 +2549,49 @@ CmdStanModel$set("public", name = "cmdstan_defaults", value = cmdstan_defaults)
 
 
 # internal ----------------------------------------------------------------
+#' The error for a stanc flag cmdstanr sets from one of its own arguments
+#'
+#' Returns `NULL` for any other flag. The five names live here so that the
+#' matcher and the messages cannot drift apart.
+#'
+#' @noRd
+derived_stanc_option_message <- function(flag) {
+  messages <- c(
+    "include-paths" = paste0(
+      "`include-paths` cannot be set through `stanc_options`. ",
+      "Pass the directories with the `include_paths` argument."
+    ),
+    "warn-pedantic" = paste0(
+      "`warn-pedantic` cannot be set through `stanc_options`. ",
+      "Use `pedantic = TRUE`."
+    ),
+    "allow-undefined" = paste0(
+      "`allow-undefined` cannot be set through `stanc_options`. ",
+      "Builds turn it on when a `user_header` is supplied, and ",
+      "`$check_syntax()`, `$format()` and `$variables()` always use it."
+    ),
+    "use-opencl" = paste0(
+      "`use-opencl` cannot be set through `stanc_options`. ",
+      "Use `cpp_options = list(stan_opencl = TRUE)`, which turns it on."
+    ),
+    "name" = paste0(
+      "`name` cannot be set through `stanc_options`. ",
+      "The model name comes from the name of the Stan file."
+    )
+  )
+  if (flag %in% names(messages)) {
+    messages[[flag]]
+  } else {
+    NULL
+  }
+}
+
 assert_valid_stanc_options <- function(stanc_options) {
   i <- 1
   names <- names(stanc_options)
   for (s in stanc_options) {
-    if (!is.null(names[i]) && nzchar(names[i])) {
+    named <- !is.null(names[i]) && nzchar(names[i])
+    if (named) {
       name <- names[i]
     } else {
       name <- s
@@ -2567,8 +2599,27 @@ assert_valid_stanc_options <- function(stanc_options) {
     if (startsWith(name, "--")) {
       stop("No leading hyphens allowed in stanc options (", name, "). ",
            "Use options without leading hyphens, for example ",
-           "`stanc_options = list('allow-undefined')`",
+           "`stanc_options = list('warn-uninitialized')`",
            call. = FALSE)
+    }
+    # The flag is the part before the first `=`, wherever the name occurs.
+    flag <- sub("=.*$", "", name)
+    derived <- derived_stanc_option_message(flag)
+    if (!is.null(derived)) {
+      stop(derived, call. = FALSE)
+    }
+    if (named && grepl("=", name, fixed = TRUE)) {
+      stop(
+        sprintf(
+          paste0(
+            "`stanc_options` names cannot contain `=`. ",
+            "Write the value after the name: `list(\"%s\" = \"%s\")` ",
+            "instead of `list(\"%s\" = ...)`."
+          ),
+          flag, sub("^[^=]*=", "", name), name
+        ),
+        call. = FALSE
+      )
     }
     i <- i + 1
   }
@@ -2597,7 +2648,7 @@ stanc_options_to_args <- function(stanc_options, quote_values = FALSE) {
     option_name <- names(stanc_options)[i]
     option_value <- stanc_options[[i]]
     if (is.null(option_name) || !nzchar(option_name)) {
-      # Unnamed options are already flag names, e.g. list("allow-undefined")
+      # Unnamed options are already flag names, e.g. list("O1")
       args <- c(args, paste0("--", option_value))
     } else if (is.logical(option_value)) {
       # TRUE emits a bare flag, FALSE leaves the flag out entirely
@@ -2650,12 +2701,7 @@ include_paths_stanc3_args <- function(include_paths = NULL, direct_call = FALSE)
   stancflags
 }
 
-model_variables <- function(stan_file, include_paths = NULL, allow_undefined = FALSE) {
-  if (allow_undefined) {
-    allow_undefined_arg <- "--allow-undefined"
-  } else {
-    allow_undefined_arg <- NULL
-  }
+model_variables <- function(stan_file, include_paths = NULL) {
   out_file <- tempfile(fileext = ".json")
   run_log <- wsl_compatible_run(
     command = stanc_cmd(),
@@ -2665,7 +2711,7 @@ model_variables <- function(stan_file, include_paths = NULL, allow_undefined = F
                 include_paths,
                 direct_call = TRUE
               ),
-              allow_undefined_arg),
+              "--allow-undefined"),
     wd = cmdstan_path(),
     echo = FALSE,
     echo_cmd = FALSE,

--- a/R/model.R
+++ b/R/model.R
@@ -19,7 +19,8 @@
 #'   omitted some `CmdStanModel` methods like `$code()` and `$print()` will not
 #'   work). If `stan_file` is omitted, the executable is used as it is:
 #'   `cpp_options`, `stanc_options`, `include_paths`, `user_header`,
-#'   `force_recompile` and `pedantic` cannot be supplied.
+#'   `force_recompile` and `pedantic` cannot be supplied, and passing `NULL`
+#'   counts as omitting them.
 #' @param compile (logical) Do compilation? The default is `TRUE`. If `FALSE`
 #'   compilation can be done later via the [`$compile()`][model-method-compile]
 #'   method.
@@ -516,8 +517,9 @@ NULL
 #'   Example](https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html).
 #'   Every entry must be named with a `Make` variable name, in any casing, which
 #'   [`$cpp_options()`][model-method-model-info] reports back in upper case.
-#'   Setting an option to `FALSE` or `NULL` passes an empty assignment, which
-#'   disables the option and overrides `make/local`.
+#'   Setting an option to `FALSE` or `NULL` passes an empty assignment such as
+#'   `STAN_THREADS=`. That empties the variable for this build, which turns a
+#'   switch off, and overrides whatever `make/local` sets.
 #' @param stanc_options (list) Any Stan-to-C++ transpiler options to be used
 #'   when compiling the model. See the **Examples** section below as well as the
 #'   [`stanc` chapter of the CmdStan User's

--- a/R/model.R
+++ b/R/model.R
@@ -196,6 +196,7 @@ cmdstan_model <- function(stan_file = NULL, exe_file = NULL, compile = TRUE, ...
 #'  [`$include_paths()`][model-method-model-info] | Return the Stan include paths. |
 #'  [`$cmdstan_version()`][model-method-model-info] | Return the CmdStan version associated with the model. |
 #'  [`$cpp_options()`][model-method-model-info] | Return the C++ options associated with the model. |
+#'  [`$user_header()`][model-method-model-info] | Return the path to the user header, if the model has one. |
 #'
 #'  ## Compilation
 #'
@@ -272,24 +273,14 @@ CmdStanModel <- R6::R6Class(
         private$stan_code_ <- readLines(stan_file)
         private$model_name_ <- gsub(" ", "_", strip_ext(basename(private$stan_file_)))
         private$precompile_stanc_options_ <- assert_valid_stanc_options(args$stanc_options) %||% list()
-        # Resolve headers here so compile = FALSE preserves an explicit NULL.
-        # names(args) distinguishes NULL from an omitted argument.
-        resolved_header <- resolve_user_header(
-          user_header = args$user_header,
-          supplied = "user_header" %in% names(args),
-          cpp_options = args$cpp_options %||% list()
-        )
-        if (!compile) {
-          # compile() reports this conflict when compilation is requested.
-          warn_user_header_conflict(resolved_header$conflict)
-        }
-        # Keep only the host path here. Persisting the WSL path would break reuse
-        # on WSL1.
-        private$precompile_cpp_options_ <- resolved_header$cpp_options
+        private$precompile_cpp_options_ <- assert_valid_cpp_options(args$cpp_options)
+        checkmate::assert_string(args$user_header, null.ok = TRUE,
+                                 .var.name = "user_header")
         # Use the header supplied to cmdstan_model() as the baseline for change
-        # detection.
-        private$user_header_ <- resolve_path(resolved_header$user_header)
-        private$using_user_header_ <- !is.null(resolved_header$user_header)
+        # detection. Keep only the host path here. Persisting the WSL path would
+        # break reuse on WSL1.
+        private$user_header_ <- resolve_path(args$user_header)
+        private$using_user_header_ <- !is.null(args$user_header)
         if (is.null(args$include_paths) && any(grepl("#include" , private$stan_code_))) {
           private$precompile_include_paths_ <- dirname(private$stan_file_)
         } else {
@@ -374,6 +365,9 @@ CmdStanModel <- R6::R6Class(
     cpp_options = function() {
       private$cpp_options_
     },
+    user_header = function() {
+      private$user_header_
+    },
     hpp_file = function() {
       if (!length(private$hpp_file_)) {
         stop("The .hpp file does not exist. Please (re)compile the model.", call. = FALSE)
@@ -417,6 +411,7 @@ CmdStanModel <- R6::R6Class(
 #'   include_paths()
 #'   cmdstan_version()
 #'   cpp_options()
+#'   user_header()
 #'   hpp_file()
 #'   save_hpp_file(dir = NULL)
 #'   ```
@@ -443,6 +438,8 @@ CmdStanModel <- R6::R6Class(
 #' * `$include_paths()` returns a character vector of absolute paths or `NULL`.
 #' * `$cmdstan_version()` returns a CmdStan version as a string.
 #' * `$cpp_options()` returns a named list of C++ options.
+#' * `$user_header()` returns the absolute path to the user header as a string,
+#'   or `NULL` if the model has no user header.
 #' * `$hpp_file()` returns the path to the `.hpp` file as a string when C++ code
 #'   was generated while compiling this model object. It errors if no `.hpp`
 #'   path is available, such as when an up-to-date executable was reused.
@@ -509,8 +506,6 @@ NULL
 #'   to compile with the Stan model. If `$compile()` is called again without
 #'   `user_header`, the most recently supplied header is reused, and changing
 #'   it forces recompilation. Pass `user_header = NULL` to compile without one.
-#'   A header can also be supplied via `cpp_options` as `USER_HEADER` or
-#'   `user_header`; the `user_header` argument takes precedence over both.
 #'   See `force_recompile` for the case of a header supplied for a program
 #'   whose executable is already up to date.
 #' @param cpp_options (list) Any makefile options to be used when compiling the
@@ -632,8 +627,9 @@ compile <- function(quiet = TRUE,
   assert_stan_file_exists(self$stan_file())
   # missing() distinguishes an omitted header from user_header = NULL.
   user_header_supplied <- !missing(user_header)
-  cpp_options_supplied <- length(cpp_options) > 0
-  if (length(cpp_options) == 0 && !is.null(private$precompile_cpp_options_)) {
+  if (length(cpp_options) > 0) {
+    cpp_options <- assert_valid_cpp_options(cpp_options)
+  } else if (!is.null(private$precompile_cpp_options_)) {
     cpp_options <- private$precompile_cpp_options_
   }
   # Precompile options still need mismatch checks even though they were not
@@ -677,16 +673,11 @@ compile <- function(quiet = TRUE,
     stanc_options[["use-opencl"]] <- TRUE
   }
 
-  resolved_header <- resolve_user_header(
-    user_header = user_header,
-    supplied = user_header_supplied,
-    cpp_options = cpp_options,
-    cpp_options_supplied = cpp_options_supplied,
-    previous = private$user_header_
-  )
-  warn_user_header_conflict(resolved_header$conflict)
-  user_header <- resolved_header$user_header
-  cpp_options <- resolved_header$cpp_options
+  if (!user_header_supplied) {
+    user_header <- private$user_header_
+  }
+  checkmate::assert_string(user_header, null.ok = TRUE,
+                           .var.name = "user_header")
 
   using_user_header <- !is.null(user_header)
   if (using_user_header) {
@@ -702,11 +693,8 @@ compile <- function(quiet = TRUE,
   private$user_header_ <- user_header
   private$using_user_header_ <- using_user_header
 
-  if (using_user_header) {
-    if (!file.exists(user_header)) {
-      stop(paste0("User header file '", user_header, "' does not exist."), call. = FALSE)
-    }
-    cpp_options[[resolved_header$spelling]] <- wsl_safe_path(user_header)
+  if (using_user_header && !file.exists(user_header)) {
+    stop(paste0("User header file '", user_header, "' does not exist."), call. = FALSE)
   }
 
   # Do not adopt an executable from a new destination. Its generated C++ and
@@ -851,6 +839,12 @@ compile <- function(quiet = TRUE,
 
   stancflags_val <- paste0("STANCFLAGS += ", stancflags_val, paste0(" ", stancflags_combined, collapse = " "))
 
+  # CmdStan reads the header from the USER_HEADER make variable.
+  user_header_flag <- NULL
+  if (using_user_header) {
+    user_header_flag <- paste0("USER_HEADER=", wsl_safe_path(user_header))
+  }
+
   if (!dry_run) {
 
     withr::with_envvar(
@@ -864,6 +858,7 @@ compile <- function(quiet = TRUE,
           command = make_cmd(),
           args = c(wsl_safe_path(repair_path(tmp_exe)),
                   cpp_options_to_compile_flags(cpp_options),
+                  user_header_flag,
                   stancflags_val),
           wd = cmdstan_path(),
           echo = !quiet || is_verbose_mode(),

--- a/R/model.R
+++ b/R/model.R
@@ -437,7 +437,8 @@ CmdStanModel <- R6::R6Class(
 #'   executable path is set.
 #' * `$include_paths()` returns a character vector of absolute paths or `NULL`.
 #' * `$cmdstan_version()` returns a CmdStan version as a string.
-#' * `$cpp_options()` returns a named list of C++ options.
+#' * `$cpp_options()` returns a named list of C++ options, with names in their
+#'   `make` spelling.
 #' * `$user_header()` returns the absolute path to the user header as a string,
 #'   or `NULL` if the model has no user header.
 #' * `$hpp_file()` returns the path to the `.hpp` file as a string when C++ code
@@ -513,13 +514,10 @@ NULL
 #'   otherwise write in the `make/local` file. For an example of using threading
 #'   see the Stan case study [Reduce Sum: A Minimal
 #'   Example](https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html).
-#'   **Note:** For historical reasons, CmdStan treats some options as enabled
-#'   whenever their `Make` variable is non-empty. In particular, setting
-#'   `stan_threads` to `FALSE` passes `STAN_THREADS=FALSE` to `Make`, which
-#'   still enables threading! To leave threading disabled, either omit
-#'   `stan_threads` entirely, which leaves any setting in `make/local` in
-#'   place, or set it to `NULL`, which passes an empty `STAN_THREADS=` and so
-#'   overrides `make/local` too.
+#'   Every entry must be named with a `Make` variable name, in any casing, which
+#'   [`$cpp_options()`][model-method-model-info] reports back in upper case.
+#'   Setting an option to `FALSE` or `NULL` passes an empty assignment, which
+#'   disables the option and overrides `make/local`.
 #' @param stanc_options (list) Any Stan-to-C++ transpiler options to be used
 #'   when compiling the model. See the **Examples** section below as well as the
 #'   [`stanc` chapter of the CmdStan User's
@@ -754,9 +752,10 @@ compile <- function(quiet = TRUE,
         # from make/local, so a rebuild would inherit them again.
         built_options <- private$built_cpp_options_
         inherited <- merge_exe_info_cpp_options(list(), exe_info)
-        # Parse make flags so unnamed assignments also count as explicit.
-        explicit <- names(parsed_cpp_options(built_options)$assignments)
-        inherited <- inherited[!tolower(names(inherited)) %in% explicit]
+        # Parse make flags because a vector value expands into one assignment
+        # per element.
+        explicit <- names(parsed_cpp_options(built_options))
+        inherited <- inherited[!names(inherited) %in% explicit]
         # Command-line options override make/local.
         options_mismatch <- cpp_options_disagree(
           c(inherited, cpp_options),

--- a/R/model.R
+++ b/R/model.R
@@ -826,7 +826,10 @@ compile <- function(quiet = TRUE,
   stanc_options[["name"]] <- paste0(self$model_name(), "_model")
   stancflags_combined <- stanc_options_to_args(stanc_options, quote_values = TRUE)
   stancflags_direct <- stanc_options_to_args(stanc_options)
-  stancflags_local <- get_cmdstan_flags("STANCFLAGS")
+  cpp_flags <- cpp_options_to_compile_flags(cpp_options)
+  # CmdStan's makefiles add stanc flags such as --use-opencl when a variable is
+  # set, so the query has to see this build's variables.
+  stancflags_local <- get_cmdstan_flags("STANCFLAGS", cpp_flags)
   is_include_path <- grepl("--include-paths", stancflags_local, fixed = TRUE) |
     startsWith(stancflags_local, "-I")
   if (any(is_include_path)) {
@@ -873,7 +876,7 @@ compile <- function(quiet = TRUE,
         run_log <- wsl_compatible_run(
           command = make_cmd(),
           args = c(wsl_safe_path(repair_path(tmp_exe)),
-                  cpp_options_to_compile_flags(cpp_options),
+                  cpp_flags,
                   user_header_flag,
                   stancflags_val),
           wd = cmdstan_path(),

--- a/R/model.R
+++ b/R/model.R
@@ -823,6 +823,20 @@ compile <- function(quiet = TRUE,
   stancflags_combined <- stanc_options_to_args(stanc_options, quote_values = TRUE)
   stancflags_direct <- stanc_options_to_args(stanc_options)
   stancflags_local <- get_cmdstan_flags("STANCFLAGS")
+  is_include_path <- grepl("--include-paths", stancflags_local, fixed = TRUE) |
+    startsWith(stancflags_local, "-I")
+  if (any(is_include_path)) {
+    stop(
+      paste0(
+        "`make/local` sets an include path in `STANCFLAGS` (`",
+        stancflags_local[is_include_path][1],
+        "`). Include paths cannot be set there. Remove it from `make/local` ",
+        "and pass the directories with the `include_paths` argument."
+      ),
+      call. = FALSE
+    )
+  }
+  stancflags_local <- drop_overridden_stancflags(stancflags_local, stancflags_direct)
   if (length(stancflags_local) > 0) {
     # get_cmdstan_flags() split the local flags into words. Requote them for
     # the STANCFLAGS value handed back to make.
@@ -2663,6 +2677,38 @@ stanc_options_to_args <- function(stanc_options, quote_values = FALSE) {
     }
   }
   args
+}
+
+#' Drop the `make/local` stanc flags that the call sets itself
+#'
+#' A flag is the text before the first `=`. An element of `local_flags` whose
+#' flag is one the call emits is dropped. When that element is a bare flag and
+#' the next element does not start with a hyphen, the next element is the value
+#' given separately and goes with it.
+#'
+#' @param local_flags (character) The `STANCFLAGS` words from `make/local`, one
+#'   argument per element.
+#' @param call_args (character) The arguments the call emits, one per element,
+#'   each starting with `--`.
+#' @return `local_flags` without the overridden elements, the rest in order.
+#' @noRd
+drop_overridden_stancflags <- function(local_flags, call_args) {
+  call_flags <- sub("=.*$", "", call_args)
+  keep <- rep(TRUE, length(local_flags))
+  i <- 1
+  while (i <= length(local_flags)) {
+    if (sub("=.*$", "", local_flags[i]) %in% call_flags) {
+      keep[i] <- FALSE
+      if (!grepl("=", local_flags[i], fixed = TRUE) &&
+          i < length(local_flags) &&
+          !startsWith(local_flags[i + 1], "-")) {
+        keep[i + 1] <- FALSE
+        i <- i + 1
+      }
+    }
+    i <- i + 1
+  }
+  local_flags[keep]
 }
 
 #' Build stanc include-path arguments

--- a/R/model.R
+++ b/R/model.R
@@ -17,7 +17,9 @@
 #' @param exe_file (string) The path to an existing Stan model executable. Can
 #'   be provided instead of or in addition to `stan_file` (if `stan_file` is
 #'   omitted some `CmdStanModel` methods like `$code()` and `$print()` will not
-#'   work).
+#'   work). If `stan_file` is omitted, the executable is used as it is:
+#'   `cpp_options`, `stanc_options`, `include_paths`, `user_header`,
+#'   `force_recompile` and `pedantic` cannot be supplied.
 #' @param compile (logical) Do compilation? The default is `TRUE`. If `FALSE`
 #'   compilation can be done later via the [`$compile()`][model-method-compile]
 #'   method.
@@ -289,11 +291,11 @@ CmdStanModel <- R6::R6Class(
         ext <- if (os_is_windows() && !os_is_wsl()) "exe" else ""
         private$exe_file_ <- resolve_path(exe_file)
         if (is.null(stan_file)) {
+          assert_no_build_args_for_exe_only(args)
           assert_file_exists(private$exe_file_, access = "r", extension = ext)
           private$model_name_ <- gsub(" ", "_", strip_ext(basename(private$exe_file_)))
         }
-        private$include_paths_ <-
-          private$precompile_include_paths_ %||% resolve_path(args$include_paths)
+        private$include_paths_ <- private$precompile_include_paths_
       }
       compiled_here <- !is.null(stan_file) && compile
       if (compiled_here) {
@@ -2563,6 +2565,53 @@ CmdStanModel$set("public", name = "cmdstan_defaults", value = cmdstan_defaults)
 
 
 # internal ----------------------------------------------------------------
+#' The error for a build argument supplied with no `stan_file`
+#'
+#' With no `stan_file` there is nothing to build, so the executable is used
+#' as it is and none of these six arguments apply. Checked in the order
+#' `cpp_options`, `stanc_options`, `include_paths`, `user_header`,
+#' `force_recompile`, `pedantic`, stopping at the first one supplied.
+#'
+#' @noRd
+assert_no_build_args_for_exe_only <- function(args) {
+  build_message <- function(arg) {
+    sprintf(
+      paste0(
+        "`%s` cannot be supplied for a model created from an executable alone. ",
+        "With no Stan file there is nothing to build, so the executable is used as it is."
+      ),
+      arg
+    )
+  }
+  if (!is.null(args$cpp_options)) {
+    stop(build_message("cpp_options"), call. = FALSE)
+  }
+  if (!is.null(args$stanc_options)) {
+    stop(build_message("stanc_options"), call. = FALSE)
+  }
+  if (!is.null(args$include_paths)) {
+    stop(
+      "`include_paths` cannot be supplied for a model created from an executable alone. ",
+      "Include paths resolve `#include` lines in a Stan file, and there is none.",
+      call. = FALSE
+    )
+  }
+  if (!is.null(args$user_header)) {
+    stop(build_message("user_header"), call. = FALSE)
+  }
+  if (!is.null(args$force_recompile)) {
+    stop(build_message("force_recompile"), call. = FALSE)
+  }
+  if (!is.null(args$pedantic)) {
+    stop(
+      "`pedantic` cannot be supplied for a model created from an executable alone. ",
+      "Pedantic mode checks a Stan program, and there is none.",
+      call. = FALSE
+    )
+  }
+  invisible(args)
+}
+
 #' The error for a stanc flag cmdstanr sets from one of its own arguments
 #'
 #' Returns `NULL` for any other flag. The five names live here so that the

--- a/R/options.R
+++ b/R/options.R
@@ -14,6 +14,8 @@
 #' * `cmdstanr_force_recompile`: Should the default be to recompile models
 #' even if there were no Stan code changes since last compiled?  See
 #' [compile][model-method-compile] for more details. The default is `FALSE`.
+#' The option has no effect on a model created from an executable alone,
+#' which is never recompiled.
 #'
 #' * `cmdstanr_max_rows`: The maximum number of rows of output to print when
 #' using the [`$print()`][fit-method-summary] method. The default is 10.

--- a/R/utils.R
+++ b/R/utils.R
@@ -868,7 +868,9 @@ parse_make_print_flag <- function(flag_name, stdout) {
 #' exactly the arguments stanc gets from make. Each line carries a prefix that
 #' tells it apart from other make output. The rule lives in a temporary makefile
 #' rather than an `--eval` argument because users may have a make too old for
-#' `--eval`; the one Apple ships with macOS is.
+#' `--eval`; the one Apple ships with macOS is. The fragment's first line removes
+#' the fragment from `MAKEFILE_LIST` so a value that reads the list sees the same
+#' makefiles the real build does.
 #'
 #' @param cmdstan_path (string) The CmdStan directory.
 #' @return A character vector, one element per argument, `character(0)` when the
@@ -881,6 +883,7 @@ stancflags_from_make <- function(cmdstan_path) {
   con <- file(rule_file, open = "wb")
   writeLines(
     c(
+      "MAKEFILE_LIST := $(filter-out $(lastword $(MAKEFILE_LIST)),$(MAKEFILE_LIST))",
       ".PHONY: cmdstanr-print-stancflags",
       "cmdstanr-print-stancflags: ; @printf 'cmdstanr-stancflag=%s\\n' $(STANCFLAGS)"
     ),

--- a/R/utils.R
+++ b/R/utils.R
@@ -870,13 +870,16 @@ parse_make_print_flag <- function(flag_name, stdout) {
 #' rather than an `--eval` argument because users may have a make too old for
 #' `--eval`; the one Apple ships with macOS is. The fragment's first line removes
 #' the fragment from `MAKEFILE_LIST` so a value that reads the list sees the same
-#' makefiles the real build does.
+#' makefiles the real build does. The call's `cpp_options` go in `make_args` so
+#' the answer is the one the build will see.
 #'
 #' @param cmdstan_path (string) The CmdStan directory.
+#' @param make_args (character) Command-line variable assignments (`NAME=value`)
+#'   for the make call.
 #' @return A character vector, one element per argument, `character(0)` when the
 #'   variable is empty. An empty argument (`''`) is dropped.
 #' @noRd
-stancflags_from_make <- function(cmdstan_path) {
+stancflags_from_make <- function(cmdstan_path, make_args = character()) {
   rule_file <- withr::local_tempfile(pattern = "cmdstanr-stancflags-", fileext = ".mk")
   # Binary mode keeps the line endings LF; under WSL a Linux make reads a file
   # written on Windows.
@@ -899,7 +902,7 @@ stancflags_from_make <- function(cmdstan_path) {
       stdout <- wsl_compatible_run(
         command = "make",
         args = c(
-          "-s", "-f", "makefile", "-f", wsl_safe_path(rule_file),
+          "-s", make_args, "-f", "makefile", "-f", wsl_safe_path(rule_file),
           "cmdstanr-print-stancflags"
         ),
         wd = cmdstan_path
@@ -931,17 +934,17 @@ make_shell_quote <- function(x) {
   gsub("$", "$$", x, fixed = TRUE)
 }
 
-get_cmdstan_flags <- function(flag_name) {
+get_cmdstan_flags <- function(flag_name, make_args = character()) {
   cmdstan_path <- cmdstanr::cmdstan_path()
   if (flag_name == "STANCFLAGS") {
     # stanc flags are returned as a character vector, one element per argument
-    return(stancflags_from_make(cmdstan_path))
+    return(stancflags_from_make(cmdstan_path, make_args))
   }
   withr::with_envvar(
     c("HOME" = short_path(Sys.getenv("HOME"))),
     flags_stdout <- wsl_compatible_run(
       command = "make",
-      args = c("-s", paste0("print-", flag_name)),
+      args = c("-s", make_args, paste0("print-", flag_name)),
       wd = cmdstan_path
     )$stdout
   )

--- a/R/utils.R
+++ b/R/utils.R
@@ -859,8 +859,81 @@ parse_make_print_flag <- function(flag_name, stdout) {
   sub(pattern, "", trimws(lines[matches]), perl = TRUE)
 }
 
+#' Ask Make for `STANCFLAGS`, one argument per line
+#'
+#' CmdStan's `print-%` rule echoes a variable through the shell, which strips the
+#' quotes, so `make print-STANCFLAGS` returns `--filename-in-msg='/my dir'` as
+#' two words (#1232). This rule hands `$(STANCFLAGS)` to the shell the way the
+#' stanc recipe does and prints what the shell delivers, so the result holds
+#' exactly the arguments stanc gets from make. Each line carries a prefix that
+#' tells it apart from other make output. The rule lives in a temporary makefile
+#' rather than an `--eval` argument because users may have a make too old for
+#' `--eval`; the one Apple ships with macOS is.
+#'
+#' @param cmdstan_path (string) The CmdStan directory.
+#' @return A character vector, one element per argument, `character(0)` when the
+#'   variable is empty. An empty argument (`''`) is dropped.
+#' @noRd
+stancflags_from_make <- function(cmdstan_path) {
+  rule_file <- withr::local_tempfile(pattern = "cmdstanr-stancflags-", fileext = ".mk")
+  # Binary mode keeps the line endings LF; under WSL a Linux make reads a file
+  # written on Windows.
+  con <- file(rule_file, open = "wb")
+  writeLines(
+    c(
+      ".PHONY: cmdstanr-print-stancflags",
+      "cmdstanr-print-stancflags: ; @printf 'cmdstanr-stancflag=%s\\n' $(STANCFLAGS)"
+    ),
+    con,
+    sep = "\n"
+  )
+  close(con)
+  # The recipe needs sh, which on Windows comes from the toolchain
+  withr::with_path(
+    toolchain_PATH_env_var(),
+    withr::with_envvar(
+      c("HOME" = short_path(Sys.getenv("HOME"))),
+      stdout <- wsl_compatible_run(
+        command = "make",
+        args = c(
+          "-s", "-f", "makefile", "-f", wsl_safe_path(rule_file),
+          "cmdstanr-print-stancflags"
+        ),
+        wd = cmdstan_path
+      )$stdout
+    )
+  )
+  lines <- strsplit(stdout, "\r?\n")[[1]]
+  flags <- grep("^cmdstanr-stancflag=", lines, value = TRUE)
+  flags <- sub("^cmdstanr-stancflag=", "", flags)
+  flags[nzchar(flags)]
+}
+
+#' Quote words for a `STANCFLAGS` value handed to Make
+#'
+#' Make expands the value and the shell splits it, so this doubles `$` for Make
+#' and single-quotes any word holding a character the shell could interpret
+#' (#1230). A word made only of characters neither touches stays as it is.
+#'
+#' @param x (character) Words, one per element.
+#' @return `x` with each element quoted as needed.
+#' @noRd
+make_shell_quote <- function(x) {
+  needs_quote <- grepl("[^A-Za-z0-9_./:=+@%,-]", x)
+  # shQuote() switches the whole vector to double quotes if any element holds
+  # a single quote, so quote one element at a time
+  x[needs_quote] <- vapply(
+    x[needs_quote], shQuote, character(1), type = "sh", USE.NAMES = FALSE
+  )
+  gsub("$", "$$", x, fixed = TRUE)
+}
+
 get_cmdstan_flags <- function(flag_name) {
   cmdstan_path <- cmdstanr::cmdstan_path()
+  if (flag_name == "STANCFLAGS") {
+    # stanc flags are returned as a character vector, one element per argument
+    return(stancflags_from_make(cmdstan_path))
+  }
   withr::with_envvar(
     c("HOME" = short_path(Sys.getenv("HOME"))),
     flags_stdout <- wsl_compatible_run(
@@ -870,15 +943,6 @@ get_cmdstan_flags <- function(flag_name) {
     )$stdout
   )
   flags <- parse_make_print_flag(flag_name, flags_stdout)
-
-  if (flag_name == "STANCFLAGS") {
-    # StanC flags need to be returned as a character vector
-    if (!nzchar(flags)) {
-      return(character())
-    }
-    flags_vec <- strsplit(x = trimws(flags), split = "\\s+", perl = TRUE)[[1]]
-    return(flags_vec[nzchar(flags_vec)])
-  }
 
   if (!nzchar(flags)) {
     return(flags)

--- a/R/utils.R
+++ b/R/utils.R
@@ -870,8 +870,8 @@ parse_make_print_flag <- function(flag_name, stdout) {
 #' rather than an `--eval` argument because users may have a make too old for
 #' `--eval`; the one Apple ships with macOS is. The fragment's first line removes
 #' the fragment from `MAKEFILE_LIST` so a value that reads the list sees the same
-#' makefiles the real build does. The call's `cpp_options` go in `make_args` so
-#' the answer is the one the build will see.
+#' makefiles the real build does. The call's `cpp_options` and `user_header` go
+#' in `make_args` so the answer is the one the build will see.
 #'
 #' @param cmdstan_path (string) The CmdStan directory.
 #' @param make_args (character) Command-line variable assignments (`NAME=value`)

--- a/dev-notes/compilation-state-contract.md
+++ b/dev-notes/compilation-state-contract.md
@@ -167,13 +167,15 @@ than anything we would write.
 
 ### [Rejection matches the option, not the spelling](compilation-state.md#rejection-matches-the-option-not-the-spelling)
 
-These entries are rejected from an R option list that currently accepts them:
-`include-paths`, `warn-pedantic`, `allow-undefined`, `use-opencl` and `name` from
-`stanc_options`, and `USER_HEADER` / `user_header` and `STANCFLAGS` from
+These entries are rejected from the R option lists that accepted them before
+Stage 1: `include-paths`, `warn-pedantic`, `allow-undefined`, `use-opencl` and
+`name` from `stanc_options`, and `USER_HEADER` / `user_header` and `STANCFLAGS` from
 `cpp_options`. **Every one is matched by where the option name occurs, never by
-enumerating accepted values.** (`--include-paths` in the effective `STANCFLAGS` is
-rejected too, but that is a value Make resolved rather than a list entry, so §6
-gives it its own detection rule.)
+enumerating accepted values.** The `stanc_options` rule covers every
+`stanc_options` list a method accepts, so `$check_syntax()`'s own argument is
+checked the same way as the constructor's. (`--include-paths` in the effective
+`STANCFLAGS` is rejected too, but that is a value Make resolved rather than a list
+entry, so §6 gives it its own detection rule.)
 
 `stanc_options_to_args()` (`R/model.R:2598`) puts the flag name in a different slot
 depending on the entry's shape, so the rule has two arms:

--- a/dev-notes/compilation-state-contract.md
+++ b/dev-notes/compilation-state-contract.md
@@ -205,7 +205,7 @@ as literals with no case folding inside the matcher.
 
 **So raw assignment-shaped entries are rejected, not reclassified.**
 
-**After normalization, a name must match `^[A-Za-z_][A-Za-z0-9_]*$`.**
+**A name must match `^[A-Za-z_][A-Za-z0-9_]*$` as written; matching names are then uppercased.**
 
 **Plain `NAME=value` is rejected too**
 

--- a/dev-notes/compilation-state-contract.md
+++ b/dev-notes/compilation-state-contract.md
@@ -532,8 +532,8 @@ stanc flags and a raw make-variable passthrough only duplicates it. In the
 begins with `-I`). We never interpret the comma lists, quoting or separator forms,
 only refuse them.
 
-**The `STANCFLAGS` check reads what Make resolved, not what `make/local` says, and
-runs at build time only.**
+**The `STANCFLAGS` check reads what Make resolves for this build, with the call's
+`cpp_options` applied, not what `make/local` says, and runs at build time only.**
 
 **The two rejections differ in scope, and should not be unified.** `cpp_options` is
 a cmdstanr argument, so the whole variable goes. `make/local` is CmdStan's own

--- a/dev-notes/compilation-state-contract.md
+++ b/dev-notes/compilation-state-contract.md
@@ -154,10 +154,10 @@ others, not as a recorded `cpp_options` entry.**
 ### [One canonical spelling, established on entry](compilation-state.md#one-canonical-spelling-established-on-entry)
 
 **Named `cpp_options` entries are normalized to their `make` spelling once, on entry
-to the build call, ahead of validation.**
+to the build call.**
 
-After that point one spelling is in play, and validation,
-comparison, the record and `$cpp_options()` all use it. `list(stan_threads = TRUE)`
+After that point one spelling is in play, and the reserved-name
+checks, comparison, the record and `$cpp_options()` all use it. `list(stan_threads = TRUE)`
 keeps working.
 
 **The `stanc_options` side is not symmetric.** `stanc_options_to_args()` passes names
@@ -533,7 +533,7 @@ begins with `-I`). We never interpret the comma lists, quoting or separator form
 only refuse them.
 
 **The `STANCFLAGS` check reads what Make resolves for this build, with the call's
-`cpp_options` applied, not what `make/local` says, and runs at build time only.**
+`cpp_options` and `user_header` applied, not what `make/local` says, and runs at build time only.**
 
 **The two rejections differ in scope, and should not be unified.** `cpp_options` is
 a cmdstanr argument, so the whole variable goes. `make/local` is CmdStan's own

--- a/dev-notes/compilation-state.md
+++ b/dev-notes/compilation-state.md
@@ -444,9 +444,10 @@ deleted it. What remains, inline in `$compile()`, is resolving a path, falling b
 to the previous header, and passing `USER_HEADER` to `make`. §8 removes the fallback
 along with deferred compilation.
 
-The code already treats the header as not belonging here: `parsed_cpp_options()`
-skips `user_header` when canonicalizing (`R/cpp_opts.R:101`), because it is not an
-ordinary Make assignment to compare.
+Before Stage 1 the code already treated the header as not belonging here:
+`parsed_cpp_options()` skipped `user_header` when canonicalizing, because it was not
+an ordinary Make assignment to compare. With the header gone from `cpp_options`,
+Stage 1 dropped that exclusion.
 
 <!-- contract -->
 
@@ -505,12 +506,12 @@ spelling, alongside the `previous` parameter §8 removes.
 
 ### One canonical spelling, established on entry
 
-`cpp_options_to_compile_flags()` (`R/cpp_opts.R:131`) uppercases every named entry,
-so `list(USER_HEADER = h)`, `list(user_header = h)` and `list(User_Header = h)` are
-one variable to `make` and three values to R. The code reconciles that three times
-in two directions today: `toupper()` on the way out to `make`, `tolower()` in
-`parsed_cpp_options()` (`:100`) on the way into comparison, and `tolower()` again in
-the dormant `validate_cpp_options()` (`:165`).
+Before Stage 1, `cpp_options_to_compile_flags()` uppercased every named entry, so
+`list(USER_HEADER = h)`, `list(user_header = h)` and `list(User_Header = h)` were
+one variable to `make` and three values to R. The code reconciled that three times
+in two directions: `toupper()` on the way out to `make`, `tolower()` in
+`parsed_cpp_options()` on the way into comparison, and `tolower()` again in the
+dormant `validate_cpp_options()`.
 
 <!-- contract -->
 
@@ -538,13 +539,13 @@ working and changes meaning, from a value the binary confirmed to one the caller
 asked for; `stan_build_info()` is where the confirmed value went (§1). Tested on
 ordinary construction and on record-backed adoption.
 
-It also retires `parsed_cpp_options()`'s exclusion list (`:101`), for a different
-reason on each entry. Both are there because that function is fed a merged list of
+Stage 1 also retired `parsed_cpp_options()`'s exclusion list, for a different
+reason on each entry. Both were there because that function is fed a merged list of
 request and binary report (`R/model.R:774`); §1 stops merging those, so the only
 input left to parse is a supplied list.
 
 `user_header` cannot appear in one, since the named spelling is rejected above and
-cmdstanr's own injection is not supplied. `stan_version` can, and should. Nothing
+cmdstanr no longer puts the header into the list. `stan_version` can, and should. Nothing
 in CmdStan reads `STAN_VERSION`: cmdstanr synthesizes the name at `R/cpp_opts.R:68`
 from the three `stan_version_*` fields `<exe> info` prints, and CmdStan's own
 version variable is `CMDSTAN_VERSION` (`makefile:151`). A supplied one is still an
@@ -568,22 +569,22 @@ diff has no job left, and with only an executable §7 makes the request an error
 helper goes in the pull request that wires the engine (#1255), with its branch and
 its tests, which turn from expecting the warning into expecting the rebuild.
 
-**Its key fold is changed with this rule, not after it.** The function matches the
+**Its key fold was changed with this rule, not after it.** The function matched the
 parser's names against `tolower(names(exe_info))`, one side folded and the other
-inherited from the parser. Canonicalizing while that stands empties the intersection
-for every option, and the check silently stops checking: no error, no mismatch ever
-reported, just a validator that always agrees. Stage 1 drops the fold, so both sides
-carry the `make` spelling, and the check keeps working until Stage 4 removes it.
+inherited from the parser. Canonicalizing while that stood would have emptied the
+intersection for every option, and the check would have silently stopped checking:
+no error, no mismatch ever reported, just a validator that always agrees. Stage 1
+dropped the fold in the same commit, so both sides carry the `make` spelling, and
+the check keeps working until Stage 4 removes it.
 
 **One function owns normalize-then-check.** `assert_valid_cpp_options()` (#1250) does
 both, called from the single build implementation §8 leaves behind, so the ordering
 is built in rather than a convention a later contributor has to know. It pairs with
 `assert_valid_stanc_options()` (`R/model.R:2562`), which already does this job for
-the other list. `validate_cpp_options()` (`R/cpp_opts.R:151`) is **deleted** rather
-than left dormant: its one substantive behaviour is a warning that a logical `FALSE`
-will turn an option on, which #1251 reverses, so leaving it in the file would
-document the opposite of v1.0's semantics to whoever reads it next. Its tests go
-with it (`test-cpp_opts.R:24-37`).
+the other list. Stage 1 **deleted** `validate_cpp_options()` rather than leaving it
+dormant: its one substantive behaviour was a warning that a logical `FALSE` will turn
+an option on, which #1251 reverses, so leaving it in the file would have documented
+the opposite of v1.0's semantics to whoever read it next. Its tests went with it.
 
 <!-- contract -->
 
@@ -667,9 +668,10 @@ is refused for its shape, and the caller still needs pointing at `user_header`.
 
 ### Only named assignments configure a build (#1250)
 
-Two verified defects. **Unnamed raw entries reach `make` but are invisible to
-everything keyed on names**, because an unnamed list entry's name is `""` while
-`cpp_options_to_compile_flags()` passes it straight through (`R/cpp_opts.R:139`):
+Two defects, verified before Stage 1 closed them. **Unnamed raw entries reached
+`make` but were invisible to everything keyed on names**, because an unnamed list
+entry's name is `""` while `cpp_options_to_compile_flags()` passed it straight
+through:
 
 ```r
 mod <- cmdstan_model(f, cpp_options = list("STAN_THREADS=TRUE"))
@@ -679,12 +681,12 @@ mod$sample(threads_per_chain = 4)
 
 The model *is* threaded. This is #765's symptom via a different spelling.
 
-**Names are lower-cased at `R/cpp_opts.R:100`**, so `foo=1` and `FOO=1` compare
+**Names were lower-cased in `parsed_cpp_options()`**, so `foo=1` and `FOO=1` compared
 equal despite being different Make variables.
 
 **Raw `NAME+=`, `NAME?=` and `NAME:=` are assignments, not Make flags.**
-`parsed_cpp_options()`'s `^[A-Za-z_][A-Za-z0-9_]*=` does not match them, so they
-fall through to `opaque`. The collapse to `=` is only true of an assignment
+`parsed_cpp_options()`'s `^[A-Za-z_][A-Za-z0-9_]*=` did not match them, so they
+fell through to its `opaque` class. The collapse to `=` is only true of an assignment
 appearing alone. Two assignments to the same variable retain operator semantics
 (GNU Make 3.81):
 
@@ -717,11 +719,11 @@ raw operators would invalidate the canonicalization rule as well.
 
 **After normalization, a name must match `^[A-Za-z_][A-Za-z0-9_]*$`.** <!-- /contract --> Without that,
 the sentence above is not true, because an operator arrives through the named door
-instead. `cpp_options_to_compile_flags()` builds each argument as
-`paste0(toupper(option_name), "=", value)` (`R/cpp_opts.R:141`) and `toupper()`
-leaves `+` alone, so `list("FOO+" = "x")` reaches `make` as `FOO+=x`. The grammar is
-the one `parsed_cpp_options()` already applies above, where all it decides is how a
-flag is classified. Nothing consults it before the flag is handed to `make`.
+instead. Before Stage 1, `cpp_options_to_compile_flags()` built each argument as
+`paste0(toupper(option_name), "=", value)` and `toupper()` leaves `+` alone, so
+`list("FOO+" = "x")` reached `make` as `FOO+=x`. The grammar was the one
+`parsed_cpp_options()` applied above, where all it decided was how a flag is
+classified. Nothing consulted it before the flag was handed to `make`.
 
 The reserved-variable rule shows this is not only about operators. `USER_HEADER+` is
 not `USER_HEADER`, so the matcher that rejects the two `cpp_options` spellings of

--- a/dev-notes/compilation-state.md
+++ b/dev-notes/compilation-state.md
@@ -598,13 +598,15 @@ not exist.
 
 <!-- contract -->
 
-These entries are rejected from an R option list that currently accepts them:
-`include-paths`, `warn-pedantic`, `allow-undefined`, `use-opencl` and `name` from
-`stanc_options`, and `USER_HEADER` / `user_header` and `STANCFLAGS` from
+These entries are rejected from the R option lists that accepted them before
+Stage 1: `include-paths`, `warn-pedantic`, `allow-undefined`, `use-opencl` and
+`name` from `stanc_options`, and `USER_HEADER` / `user_header` and `STANCFLAGS` from
 `cpp_options`. **Every one is matched by where the option name occurs, never by
-enumerating accepted values.** (`--include-paths` in the effective `STANCFLAGS` is
-rejected too, but that is a value Make resolved rather than a list entry, so §6
-gives it its own detection rule.)
+enumerating accepted values.** The `stanc_options` rule covers every
+`stanc_options` list a method accepts, so `$check_syntax()`'s own argument is
+checked the same way as the constructor's. (`--include-paths` in the effective
+`STANCFLAGS` is rejected too, but that is a value Make resolved rather than a list
+entry, so §6 gives it its own detection rule.)
 
 `stanc_options_to_args()` (`R/model.R:2598`) puts the flag name in a different slot
 depending on the entry's shape, so the rule has two arms:

--- a/dev-notes/compilation-state.md
+++ b/dev-notes/compilation-state.md
@@ -719,7 +719,7 @@ raw operators would invalidate the canonicalization rule as well.
 
 <!-- contract -->
 
-**After normalization, a name must match `^[A-Za-z_][A-Za-z0-9_]*$`.** <!-- /contract --> Without that,
+**A name must match `^[A-Za-z_][A-Za-z0-9_]*$` as written; matching names are then uppercased.** <!-- /contract --> Without that,
 the sentence above is not true, because an operator arrives through the named door
 instead. Before Stage 1, `cpp_options_to_compile_flags()` built each argument as
 `paste0(toupper(option_name), "=", value)` and `toupper()` leaves `+` alone, so

--- a/dev-notes/compilation-state.md
+++ b/dev-notes/compilation-state.md
@@ -437,11 +437,12 @@ spellings are rejected, with an error naming it.
 
 This is the same rule as for `include_paths`, `warn-pedantic` and `STANCFLAGS` (§6,
 §4): one setting, one channel. It is stated separately because of what it deletes.
-`resolve_user_header()` (`R/cpp_opts.R:189-245`) exists almost entirely to reconcile
-the three, tracking positions of both casings so duplicates follow make's last-wins
-rule, walking a four-level precedence chain, and raising two distinct conflict
-warnings. §8 removes its `previous` parameter along with deferred compilation, and
-what remains is resolving a path and setting `USER_HEADER` for `make`.
+`resolve_user_header()` existed almost entirely to reconcile the three, tracking
+positions of both casings so duplicates followed make's last-wins rule, walking a
+four-level precedence chain, and raising two distinct conflict warnings. Stage 1
+deleted it. What remains, inline in `$compile()`, is resolving a path, falling back
+to the previous header, and passing `USER_HEADER` to `make`. §8 removes the fallback
+along with deferred compilation.
 
 The code already treats the header as not belonging here: `parsed_cpp_options()`
 skips `user_header` when canonicalizing (`R/cpp_opts.R:101`), because it is not an
@@ -2675,12 +2676,11 @@ explicit `NULL` default breaks it just as well.
 **Explicit `NULL` means omission for all six, so one sentinel covers them.** <!-- /contract -->
 `user_header` is the one that looks like an exception, because `user_header = NULL`
 currently means compile without one. That meaning exists only because the header
-persisted: `resolve_user_header()`'s `supplied` flag decides precedence over the two
-`cpp_options` spellings and otherwise falls back to `previous`
-(`R/cpp_opts.R:189-245`). §3 rejects both spellings and §8 removes `previous`, so
+persists: `$compile()` tells an omitted `user_header` from an explicit `NULL` with
+`missing()` and falls back to the previous header when it is omitted. §3 rejected
+the two `cpp_options` spellings (done in Stage 1) and §8 removes the fallback, so
 nothing is left for an explicit `NULL` to override, and under §2 omitting the
-argument already means no header. `supplied` leaves `resolve_user_header()` with the
-precedence chain it existed for.
+argument already means no header.
 
 <!-- contract -->
 

--- a/dev-notes/compilation-state.md
+++ b/dev-notes/compilation-state.md
@@ -516,10 +516,10 @@ dormant `validate_cpp_options()`.
 <!-- contract -->
 
 **Named `cpp_options` entries are normalized to their `make` spelling once, on entry
-to the build call, ahead of validation.** <!-- /contract --> Uppercase is the canonical direction
+to the build call.** <!-- /contract --> Uppercase is the canonical direction
 because it is what `make` receives and what a compile log shows; lowercase is an R
-naming convention. <!-- contract -->After that point one spelling is in play, and validation,
-comparison, the record and `$cpp_options()` all use it. `list(stan_threads = TRUE)`
+naming convention. <!-- contract -->After that point one spelling is in play, and the reserved-name
+checks, comparison, the record and `$cpp_options()` all use it. `list(stan_threads = TRUE)`
 keeps working. <!-- /contract --> It is normalized immediately instead of at three later points.
 
 This is what makes the reserved-variable rejection below exact, but the rejection is
@@ -1742,7 +1742,7 @@ only refuse them.
 <!-- contract -->
 
 **The `STANCFLAGS` check reads what Make resolves for this build, with the call's
-`cpp_options` applied, not what `make/local` says, and runs at build time only.** <!-- /contract --> `make/local` may include another makefile, a pattern
+`cpp_options` and `user_header` applied, not what `make/local` says, and runs at build time only.** <!-- /contract --> `make/local` may include another makefile, a pattern
 CmdStan's own `make/local.example` suggests (below), so scanning the file misses
 any flag arriving that way. Measured, the
 file reads `include $(HOME)/.config/stan/extra.mk` while `make -s print-STANCFLAGS`

--- a/dev-notes/compilation-state.md
+++ b/dev-notes/compilation-state.md
@@ -1741,8 +1741,8 @@ only refuse them.
 
 <!-- contract -->
 
-**The `STANCFLAGS` check reads what Make resolved, not what `make/local` says, and
-runs at build time only.** <!-- /contract --> `make/local` may include another makefile, a pattern
+**The `STANCFLAGS` check reads what Make resolves for this build, with the call's
+`cpp_options` applied, not what `make/local` says, and runs at build time only.** <!-- /contract --> `make/local` may include another makefile, a pattern
 CmdStan's own `make/local.example` suggests (below), so scanning the file misses
 any flag arriving that way. Measured, the
 file reads `include $(HOME)/.config/stan/extra.mk` while `make -s print-STANCFLAGS`

--- a/man/CmdStanModel.Rd
+++ b/man/CmdStanModel.Rd
@@ -30,6 +30,7 @@ methods, many of which have their own (linked) documentation pages:
    \code{\link[=model-method-model-info]{$include_paths()}} \tab Return the Stan include paths. \cr
    \code{\link[=model-method-model-info]{$cmdstan_version()}} \tab Return the CmdStan version associated with the model. \cr
    \code{\link[=model-method-model-info]{$cpp_options()}} \tab Return the C++ options associated with the model. \cr
+   \code{\link[=model-method-model-info]{$user_header()}} \tab Return the path to the user header, if the model has one. \cr
 }
 
 }

--- a/man/cmdstan_model.Rd
+++ b/man/cmdstan_model.Rd
@@ -15,7 +15,9 @@ it is more convenient to specify the Stan program as a string. If
 \item{exe_file}{(string) The path to an existing Stan model executable. Can
 be provided instead of or in addition to \code{stan_file} (if \code{stan_file} is
 omitted some \code{CmdStanModel} methods like \verb{$code()} and \verb{$print()} will not
-work).}
+work). If \code{stan_file} is omitted, the executable is used as it is:
+\code{cpp_options}, \code{stanc_options}, \code{include_paths}, \code{user_header},
+\code{force_recompile} and \code{pedantic} cannot be supplied.}
 
 \item{compile}{(logical) Do compilation? The default is \code{TRUE}. If \code{FALSE}
 compilation can be done later via the \code{\link[=model-method-compile]{$compile()}}

--- a/man/cmdstan_model.Rd
+++ b/man/cmdstan_model.Rd
@@ -17,7 +17,8 @@ be provided instead of or in addition to \code{stan_file} (if \code{stan_file} i
 omitted some \code{CmdStanModel} methods like \verb{$code()} and \verb{$print()} will not
 work). If \code{stan_file} is omitted, the executable is used as it is:
 \code{cpp_options}, \code{stanc_options}, \code{include_paths}, \code{user_header},
-\code{force_recompile} and \code{pedantic} cannot be supplied.}
+\code{force_recompile} and \code{pedantic} cannot be supplied, and passing \code{NULL}
+counts as omitting them.}
 
 \item{compile}{(logical) Do compilation? The default is \code{TRUE}. If \code{FALSE}
 compilation can be done later via the \code{\link[=model-method-compile]{$compile()}}

--- a/man/cmdstanr_global_options.Rd
+++ b/man/cmdstanr_global_options.Rd
@@ -15,6 +15,8 @@ draws? The default depends on the model fitting method. See
 \item \code{cmdstanr_force_recompile}: Should the default be to recompile models
 even if there were no Stan code changes since last compiled?  See
 \link[=model-method-compile]{compile} for more details. The default is \code{FALSE}.
+The option has no effect on a model created from an executable alone,
+which is never recompiled.
 \item \code{cmdstanr_max_rows}: The maximum number of rows of output to print when
 using the \code{\link[=fit-method-summary]{$print()}} method. The default is 10.
 \item \code{cmdstanr_print_line_numbers}: Should line numbers be included when

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -49,8 +49,6 @@ recompilation. Edits to the included files themselves do not; see
 to compile with the Stan model. If \verb{$compile()} is called again without
 \code{user_header}, the most recently supplied header is reused, and changing
 it forces recompilation. Pass \code{user_header = NULL} to compile without one.
-A header can also be supplied via \code{cpp_options} as \code{USER_HEADER} or
-\code{user_header}; the \code{user_header} argument takes precedence over both.
 See \code{force_recompile} for the case of a header supplied for a program
 whose executable is already up to date.}
 
@@ -58,18 +56,19 @@ whose executable is already up to date.}
 model (\code{stan_threads}, \code{stan_mpi}, \code{stan_opencl}, etc.). Anything you would
 otherwise write in the \code{make/local} file. For an example of using threading
 see the Stan case study \href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.
-\strong{Note:} For historical reasons, CmdStan treats some options as enabled
-whenever their \code{Make} variable is non-empty. In particular, setting
-\code{stan_threads} to \code{FALSE} passes \code{STAN_THREADS=FALSE} to \code{Make}, which
-still enables threading! To leave threading disabled, either omit
-\code{stan_threads} entirely, which leaves any setting in \code{make/local} in
-place, or set it to \code{NULL}, which passes an empty \verb{STAN_THREADS=} and so
-overrides \code{make/local} too.}
+Every entry must be named with a \code{Make} variable name, in any casing, which
+\code{\link[=model-method-model-info]{$cpp_options()}} reports back in upper case.
+Setting an option to \code{FALSE} or \code{NULL} passes an empty assignment, which
+disables the option and overrides \code{make/local}.}
 
 \item{stanc_options}{(list) Any Stan-to-C++ transpiler options to be used
 when compiling the model. See the \strong{Examples} section below as well as the
 \href{https://mc-stan.org/docs/cmdstan-guide/stanc.html}{\code{stanc} chapter of the CmdStan User's Guide} for more details
-on available options.}
+on available options. Options that cmdstanr sets from its own arguments
+cannot be passed here: \code{include-paths} (use \code{include_paths}),
+\code{warn-pedantic} (\code{pedantic}), \code{allow-undefined} (\code{user_header}),
+\code{use-opencl} (\code{cpp_options = list(stan_opencl = TRUE)}) and \code{name} (taken
+from the name of the Stan file).}
 
 \item{force_recompile}{(logical) Should the model be recompiled even if it
 has not been modified since it was last compiled? The default is \code{FALSE}.

--- a/man/model-method-compile.Rd
+++ b/man/model-method-compile.Rd
@@ -58,8 +58,9 @@ otherwise write in the \code{make/local} file. For an example of using threading
 see the Stan case study \href{https://mc-stan.org/users/documentation/case-studies/reduce_sum_tutorial.html}{Reduce Sum: A Minimal Example}.
 Every entry must be named with a \code{Make} variable name, in any casing, which
 \code{\link[=model-method-model-info]{$cpp_options()}} reports back in upper case.
-Setting an option to \code{FALSE} or \code{NULL} passes an empty assignment, which
-disables the option and overrides \code{make/local}.}
+Setting an option to \code{FALSE} or \code{NULL} passes an empty assignment such as
+\verb{STAN_THREADS=}. That empties the variable for this build, which turns a
+switch off, and overrides whatever \code{make/local} sets.}
 
 \item{stanc_options}{(list) Any Stan-to-C++ transpiler options to be used
 when compiling the model. See the \strong{Examples} section below as well as the

--- a/man/model-method-model-info.Rd
+++ b/man/model-method-model-info.Rd
@@ -28,7 +28,10 @@ code, or \code{NULL} if the model was created without a Stan file.
 executable path is set.
 \item \verb{$include_paths()} returns a character vector of absolute paths or \code{NULL}.
 \item \verb{$cmdstan_version()} returns a CmdStan version as a string.
-\item \verb{$cpp_options()} returns a named list of C++ options.
+\item \verb{$cpp_options()} returns a named list of C++ options, with names in their
+\code{make} spelling.
+\item \verb{$user_header()} returns the absolute path to the user header as a string,
+or \code{NULL} if the model has no user header.
 \item \verb{$hpp_file()} returns the path to the \code{.hpp} file as a string when C++ code
 was generated while compiling this model object. It errors if no \code{.hpp}
 path is available, such as when an up-to-date executable was reused.
@@ -50,6 +53,7 @@ exe_file(path = NULL)
 include_paths()
 cmdstan_version()
 cpp_options()
+user_header()
 hpp_file()
 save_hpp_file(dir = NULL)
 }\if{html}{\out{</div>}}

--- a/tests/testthat/_snaps/threads.md
+++ b/tests/testthat/_snaps/threads.md
@@ -6,11 +6,3 @@
       Warning:
       'num_threads' is deprecated as of CmdStanR 1.0.0 and will be removed in a future release. Please use 'threads' instead.
 
-# executable metadata takes precedence over compile options
-
-    Code
-      mod$sample(data = data_file_json, chains = 1)
-    Condition
-      Error:
-      ! The model executable was built with threading enabled but 'threads_per_chain' was not set!
-

--- a/tests/testthat/test-cpp_opts.R
+++ b/tests/testthat/test-cpp_opts.R
@@ -54,6 +54,36 @@ test_that("assert_valid_cpp_options rejects a user header", {
   }
 })
 
+test_that("assert_valid_cpp_options points an empty user header at NULL", {
+  expected_null <- paste0(
+    "The user header cannot be set through `cpp_options`. ",
+    "Pass it with the `user_header` argument: `user_header = NULL`."
+  )
+  expect_error(
+    assert_valid_cpp_options(list("USER_HEADER=")),
+    expected_null,
+    fixed = TRUE
+  )
+  expect_error(
+    assert_valid_cpp_options(list(USER_HEADER = FALSE)),
+    expected_null,
+    fixed = TRUE
+  )
+  expect_error(
+    assert_valid_cpp_options(list(USER_HEADER = NULL)),
+    expected_null,
+    fixed = TRUE
+  )
+  expect_error(
+    assert_valid_cpp_options(list("USER_HEADER=C:\\h\\f.hpp")),
+    paste0(
+      "The user header cannot be set through `cpp_options`. ",
+      "Pass it with the `user_header` argument: `user_header = \"C:\\\\h\\\\f.hpp\"`."
+    ),
+    fixed = TRUE
+  )
+})
+
 test_that("assert_valid_cpp_options rejects an unnamed assignment", {
   expect_error(
     assert_valid_cpp_options(list("FOO=1")),
@@ -101,7 +131,7 @@ test_that("assert_valid_cpp_options sends makefile syntax to make/local", {
       fixed = TRUE
     )
   }
-  for (entry in c("-j4", "-f other.mk", "--eval=STAN_OPENCL=1")) {
+  for (entry in c("-j4", "--eval=STAN_OPENCL=1")) {
     expect_error(
       assert_valid_cpp_options(list(entry)),
       paste0(
@@ -115,6 +145,50 @@ test_that("assert_valid_cpp_options sends makefile syntax to make/local", {
   expect_error(
     assert_valid_cpp_options(list(1)),
     "`cpp_options` entries must be named: `list(NAME = value)`.",
+    fixed = TRUE
+  )
+})
+
+test_that("assert_valid_cpp_options rejects an unnamed assignment quoted as an R literal", {
+  expect_error(
+    assert_valid_cpp_options(list('CXXFLAGS=-DVERSION="foo"')),
+    '`cpp_options` entries must be named. Write `list(CXXFLAGS = "-DVERSION=\\"foo\\"")` instead of `"CXXFLAGS=-DVERSION=\\"foo\\""`.',
+    fixed = TRUE
+  )
+})
+
+test_that("assert_valid_cpp_options rejects -B and --always-make", {
+  for (entry in c("-B", "--always-make")) {
+    expect_error(
+      assert_valid_cpp_options(list(entry)),
+      paste0(
+        "Make flags cannot be passed through `cpp_options`. `", entry,
+        "` rebuilds everything; pass `force_recompile = TRUE` instead."
+      ),
+      fixed = TRUE
+    )
+  }
+})
+
+test_that("assert_valid_cpp_options sends -f entries to make/local's include", {
+  for (entry in c("-f other.mk", "-fother.mk", "--file=other.mk", "--makefile=other.mk")) {
+    expect_error(
+      assert_valid_cpp_options(list(entry)),
+      paste0(
+        "Make flags cannot be passed through `cpp_options`. To read another ",
+        "makefile add `include other.mk` to `make/local`, for example ",
+        "`cmdstan_make_local(cpp_options = list(\"include other.mk\"))`."
+      ),
+      fixed = TRUE
+    )
+  }
+  expect_error(
+    assert_valid_cpp_options(list("-f")),
+    paste0(
+      "Make flags cannot be passed through `cpp_options`. Set them in ",
+      "`make/local` with `cmdstan_make_local()`, for example ",
+      "`MAKEFLAGS += -j4`."
+    ),
     fixed = TRUE
   )
 })

--- a/tests/testthat/test-cpp_opts.R
+++ b/tests/testthat/test-cpp_opts.R
@@ -37,6 +37,33 @@ test_that("validate_cpp_options works", {
   expect_warning(validate_cpp_options(list(STAN_OPENCL = FALSE)))
 })
 
+test_that("assert_valid_cpp_options passes options through", {
+  expect_equal(assert_valid_cpp_options(NULL), list())
+  options <- list(stan_threads = TRUE, STAN_OPENCL = NULL)
+  expect_identical(assert_valid_cpp_options(options), options)
+})
+
+test_that("assert_valid_cpp_options rejects a user header", {
+  for (option_name in c("USER_HEADER", "user_header", "User_Header")) {
+    expect_error(
+      assert_valid_cpp_options(setNames(list("header.hpp"), option_name)),
+      paste0(
+        "The user header cannot be set through `cpp_options`. ",
+        "Pass it with the `user_header` argument: `user_header = \"header.hpp\"`."
+      ),
+      fixed = TRUE
+    )
+    expect_error(
+      assert_valid_cpp_options(setNames(list(c("a.hpp", "b.hpp")), option_name)),
+      paste0(
+        "The user header cannot be set through `cpp_options`. ",
+        "Pass it with the `user_header` argument."
+      ),
+      fixed = TRUE
+    )
+  }
+})
+
 test_that("cpp option lookup is exact and case-insensitive", {
   cpp_options <- list(STAN_THREADS = TRUE)
   expect_identical(cpp_option_value(cpp_options, "stan_threads"), TRUE)

--- a/tests/testthat/test-cpp_opts.R
+++ b/tests/testthat/test-cpp_opts.R
@@ -21,26 +21,16 @@ test_that("parse_exe_info_string works", {
   )
 })
 
-test_that("validate_cpp_options works", {
-  expect_equal_ignore_order(
-    validate_cpp_options(list(
-      Stan_Threads = TRUE,
-      STAN_OPENCL = NULL,
-      aBc = FALSE
-    )),
-    list(
-      stan_threads = TRUE,
-      stan_opencl = NULL,
-      abc = FALSE
-    )
-  )
-  expect_warning(validate_cpp_options(list(STAN_OPENCL = FALSE)))
-})
-
 test_that("assert_valid_cpp_options passes options through", {
   expect_equal(assert_valid_cpp_options(NULL), list())
-  options <- list(stan_threads = TRUE, STAN_OPENCL = NULL)
-  expect_identical(assert_valid_cpp_options(options), options)
+  expect_identical(
+    assert_valid_cpp_options(list(stan_threads = TRUE, Stan_OpenCL = TRUE)),
+    list(STAN_THREADS = TRUE, STAN_OPENCL = TRUE)
+  )
+  expect_identical(
+    assert_valid_cpp_options(list(STAN_OPENCL = NULL)),
+    list(STAN_OPENCL = NULL)
+  )
 })
 
 test_that("assert_valid_cpp_options rejects a user header", {
@@ -58,6 +48,98 @@ test_that("assert_valid_cpp_options rejects a user header", {
       paste0(
         "The user header cannot be set through `cpp_options`. ",
         "Pass it with the `user_header` argument."
+      ),
+      fixed = TRUE
+    )
+  }
+})
+
+test_that("assert_valid_cpp_options rejects an unnamed assignment", {
+  expect_error(
+    assert_valid_cpp_options(list("FOO=1")),
+    "Write `list(FOO = \"1\")` instead of `\"FOO=1\"`.",
+    fixed = TRUE
+  )
+  expect_error(
+    assert_valid_cpp_options(list("foo=1")),
+    "Write `list(FOO = \"1\")` instead of `\"foo=1\"`.",
+    fixed = TRUE
+  )
+  expect_error(
+    assert_valid_cpp_options(list("STAN_THREADS=TRUE")),
+    "Write `list(STAN_THREADS = \"TRUE\")` instead of `\"STAN_THREADS=TRUE\"`.",
+    fixed = TRUE
+  )
+})
+
+test_that("assert_valid_cpp_options sends an unnamed entry to the right argument", {
+  for (entry in c("USER_HEADER=h", "user_header=h")) {
+    expect_error(
+      assert_valid_cpp_options(list(entry)),
+      "Pass it with the `user_header` argument: `user_header = \"h\"`.",
+      fixed = TRUE
+    )
+  }
+  for (entry in c("STANCFLAGS=--O1", "STANCFLAGS += --O1")) {
+    expect_error(
+      assert_valid_cpp_options(list(entry)),
+      "Pass stanc flags with the `stanc_options` argument.",
+      fixed = TRUE
+    )
+  }
+})
+
+test_that("assert_valid_cpp_options sends makefile syntax to make/local", {
+  for (entry in c("CXXFLAGS += -x", "CXXFLAGS+=-x")) {
+    expect_error(
+      assert_valid_cpp_options(list(entry)),
+      paste0(
+        "`\"", entry, "\"` is makefile syntax and cannot be passed through ",
+        "`cpp_options`. To set it in `make/local` use ",
+        "`cmdstan_make_local(cpp_options = list(\"", entry, "\"))`."
+      ),
+      fixed = TRUE
+    )
+  }
+  for (entry in c("-j4", "-f other.mk", "--eval=STAN_OPENCL=1")) {
+    expect_error(
+      assert_valid_cpp_options(list(entry)),
+      paste0(
+        "Make flags cannot be passed through `cpp_options`. Set them in ",
+        "`make/local` with `cmdstan_make_local()`, for example ",
+        "`MAKEFLAGS += -j4`."
+      ),
+      fixed = TRUE
+    )
+  }
+  expect_error(
+    assert_valid_cpp_options(list(1)),
+    "`cpp_options` entries must be named: `list(NAME = value)`.",
+    fixed = TRUE
+  )
+})
+
+test_that("assert_valid_cpp_options requires Make variable names", {
+  for (options in list(list("CXXFLAGS+" = "-x"), list("2FOO" = 1))) {
+    expect_error(
+      assert_valid_cpp_options(options),
+      paste0(
+        "`cpp_options` names must be Make variable names, made of letters, ",
+        "digits and underscores and not starting with a digit. `",
+        names(options), "` is not one."
+      ),
+      fixed = TRUE
+    )
+  }
+})
+
+test_that("assert_valid_cpp_options rejects a named STANCFLAGS", {
+  for (options in list(list(STANCFLAGS = "--O1"), list(stancflags = "--O1"))) {
+    expect_error(
+      assert_valid_cpp_options(options),
+      paste0(
+        "`STANCFLAGS` cannot be set through `cpp_options`. ",
+        "Pass stanc flags with the `stanc_options` argument."
       ),
       fixed = TRUE
     )
@@ -151,29 +233,36 @@ test_that("cpp option checks do not use partial matching", {
   )
 })
 
+test_that("option comparison keeps the Stan version like any other option", {
+  expect_true(cpp_options_disagree(
+    list(STAN_VERSION = "9.9"),
+    list(STAN_VERSION = "8.8")
+  ))
+})
+
 test_that("exe_info cpp_options comparison works", {
   exe_info_all_flags_off <- exe_info_style_cpp_options(list())
-  exe_info_all_flags_off[["stan_version"]] <- "35.0.0"
+  exe_info_all_flags_off[["STAN_VERSION"]] <- "35.0.0"
 
   expect_true(exe_info_reflects_cpp_options(
     exe_info_all_flags_off,
     list()
   ))
   expect_true(exe_info_reflects_cpp_options(
-    list(stan_opencl = FALSE),
-    list(stan_opencl = NULL)
+    list(STAN_OPENCL = FALSE),
+    list(STAN_OPENCL = NULL)
+  ))
+  expect_true(exe_info_reflects_cpp_options(
+    list(STAN_OPENCL = FALSE),
+    list(STAN_OPENCL = FALSE)
   ))
   expect_not_true(exe_info_reflects_cpp_options(
-    list(stan_opencl = FALSE),
-    list(stan_opencl = FALSE)
+    list(STAN_OPENCL = FALSE, STAN_THREADS = FALSE),
+    list(STAN_OPENCL = NULL, STAN_THREADS = TRUE)
   ))
   expect_not_true(exe_info_reflects_cpp_options(
-    list(stan_opencl = FALSE, stan_threads = FALSE),
-    list(stan_opencl = NULL, stan_threads = TRUE)
-  ))
-  expect_not_true(exe_info_reflects_cpp_options(
-    list(stan_opencl = FALSE, stan_threads = FALSE),
-    list(stan_opencl = NULL, stan_threads = TRUE, EXTRA_ARG = TRUE)
+    list(STAN_OPENCL = FALSE, STAN_THREADS = FALSE),
+    list(STAN_OPENCL = NULL, STAN_THREADS = TRUE, EXTRA_ARG = TRUE)
   ))
 
   # no exe_info -> no recompile based on cpp info
@@ -184,39 +273,35 @@ test_that("exe_info cpp_options comparison works", {
 })
 
 test_that("exe_info comparison reads cpp_options the way make does", {
-  # Upper-case, as model_compile_info() reports it.
+  # Upper-case, as model_compile_info() reports it and as
+  # assert_valid_cpp_options() hands the request over.
   disabled <- list(STAN_THREADS = FALSE)
-
-  # An unnamed raw assignment is as much a request as a named one; reading the
-  # list's names cannot see it.
-  expect_not_true(
-    exe_info_reflects_cpp_options(disabled, list("STAN_THREADS=TRUE"))
-  )
 
   # Every duplicate reaches make and a makefile takes the last, so the order
   # decides which of these agrees.
   expect_true(exe_info_reflects_cpp_options(
     disabled,
-    list(stan_threads = TRUE, stan_threads = NULL)
+    list(STAN_THREADS = TRUE, STAN_THREADS = NULL)
   ))
   expect_not_true(exe_info_reflects_cpp_options(
     disabled,
-    list(stan_threads = NULL, stan_threads = TRUE)
+    list(STAN_THREADS = NULL, STAN_THREADS = TRUE)
   ))
 
-  # A vector value expands into one assignment per element. This used to error.
+  # A vector value expands into one assignment per element, and the last one
+  # decides.
   expect_not_true(exe_info_reflects_cpp_options(
     disabled,
-    list(stan_threads = c(TRUE, FALSE))
+    list(STAN_THREADS = c(FALSE, TRUE))
   ))
 
-  # Non-empty enables whatever the value, so FALSE does not ask for "off".
-  expect_not_true(
-    exe_info_reflects_cpp_options(disabled, list(stan_threads = FALSE))
+  # FALSE reaches make as an empty assignment, so it asks for the option off.
+  expect_true(
+    exe_info_reflects_cpp_options(disabled, list(STAN_THREADS = FALSE))
   )
 
   # An option the binary cannot report is unverifiable, not a mismatch.
   expect_true(
-    exe_info_reflects_cpp_options(disabled, list(my_custom_make_flag = TRUE))
+    exe_info_reflects_cpp_options(disabled, list(MY_CUSTOM_MAKE_FLAG = TRUE))
   )
 })

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -21,10 +21,12 @@ test_that("a user header in cpp_options is rejected", {
   stan_file <- testing_stan_file("bernoulli_external")
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
   model <- cmdstan_model(stan_file, compile = FALSE)
+  # The message writes the path as an R literal, so a Windows path shows its
+  # backslashes doubled.
   expected <- paste0(
     "The user header cannot be set through `cpp_options`. ",
-    "Pass it with the `user_header` argument: `user_header = \"",
-    user_header, "\"`."
+    "Pass it with the `user_header` argument: `user_header = ",
+    encodeString(user_header, quote = '"'), "`."
   )
 
   for (option_name in c("USER_HEADER", "user_header", "User_Header")) {

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -16,45 +16,30 @@ local_external_model <- function(.local_envir = parent.frame()) {
   stan_file
 }
 
-user_header_routes <- function(header) {
-  list(
-    list(user_header = header),
-    list(cpp_options = list(USER_HEADER = header)),
-    list(cpp_options = list(user_header = header))
-  )
-}
-
 # Keep mocked compilation tests above the toolchain skip below.
-test_that("cpp_options user headers allow undefined functions", {
+test_that("a user header in cpp_options is rejected", {
   stan_file <- testing_stan_file("bernoulli_external")
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
-  received_stancflags <- list()
-  local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
-    get_standalone_hpp = function(stan_file, stancflags) {
-      received_stancflags <<- append(received_stancflags, list(stancflags))
-      ""
-    }
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  expected <- paste0(
+    "The user header cannot be set through `cpp_options`. ",
+    "Pass it with the `user_header` argument: `user_header = \"",
+    user_header, "\"`."
   )
 
-  for (option_name in c("USER_HEADER", "user_header")) {
-    model <- cmdstan_model(stan_file, compile = FALSE)
-    model$compile(
-      cpp_options = setNames(list(user_header), option_name),
-      force_recompile = TRUE,
-      dry_run = TRUE
+  for (option_name in c("USER_HEADER", "user_header", "User_Header")) {
+    cpp_options <- setNames(list(user_header), option_name)
+    expect_error(
+      cmdstan_model(stan_file, compile = FALSE, cpp_options = cpp_options),
+      expected,
+      fixed = TRUE
+    )
+    expect_error(
+      model$compile(cpp_options = cpp_options),
+      expected,
+      fixed = TRUE
     )
   }
-
-  expect_length(received_stancflags, 4)
-  expect_equal(
-    vapply(
-      received_stancflags,
-      function(x) "--allow-undefined" %in% x,
-      logical(1)
-    ),
-    rep(TRUE, 4)
-  )
 })
 
 test_that("compile() reuses the user header from the previous compilation", {
@@ -86,17 +71,15 @@ test_that("compile() reuses the user header from the previous compilation", {
     code = model$compile(force_recompile = TRUE)
   )
   expect_true(model$.__enclos_env__$private$using_user_header_)
-  expect_equal(
-    model$cpp_options()[["USER_HEADER"]],
-    wsl_safe_path(absolute_path(user_header))
-  )
+  expect_equal(model$user_header(), resolve_path(user_header))
+  expect_false("USER_HEADER" %in% names(model$cpp_options()))
   expect_equal(
     vapply(received_stancflags, function(x) "--allow-undefined" %in% x, logical(1)),
     rep(TRUE, 2)
   )
 })
 
-test_that("a no-op compile preserves a header supplied via cpp_options", {
+test_that("a no-op compile preserves the user header", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli_external.stan")
   file.copy(testing_stan_file("bernoulli_external"), stan_file)
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
@@ -106,31 +89,19 @@ test_that("a no-op compile preserves a header supplied via cpp_options", {
   )
   model <- cmdstan_model(stan_file, compile = FALSE)
 
-  # The lowercase spelling is the telling one: a bare recompile re-derives the
-  # header under the USER_HEADER spelling, so only this one shows whether the
-  # no-op path rebuilt the recorded options or left them alone.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
-    code = model$compile(
-      cpp_options = list(user_header = user_header),
-      force_recompile = TRUE
-    )
+    code = model$compile(user_header = user_header, force_recompile = TRUE)
   )
-  expect_equal(
-    model$cpp_options()[["user_header"]],
-    wsl_safe_path(absolute_path(user_header))
-  )
+  expect_equal(model$user_header(), resolve_path(user_header))
 
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
     code = expect_no_mock_compile(model$compile())
   )
-  expect_equal(
-    model$cpp_options()[["user_header"]],
-    wsl_safe_path(absolute_path(user_header))
-  )
+  expect_equal(model$user_header(), resolve_path(user_header))
 })
 
 test_that("compile() uses a user header supplied to cmdstan_model()", {
@@ -156,10 +127,7 @@ test_that("compile() uses a user header supplied to cmdstan_model()", {
     code = model$compile(force_recompile = TRUE)
   )
 
-  expect_equal(
-    model$cpp_options()[["USER_HEADER"]],
-    wsl_safe_path(absolute_path(user_header))
-  )
+  expect_equal(model$user_header(), resolve_path(user_header))
   expect_equal(
     vapply(received_stancflags, function(x) "--allow-undefined" %in% x, logical(1)),
     rep(TRUE, 2)
@@ -184,57 +152,41 @@ test_that("a header configured over a current executable does not rebuild", {
   Sys.setFileTime(exe, Sys.time())
 
   # A fresh object cannot know which header built an existing executable, so it
-  # keeps the executable without recording the requested header.
-  for (route in user_header_routes(header)) {
-    model <- do.call(
-      cmdstan_model,
-      c(list(stan_file, compile = FALSE), route)
-    )
-    with_mocked_cli(
-      compile_ret = list(status = 0),
-      info_ret = list(status = 1),
-      code = expect_no_mock_compile(model$compile())
-    )
-    expect_null(model$cpp_options()[["USER_HEADER"]])
-    expect_null(model$cpp_options()[["user_header"]])
-    # Stanc still uses the configured header.
-    expect_true(model$.__enclos_env__$private$using_user_header_)
-  }
+  # keeps the executable without rebuilding against the requested header.
+  model <- cmdstan_model(stan_file, compile = FALSE, user_header = header)
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_no_mock_compile(model$compile())
+  )
+  expect_equal(model$user_header(), resolve_path(header))
+  # Stanc still uses the configured header.
+  expect_true(model$.__enclos_env__$private$using_user_header_)
 })
 
-test_that("cmdstan_model() records a user header from every supply route", {
+test_that("cmdstan_model() records a user header", {
   header <- withr::local_tempfile(lines = "", fileext = ".hpp")
 
-  for (route in user_header_routes(header)) {
-    model <- do.call(
-      cmdstan_model,
-      c(list(testing_stan_file("bernoulli_external"), compile = FALSE), route)
-    )
-    private <- model$.__enclos_env__$private
-    expect_equal(private$user_header_, resolve_path(header))
-    expect_true(private$using_user_header_)
-    expect_false(private$user_header_dirty_)
-  }
+  model <- cmdstan_model(
+    testing_stan_file("bernoulli_external"),
+    compile = FALSE,
+    user_header = header
+  )
+  private <- model$.__enclos_env__$private
+  expect_equal(private$user_header_, resolve_path(header))
+  expect_true(private$using_user_header_)
+  expect_false(private$user_header_dirty_)
 })
 
 test_that("cmdstan_model() honours an explicit user_header = NULL", {
-  header <- withr::local_tempfile(lines = "", fileext = ".hpp")
-
-  expect_warning(
-    model <- cmdstan_model(
-      testing_stan_file("bernoulli_external"),
-      compile = FALSE,
-      user_header = NULL,
-      cpp_options = list(USER_HEADER = header)
-    ),
-    "User header specified both"
+  model <- cmdstan_model(
+    testing_stan_file("bernoulli_external"),
+    compile = FALSE,
+    user_header = NULL
   )
 
-  private <- model$.__enclos_env__$private
-  expect_null(private$user_header_)
-  expect_false(private$using_user_header_)
-  expect_null(private$precompile_cpp_options_[["USER_HEADER"]])
-  expect_null(private$precompile_cpp_options_[["user_header"]])
+  expect_null(model$user_header())
+  expect_false(model$.__enclos_env__$private$using_user_header_)
 })
 
 test_that("cmdstan_model() rejects an empty user header", {
@@ -250,7 +202,7 @@ test_that("cmdstan_model() rejects an empty user header", {
   expect_error(model$compile(user_header = character(0)), "user_header")
 })
 
-test_that("a relative cpp_options user header survives a directory change", {
+test_that("a relative user header survives a directory change", {
   model_dir <- withr::local_tempdir()
   file.copy(testing_stan_file("bernoulli_external"), model_dir)
   writeLines("", file.path(model_dir, "header.hpp"))
@@ -261,12 +213,12 @@ test_that("a relative cpp_options user header survives a directory change", {
     cmdstan_model(
       "bernoulli_external.stan",
       compile = FALSE,
-      cpp_options = list(USER_HEADER = "header.hpp")
+      user_header = "header.hpp"
     )
   )
 
   expect_equal(
-    normalizePath(model$.__enclos_env__$private$user_header_),
+    normalizePath(model$user_header()),
     normalizePath(file.path(model_dir, "header.hpp"))
   )
   # The compile happens from the test's own working directory.
@@ -305,10 +257,7 @@ test_that("a bare retry after a failed compile keeps the newly supplied header",
   )
   expect_equal(private$user_header_, resolve_path(h2))
   expect_false(private$user_header_dirty_)
-  expect_equal(
-    model$cpp_options()[["USER_HEADER"]],
-    wsl_safe_path(resolve_path(h2))
-  )
+  expect_equal(model$user_header(), resolve_path(h2))
 })
 
 test_that("a header that does not exist is still recorded as the request", {
@@ -333,10 +282,7 @@ test_that("a header that does not exist is still recorded as the request", {
     info_ret = list(status = 1),
     code = expect_mock_compile(model$compile())
   )
-  expect_equal(
-    model$cpp_options()[["USER_HEADER"]],
-    wsl_safe_path(resolve_path(header))
-  )
+  expect_equal(model$user_header(), resolve_path(header))
 })
 
 test_that("changing the user header forces compilation", {
@@ -360,94 +306,30 @@ test_that("changing the user header forces compilation", {
     info_ret = list(status = 1),
     code = expect_mock_compile(model$compile(user_header = h2))
   )
-  expect_equal(
-    model$cpp_options()[["USER_HEADER"]],
-    wsl_safe_path(resolve_path(h2))
-  )
+  expect_equal(model$user_header(), resolve_path(h2))
 })
 
-test_that("user_header = NULL clears a header from every supply route", {
+test_that("user_header = NULL clears a compiled header", {
   header <- withr::local_tempfile(lines = "", fileext = ".hpp")
   local_mocked_stanc()
 
-  for (route in user_header_routes(header)) {
-    model <- cmdstan_model(local_external_model(), compile = FALSE)
-    private <- model$.__enclos_env__$private
-    with_mocked_cli(
-      compile_ret = list(status = 0),
-      info_ret = list(status = 1),
-      code = do.call(model$compile, c(route, list(force_recompile = TRUE)))
-    )
-    expect_true(private$using_user_header_)
-
-    # Clearing a compiled header must force a rebuild.
-    with_mocked_cli(
-      compile_ret = list(status = 0),
-      info_ret = list(status = 1),
-      code = expect_mock_compile(model$compile(user_header = NULL))
-    )
-    expect_null(private$user_header_)
-    expect_false(private$using_user_header_)
-    expect_null(model$cpp_options()[["USER_HEADER"]])
-    expect_null(model$cpp_options()[["user_header"]])
-  }
-})
-
-test_that("duplicate headers of one spelling take the last, as make does", {
-  first <- withr::local_tempfile(lines = "", fileext = ".hpp")
-  second <- withr::local_tempfile(lines = "", fileext = ".hpp")
-
-  # Use the last duplicate and remove every header entry before calling make.
-  for (spelling in c("USER_HEADER", "user_header")) {
-    duplicated <- structure(
-      list(first, second),
-      names = c(spelling, spelling)
-    )
-    resolved <- resolve_user_header(NULL, FALSE, duplicated)
-    expect_equal(resolved$user_header, second)
-    expect_length(resolved$cpp_options, 0)
-  }
-
-  # USER_HEADER still takes precedence across spellings.
-  mixed <- structure(
-    list(first, second, first),
-    names = c("user_header", "USER_HEADER", "user_header")
+  model <- cmdstan_model(local_external_model(), compile = FALSE)
+  private <- model$.__enclos_env__$private
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(user_header = header, force_recompile = TRUE)
   )
-  resolved <- resolve_user_header(NULL, FALSE, mixed)
-  expect_equal(resolved$user_header, second)
-  expect_length(resolved$cpp_options, 0)
-})
+  expect_true(private$using_user_header_)
 
-test_that("a NULL header entry clears a persisted one rather than being ignored", {
-  persisted <- withr::local_tempfile(lines = "", fileext = ".hpp")
-  first <- withr::local_tempfile(lines = "", fileext = ".hpp")
-
-  # A NULL entry emits USER_HEADER= and clears any previous header.
-  for (spelling in c("USER_HEADER", "user_header")) {
-    single <- structure(list(NULL), names = spelling)
-    resolved <- resolve_user_header(NULL, FALSE, single, previous = persisted)
-    expect_null(resolved$user_header)
-    expect_length(resolved$cpp_options, 0)
-
-    duplicated <- structure(list(first, NULL), names = c(spelling, spelling))
-    resolved <- resolve_user_header(NULL, FALSE, duplicated, previous = persisted)
-    expect_null(resolved$user_header)
-    expect_length(resolved$cpp_options, 0)
-  }
-
-  # A non-NULL last occurrence still wins, so this is not just "any NULL clears".
-  kept <- structure(list(NULL, first), names = c("USER_HEADER", "USER_HEADER"))
-  resolved <- resolve_user_header(NULL, FALSE, kept, previous = persisted)
-  expect_equal(resolved$user_header, first)
-
-  # An entry that clears is still an entry, so it conflicts with the argument.
-  resolved <- resolve_user_header(
-    first,
-    TRUE,
-    list(USER_HEADER = NULL),
-    previous = persisted
+  # Clearing a compiled header must force a rebuild.
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = expect_mock_compile(model$compile(user_header = NULL))
   )
-  expect_identical(resolved$conflict, "argument")
+  expect_null(model$user_header())
+  expect_false(private$using_user_header_)
 })
 
 skip_if(os_is_macos())
@@ -512,8 +394,7 @@ test_that("cmdstan_model works with user_header with mock", {
       mod_2 <- cmdstan_model(
         stan_file = testing_stan_file("bernoulli_external"),
         exe_file = file_that_doesnt_exist,
-        cpp_options = list(USER_HEADER = tmpfile),
-        stanc_options = list("allow-undefined")
+        user_header = tmpfile
       )
     })
   )
@@ -541,58 +422,16 @@ test_that("cmdstan_model works with user_header with mock", {
     })
   )
 
-  Sys.setFileTime(mod$exe_file(), header_mtime + 10) # make exe newer than header
-
-  # Alternative spec of user header
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(),
-    code = expect_no_mock_compile({
-      mod$compile(
-        quiet = TRUE,
-        cpp_options = list(user_header = tmpfile),
-        dry_run = TRUE
-      )
-    })
-  )
-
-  # Error/warning messages
+  # Error messages
   with_mocked_cli(
     compile_ret = list(status = 1),
     info_ret = list(),
     code = expect_error(
       cmdstan_model(
         stan_file = testing_stan_file("bernoulli_external"),
-        cpp_options = list(USER_HEADER = "non_existent.hpp"),
-        stanc_options = list("allow-undefined")
+        user_header = "non_existent.hpp"
       ),
       "header file '[^']*' does not exist"
-    )
-  )
-
-  with_mocked_cli(
-    compile_ret = list(status = 1),
-    info_ret = list(),
-    code = expect_warning(
-      cmdstan_model(
-        stan_file = testing_stan_file("bernoulli_external"),
-        cpp_options = list(USER_HEADER = tmpfile, user_header = tmpfile),
-        dry_run = TRUE
-      ),
-      "User header specified both"
-    )
-  )
-  with_mocked_cli(
-    compile_ret = list(status = 1),
-    info_ret = list(),
-    code = expect_warning(
-      cmdstan_model(
-        stan_file = testing_stan_file("bernoulli_external"),
-        user_header = tmpfile,
-        cpp_options = list(USER_HEADER = tmpfile),
-        dry_run = TRUE
-      ),
-      "User header specified both"
     )
   )
 })
@@ -601,98 +440,31 @@ test_that("wsl path conversion is done as expected", {
   tmp_file <- withr::local_tempfile(lines = hpp, fileext = ".hpp")
   local_mocked_stanc()
 
-  routes <- user_header_routes(tmp_file)
-  expected_names <- c("USER_HEADER", "USER_HEADER", "user_header")
-  for (i in seq_along(routes)) {
-    with_mocked_cli(
-      compile_ret = list(status = 0),
-      info_ret = list(status = 1),
-      code = {
-        mod <- do.call(
-          cmdstan_model,
-          c(list(stan_file = local_external_model()), routes[[i]])
-        )
+  # Capture the flags handed to make the way with_mocked_cli() does.
+  make_args <- NULL
+  local_mocked_bindings(
+    wsl_compatible_run = function(command, args, ...) {
+      if (!is.null(command)
+          && command == make_cmd()
+          && !is.null(args)
+          && startsWith(basename(args[1]), "model-")) {
+        make_args <<- args
+        mock_exe <- wsl_safe_path(args[1], revert = TRUE)
+        writeLines("mock executable", mock_exe)
+        Sys.chmod(mock_exe, "0755", use_umask = FALSE)
+        list(status = 0)
+      } else if (!is.null(args) && args[1] == "info") {
+        list(status = 1)
+      } else {
+        real_wcr(command = command, args = args, ...)
       }
-    )
-
-    expected_name <- expected_names[[i]]
-    other_name <- setdiff(c("USER_HEADER", "user_header"), expected_name)
-    expect_equal(mod$cpp_options()[[expected_name]], w_path(tmp_file))
-    expect_null(mod$cpp_options()[[other_name]])
-  }
-})
-
-test_that("user_header precedence order is correct", {
-  tmp_files <- sapply(1:3, function(n) withr::local_tempfile(
-    lines = hpp,
-    fileext = ".hpp",
-    .local_envir = parent.frame(3)
-  ))
-
-  local_mocked_stanc()
-  # Successful compiles record the selected header and drop ignored spellings.
-
-  # The explicit argument wins.
-  mod <- cmdstan_model(local_external_model(), compile = FALSE)
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = expect_warning({
-      mod$compile(
-        user_header = tmp_files[1],
-        cpp_options = list(
-          USER_HEADER = tmp_files[2],
-          user_header = tmp_files[3]
-        ),
-        force_recompile = TRUE
-      )
-    }, "User header specified both")
+    },
+    .package = "cmdstanr"
   )
-  expect_equal(
-    match(!!(mod$cpp_options()[['USER_HEADER']]), w_path(tmp_files)),
-    1
-  )
-  expect_null(mod$cpp_options()[['user_header']])
 
-  # USER_HEADER wins over user_header.
-  mod <- cmdstan_model(local_external_model(), compile = FALSE)
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = expect_warning({
-      mod$compile(
-        cpp_options = list(
-          USER_HEADER = tmp_files[2],
-          user_header = tmp_files[3]
-        ),
-        force_recompile = TRUE
-      )
-    }, "User header specified both")
-  )
-  expect_equal(
-    match(!!(mod$cpp_options()[['USER_HEADER']]), w_path(tmp_files)),
-    2
-  )
-  expect_null(mod$cpp_options()[['user_header']])
+  mod <- cmdstan_model(local_external_model(), user_header = tmp_file)
 
-  # Option order does not change precedence.
-  mod <- cmdstan_model(local_external_model(), compile = FALSE)
-  with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = expect_warning({
-      mod$compile(
-        cpp_options = list(
-          user_header = tmp_files[3],
-          USER_HEADER = tmp_files[2]
-        ),
-        force_recompile = TRUE
-      )
-    }, "User header specified both")
-  )
-  expect_equal(
-    match(!!(mod$cpp_options()[['USER_HEADER']]), w_path(tmp_files)),
-    2
-  )
-  expect_null(mod$cpp_options()[['user_header']])
+  expect_true(paste0("USER_HEADER=", w_path(tmp_file)) %in% make_args)
+  expect_equal(mod$user_header(), resolve_path(tmp_file))
+  expect_false("USER_HEADER" %in% names(mod$cpp_options()))
 })

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -1,6 +1,6 @@
 local_mocked_stanc <- function(.local_envir = parent.frame()) {
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) "",
     .env = .local_envir
   )
@@ -48,7 +48,7 @@ test_that("compile() reuses the user header from the previous compilation", {
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
   received_stancflags <- list()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) {
       received_stancflags <<- append(received_stancflags, list(stancflags))
       ""
@@ -83,7 +83,7 @@ test_that("a no-op compile preserves the user header", {
   file.copy(testing_stan_file("bernoulli_external"), stan_file)
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) ""
   )
   model <- cmdstan_model(stan_file, compile = FALSE)
@@ -107,7 +107,7 @@ test_that("compile() uses a user header supplied to cmdstan_model()", {
   user_header <- withr::local_tempfile(lines = "", fileext = ".hpp")
   received_stancflags <- list()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) {
       received_stancflags <<- append(received_stancflags, list(stancflags))
       ""

--- a/tests/testthat/test-model-compile-user_header.R
+++ b/tests/testthat/test-model-compile-user_header.R
@@ -55,14 +55,14 @@ test_that("compile() reuses the user header from the previous compilation", {
     }
   )
   model <- cmdstan_model(stan_file, compile = FALSE)
-  expect_false(model$.__enclos_env__$private$using_user_header_)
+  expect_null(model$user_header())
 
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 0),
     code = model$compile(user_header = user_header, force_recompile = TRUE)
   )
-  expect_true(model$.__enclos_env__$private$using_user_header_)
+  expect_equal(model$user_header(), resolve_path(user_header))
 
   received_stancflags <- list()
   with_mocked_cli(
@@ -70,7 +70,6 @@ test_that("compile() reuses the user header from the previous compilation", {
     info_ret = list(status = 0),
     code = model$compile(force_recompile = TRUE)
   )
-  expect_true(model$.__enclos_env__$private$using_user_header_)
   expect_equal(model$user_header(), resolve_path(user_header))
   expect_false("USER_HEADER" %in% names(model$cpp_options()))
   expect_equal(
@@ -160,8 +159,6 @@ test_that("a header configured over a current executable does not rebuild", {
     code = expect_no_mock_compile(model$compile())
   )
   expect_equal(model$user_header(), resolve_path(header))
-  # Stanc still uses the configured header.
-  expect_true(model$.__enclos_env__$private$using_user_header_)
 })
 
 test_that("cmdstan_model() records a user header", {
@@ -174,7 +171,6 @@ test_that("cmdstan_model() records a user header", {
   )
   private <- model$.__enclos_env__$private
   expect_equal(private$user_header_, resolve_path(header))
-  expect_true(private$using_user_header_)
   expect_false(private$user_header_dirty_)
 })
 
@@ -186,7 +182,6 @@ test_that("cmdstan_model() honours an explicit user_header = NULL", {
   )
 
   expect_null(model$user_header())
-  expect_false(model$.__enclos_env__$private$using_user_header_)
 })
 
 test_that("cmdstan_model() rejects an empty user header", {
@@ -272,7 +267,6 @@ test_that("a header that does not exist is still recorded as the request", {
     "does not exist"
   )
   expect_equal(private$user_header_, resolve_path(header))
-  expect_true(private$using_user_header_)
   expect_true(private$user_header_dirty_)
 
   # A bare retry once the header exists must build against it.
@@ -314,13 +308,12 @@ test_that("user_header = NULL clears a compiled header", {
   local_mocked_stanc()
 
   model <- cmdstan_model(local_external_model(), compile = FALSE)
-  private <- model$.__enclos_env__$private
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
     code = model$compile(user_header = header, force_recompile = TRUE)
   )
-  expect_true(private$using_user_header_)
+  expect_equal(model$user_header(), resolve_path(header))
 
   # Clearing a compiled header must force a rebuild.
   with_mocked_cli(
@@ -329,7 +322,6 @@ test_that("user_header = NULL clears a compiled header", {
     code = expect_mock_compile(model$compile(user_header = NULL))
   )
   expect_null(model$user_header())
-  expect_false(private$using_user_header_)
 })
 
 skip_if(os_is_macos())

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -229,7 +229,7 @@ test_that("$compile() reuses include paths from the previous compilation", {
 
   received_stancflags <- list()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) {
       received_stancflags <<- append(received_stancflags, list(stancflags))
       ""
@@ -273,7 +273,7 @@ test_that("$compile() doesn't reuse cpp and stanc options from the previous comp
   model <- cmdstan_model(stan_file, compile = FALSE)
   received_stancflags <- list()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) {
       received_stancflags <<- append(received_stancflags, list(stancflags))
       ""
@@ -324,7 +324,7 @@ test_that("$compile() doesn't reuse cpp and stanc options supplied to cmdstan_mo
   )
   received_stancflags <- list()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) {
       received_stancflags <<- append(received_stancflags, list(stancflags))
       ""
@@ -443,7 +443,7 @@ test_that("compile() with dry_run = TRUE doesn't refresh cached model state", {
   code_before <- model$code()
   variables_before <- model$variables()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) ""
   )
 
@@ -1521,11 +1521,11 @@ test_that("STANCFLAGS from get_cmdstan_flags() are included in compile output", 
   local_reproducible_output()
   real_get_cmdstan_flags <- get_cmdstan_flags
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) {
+    get_cmdstan_flags = function(flag_name, ...) {
       if (identical(flag_name, "STANCFLAGS")) {
         c("--O1", "--warn-pedantic")
       } else {
-        real_get_cmdstan_flags(flag_name)
+        real_get_cmdstan_flags(flag_name, ...)
       }
     }
   )
@@ -1583,7 +1583,7 @@ test_that("include paths in make/local STANCFLAGS stop the build", {
   local_flags <- NULL
   received_stancflags <- list()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) {
+    get_cmdstan_flags = function(flag_name, ...) {
       if (identical(flag_name, "STANCFLAGS")) local_flags else character()
     },
     get_standalone_hpp = function(stan_file, stancflags) {
@@ -1618,7 +1618,7 @@ test_that("a flag the call emits reaches stanc once when make/local sets it too"
   local_flags <- NULL
   received_stancflags <- list()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) {
+    get_cmdstan_flags = function(flag_name, ...) {
       if (identical(flag_name, "STANCFLAGS")) local_flags else character()
     },
     get_standalone_hpp = function(stan_file, stancflags) {
@@ -1756,7 +1756,7 @@ test_that("compile() passes unquoted named stanc options to direct calls", {
   model <- cmdstan_model(stan_file, compile = FALSE)
   received_stancflags <- list()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) {
       received_stancflags <<- append(received_stancflags, list(stancflags))
       ""
@@ -1822,7 +1822,7 @@ test_that("compile() detects stan_opencl without case or partial matching", {
   model <- cmdstan_model(stan_file, compile = FALSE)
   received_stancflags <- list()
   local_mocked_bindings(
-    get_cmdstan_flags = function(flag_name) character(),
+    get_cmdstan_flags = function(flag_name, ...) character(),
     get_standalone_hpp = function(stan_file, stancflags) {
       received_stancflags <<- append(received_stancflags, list(stancflags))
       ""
@@ -1859,6 +1859,36 @@ test_that("compile() detects stan_opencl without case or partial matching", {
     ),
     rep(FALSE, length(received_stancflags))
   )
+})
+
+test_that("compile() resolves make/local STANCFLAGS with the call's cpp_options applied", {
+  local_cmdstan_make_local(list(STAN_OPENCL = TRUE))
+  stan_file <- testing_stan_file("bernoulli")
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  received <- list()
+  local_mocked_bindings(
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received <<- append(received, list(stancflags))
+      ""
+    }
+  )
+  opencl_count <- function() {
+    vapply(received, function(x) sum(x == "--use-opencl"), integer(1))
+  }
+
+  model$compile(cpp_options = list(stan_opencl = FALSE), force_recompile = TRUE, dry_run = TRUE)
+  expect_length(received, 2)
+  expect_equal(opencl_count(), c(0L, 0L))
+
+  received <- list()
+  model$compile(cpp_options = list(stan_opencl = TRUE), force_recompile = TRUE, dry_run = TRUE)
+  expect_length(received, 2)
+  expect_equal(opencl_count(), c(1L, 1L))
+
+  received <- list()
+  model$compile(force_recompile = TRUE, dry_run = TRUE)
+  expect_length(received, 2)
+  expect_equal(opencl_count(), c(1L, 1L))
 })
 
 test_that("compile() ignores directory chatter from MAKEFLAGS when reading STANCFLAGS", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -1138,6 +1138,69 @@ test_that("cmdstan_model works with exe_file", {
   )
 })
 
+test_that("build configuration cannot accompany an executable-only model", {
+  if (length(mod$exe_file()) == 0 || !file.exists(mod$exe_file())) {
+    mod$compile()
+  }
+  exe <- mod$exe_file()
+
+  expect_error(
+    cmdstan_model(exe_file = exe, cpp_options = list(stan_threads = TRUE)),
+    "`cpp_options` cannot be supplied",
+    fixed = TRUE
+  )
+  expect_error(
+    cmdstan_model(exe_file = exe, stanc_options = list("O1")),
+    "`stanc_options` cannot be supplied",
+    fixed = TRUE
+  )
+  expect_error(
+    cmdstan_model(exe_file = exe, include_paths = tempdir()),
+    "`include_paths` cannot be supplied",
+    fixed = TRUE
+  )
+  expect_error(
+    cmdstan_model(exe_file = exe, user_header = tempfile(fileext = ".hpp")),
+    "`user_header` cannot be supplied",
+    fixed = TRUE
+  )
+  expect_error(
+    cmdstan_model(exe_file = exe, force_recompile = TRUE),
+    "`force_recompile` cannot be supplied",
+    fixed = TRUE
+  )
+  expect_error(
+    cmdstan_model(exe_file = exe, force_recompile = FALSE),
+    "`force_recompile` cannot be supplied",
+    fixed = TRUE
+  )
+  expect_error(
+    cmdstan_model(exe_file = exe, pedantic = TRUE),
+    "`pedantic` cannot be supplied",
+    fixed = TRUE
+  )
+
+  mod_exe <- cmdstan_model(
+    exe_file = exe,
+    cpp_options = NULL,
+    stanc_options = NULL,
+    include_paths = NULL,
+    user_header = NULL,
+    force_recompile = NULL,
+    pedantic = NULL
+  )
+  expect_false(mod_exe$has_stan_file())
+
+  withr::local_options(cmdstanr_force_recompile = TRUE)
+  expect_no_error(cmdstan_model(exe_file = exe))
+
+  expect_error(
+    cmdstan_model(exe_file = file.path(tempdir(), "missing"), pedantic = TRUE),
+    "`pedantic` cannot be supplied",
+    fixed = TRUE
+  )
+})
+
 test_that("cmdstan_model created only with exe_file errors for check_syntax, code, ... ", {
   mod <- testing_model("bernoulli")
   mod_exe <- cmdstan_model(exe_file = mod$exe_file())

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -936,6 +936,33 @@ test_that("include_paths_stanc3_args() works", {
     ),
     c("--include-paths", paste0(path_1_compare, ",", path_2_compare))
   )
+
+  # Make expands the flag before the shell splits it, so a quote in the path is
+  # quoted for the shell and a dollar sign is doubled for Make (#1230). Direct
+  # calls still get the path as it is.
+  path_3 <- file.path(tempdir(), "the model's includes")
+  path_4 <- file.path(tempdir(), "costs $5")
+  for (p in c(path_3, path_4)) {
+    if (!dir.exists(p)) {
+      dir.create(p)
+    }
+  }
+  path_3 <- repair_path(path_3)
+  path_4 <- repair_path(path_4)
+  path_3_compare <- ifelse(os_is_wsl(), wsl_safe_path(path_3), path_3)
+  path_4_compare <- ifelse(os_is_wsl(), wsl_safe_path(path_4), path_4)
+  expect_equal(
+    include_paths_stanc3_args(c(path_3, path_4)),
+    paste0(
+      "--include-paths=",
+      "\"", path_3_compare, "\"", ",",
+      "'", sub("$5", "$$5", path_4_compare, fixed = TRUE), "'"
+    )
+  )
+  expect_equal(
+    include_paths_stanc3_args(c(path_3, path_4), direct_call = TRUE),
+    c("--include-paths", paste0(path_3_compare, ",", path_4_compare))
+  )
 })
 
 test_that("cpp_options work with settings in make/local", {
@@ -1345,6 +1372,28 @@ test_that("STANCFLAGS from get_cmdstan_flags() are included in compile output", 
     out_w_flags <- "bin/stanc --name=bernoulli_model[[:space:]]+--O1[[:space:]]+--warn-pedantic[[:space:]]+--o"
   }
   expect_output(print(out), out_w_flags)
+})
+
+test_that("quoted make/local STANCFLAGS values reach stanc as one argument (#1232)", {
+  # Nothing is mocked: the direct stanc call would fail with "too many
+  # arguments" if the value split at the space, and the make recipe echoes the
+  # requoted flag.
+  local_reproducible_output()
+  local_cmdstan_make_local(
+    cpp_options = list("STANCFLAGS += --filename-in-msg='/my dir/model.stan'")
+  )
+  expect_equal(get_cmdstan_flags("STANCFLAGS"), "--filename-in-msg=/my dir/model.stan")
+
+  stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
+  file.copy(stan_program, stan_file)
+  mod_local <- cmdstan_model(stan_file, compile = FALSE)
+  out <- utils::capture.output(mod_local$compile(quiet = FALSE, force_recompile = TRUE))
+  expect_true(file.exists(mod_local$exe_file()))
+  expect_output(
+    print(out),
+    "'--filename-in-msg=/my dir/model.stan'",
+    fixed = TRUE
+  )
 })
 
 test_that("stanc_options_to_args() builds direct and Make-quoted arguments", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -999,11 +999,9 @@ test_that("include_paths_stanc3_args() works", {
   }
   path_1 <- repair_path(path_1)
   path_1_compare <- ifelse(os_is_wsl(), wsl_safe_path(path_1), path_1)
-  path_1_make <- if (grepl(" ", path_1_compare, fixed = TRUE)) {
-    paste0("'", path_1_compare, "'")
-  } else {
-    path_1_compare
-  }
+  # tempdir() can hold characters that need quoting, such as the `~` in a
+  # Windows short path. The quoting rule itself is pinned below.
+  path_1_make <- make_shell_quote(path_1_compare)
   expect_equal(
     include_paths_stanc3_args(path_1),
     paste0("--include-paths=", path_1_make))
@@ -1030,28 +1028,42 @@ test_that("include_paths_stanc3_args() works", {
   # quoted for the shell and a dollar sign is doubled for Make (#1230). Direct
   # calls still get the path as it is.
   path_3 <- file.path(tempdir(), "the model's includes")
-  path_4 <- file.path(tempdir(), "costs $5")
-  for (p in c(path_3, path_4)) {
-    if (!dir.exists(p)) {
-      dir.create(p)
-    }
+  if (!dir.exists(path_3)) {
+    dir.create(path_3)
   }
   path_3 <- repair_path(path_3)
-  path_4 <- repair_path(path_4)
   path_3_compare <- ifelse(os_is_wsl(), wsl_safe_path(path_3), path_3)
-  path_4_compare <- ifelse(os_is_wsl(), wsl_safe_path(path_4), path_4)
   expect_equal(
-    include_paths_stanc3_args(c(path_3, path_4)),
-    paste0(
-      "--include-paths=",
-      "\"", path_3_compare, "\"", ",",
-      "'", sub("$5", "$$5", path_4_compare, fixed = TRUE), "'"
+    include_paths_stanc3_args(path_3),
+    paste0("--include-paths=", "\"", path_3_compare, "\"")
+  )
+  expect_equal(
+    include_paths_stanc3_args(path_3, direct_call = TRUE),
+    c("--include-paths", path_3_compare)
+  )
+
+  # The wsl launcher passes paths through a shell, so a `$` in the last path
+  # component does not survive the directory check under WSL. That limit is
+  # in the WSL path handling, not in the quoting tested here.
+  if (!os_is_wsl()) {
+    path_4 <- file.path(tempdir(), "costs $5")
+    if (!dir.exists(path_4)) {
+      dir.create(path_4)
+    }
+    path_4 <- repair_path(path_4)
+    expect_equal(
+      include_paths_stanc3_args(c(path_3, path_4)),
+      paste0(
+        "--include-paths=",
+        "\"", path_3, "\"", ",",
+        "'", sub("$5", "$$5", path_4, fixed = TRUE), "'"
+      )
     )
-  )
-  expect_equal(
-    include_paths_stanc3_args(c(path_3, path_4), direct_call = TRUE),
-    c("--include-paths", paste0(path_3_compare, ",", path_4_compare))
-  )
+    expect_equal(
+      include_paths_stanc3_args(c(path_3, path_4), direct_call = TRUE),
+      c("--include-paths", paste0(path_3, ",", path_4))
+    )
+  }
 })
 
 test_that("cpp_options work with settings in make/local", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -1891,6 +1891,38 @@ test_that("compile() resolves make/local STANCFLAGS with the call's cpp_options 
   expect_equal(opencl_count(), c(1L, 1L))
 })
 
+test_that("compile() resolves make/local STANCFLAGS with the call's user_header applied", {
+  local_cmdstan_make_local(list(
+    "ifeq ($(origin USER_HEADER),command line)",
+    "STANCFLAGS += --O1",
+    "else",
+    "STANCFLAGS += --O0",
+    "endif"
+  ), append = FALSE)
+  stan_file <- testing_stan_file("bernoulli")
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  header <- withr::local_tempfile(fileext = ".hpp")
+  writeLines("", header)
+  received <- list()
+  local_mocked_bindings(
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received <<- append(received, list(stancflags))
+      ""
+    }
+  )
+
+  model$compile(user_header = header, force_recompile = TRUE, dry_run = TRUE)
+  expect_length(received, 2)
+  expect_true(all(vapply(received, function(x) "--O1" %in% x, logical(1))))
+  expect_false(any(vapply(received, function(x) "--O0" %in% x, logical(1))))
+
+  received <- list()
+  model$compile(user_header = NULL, force_recompile = TRUE, dry_run = TRUE)
+  expect_length(received, 2)
+  expect_true(all(vapply(received, function(x) "--O0" %in% x, logical(1))))
+  expect_false(any(vapply(received, function(x) "--O1" %in% x, logical(1))))
+})
+
 test_that("compile() ignores directory chatter from MAKEFLAGS when reading STANCFLAGS", {
   withr::local_envvar(MAKEFLAGS = "-w -j 4")
   expect_compilation(mod, quiet = TRUE, force_recompile = TRUE)

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -1091,14 +1091,16 @@ test_that("cmdstan_model works with user_header", {
       stan_file = testing_stan_file("bernoulli_external"),
       user_header = tmpfile
   ))
+  expect_equal(mod$user_header(), resolve_path(tmpfile))
+  expect_false("USER_HEADER" %in% names(mod$cpp_options()))
   file.remove(mod$exe_file())
 
-  # No stanc_options here: a user header supplied via cpp_options must enable
-  # allow-undefined on its own (#1227)
+  # No stanc_options here: the user header argument must enable allow-undefined
+  # on its own (#1227)
   expect_call_compilation(
     mod_2 <- cmdstan_model(
       stan_file = testing_stan_file("bernoulli_external"),
-      cpp_options=list(USER_HEADER=tmpfile)
+      user_header = tmpfile
     )
   )
 
@@ -1108,35 +1110,13 @@ test_that("cmdstan_model works with user_header", {
   Sys.setFileTime(tmpfile, Sys.time() + 1) #touch file to trigger recompile
   expect_compilation(mod, quiet = TRUE, user_header = tmpfile)
 
-  # Alternative spec of user header
-  expect_no_recompilation(mod,
-    quiet = TRUE,
-    cpp_options = list(user_header = tmpfile),
-    dry_run = TRUE
-  )
-
-  # Error/warning messages
+  # Error messages
   expect_error(
     cmdstan_model(
       stan_file = testing_stan_file("bernoulli_external"),
-      cpp_options = list(USER_HEADER = "non_existent.hpp"),
-      stanc_options = list("allow-undefined")
+      user_header = "non_existent.hpp"
     ),
     "header file '[^']*' does not exist"
-  )
-
-  expect_warning(cmdstan_model(
-    stan_file = testing_stan_file("bernoulli_external"),
-    cpp_options = list(USER_HEADER = tmpfile, user_header = tmpfile),
-    dry_run = TRUE),
-    "User header specified both"
-  )
-  expect_warning(cmdstan_model(
-    stan_file = testing_stan_file("bernoulli_external"),
-    user_header = tmpfile,
-    cpp_options = list(USER_HEADER = tmpfile),
-    dry_run = TRUE),
-    "User header specified both"
   )
 })
 

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -286,13 +286,13 @@ test_that("$compile() doesn't reuse cpp and stanc options from the previous comp
     info_ret = list(status = 1),
     code = model$compile(
       cpp_options = list(stan_threads = TRUE),
-      stanc_options = list("warn-pedantic" = TRUE),
+      stanc_options = list("warn-uninitialized" = TRUE),
       force_recompile = TRUE
     )
   )
   expect_true(model$cpp_options()[["STAN_THREADS"]])
   expect_equal(
-    vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
+    vapply(received_stancflags, function(x) "--warn-uninitialized" %in% x, logical(1)),
     rep(TRUE, 2)
   )
 
@@ -305,7 +305,7 @@ test_that("$compile() doesn't reuse cpp and stanc options from the previous comp
 
   expect_null(model$cpp_options()[["STAN_THREADS"]])
   expect_equal(
-    vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
+    vapply(received_stancflags, function(x) "--warn-uninitialized" %in% x, logical(1)),
     rep(FALSE, 2)
   )
 })
@@ -320,7 +320,7 @@ test_that("$compile() doesn't reuse cpp and stanc options supplied to cmdstan_mo
     stan_file,
     compile = FALSE,
     cpp_options = list(stan_threads = TRUE),
-    stanc_options = list("warn-pedantic" = TRUE)
+    stanc_options = list("warn-uninitialized" = TRUE)
   )
   received_stancflags <- list()
   local_mocked_bindings(
@@ -338,7 +338,7 @@ test_that("$compile() doesn't reuse cpp and stanc options supplied to cmdstan_mo
   )
   expect_true(model$cpp_options()[["STAN_THREADS"]])
   expect_equal(
-    vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
+    vapply(received_stancflags, function(x) "--warn-uninitialized" %in% x, logical(1)),
     rep(TRUE, 2)
   )
 
@@ -351,31 +351,26 @@ test_that("$compile() doesn't reuse cpp and stanc options supplied to cmdstan_mo
 
   expect_null(model$cpp_options()[["STAN_THREADS"]])
   expect_equal(
-    vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
+    vapply(received_stancflags, function(x) "--warn-uninitialized" %in% x, logical(1)),
     rep(FALSE, 2)
   )
 })
 
-test_that("name in STANCFLAGS is set correctly", {
+test_that("the model name stanc receives comes from the file name", {
   local_reproducible_output()
   out <- utils::capture.output(mod$compile(quiet = FALSE, force_recompile = TRUE))
   if(os_is_windows() && !os_is_wsl()) {
     out_no_name <- "bin/stanc.exe --name=bernoulli_model --o"
-    out_name <- "bin/stanc.exe --name=bernoulli2_model --o"
   } else {
     out_no_name <- "bin/stanc --name=bernoulli_model --o"
-    out_name <- "bin/stanc --name=bernoulli2_model --o"
   }
   expect_output(print(out), out_no_name)
 
-  out <- utils::capture.output(
-    mod$compile(
-      quiet = FALSE,
-      force_recompile = TRUE,
-      stanc_options = list(name = "bernoulli2_model")
-    )
+  expect_error(
+    mod$compile(force_recompile = TRUE, stanc_options = list(name = "bernoulli2_model")),
+    "The model name comes from the name of the Stan file.",
+    fixed = TRUE
   )
-  expect_output(print(out), out_name)
 })
 
 
@@ -633,40 +628,105 @@ test_that("compiling stops on hyphens in stanc_options", {
   stan_file <- testing_stan_file("bernoulli")
   expect_error(
     cmdstan_model(stan_file, stanc_options = hyphens, compile = FALSE),
-    "No leading hyphens allowed in stanc options (--allow-undefined). Use options without leading hyphens, for example `stanc_options = list('allow-undefined')`",
+    "No leading hyphens allowed in stanc options (--allow-undefined). Use options without leading hyphens, for example `stanc_options = list('warn-uninitialized')`",
     fixed = TRUE
   )
   expect_error(
     cmdstan_model(stan_file, stanc_options = hyphens2, compile = FALSE),
-    "No leading hyphens allowed in stanc options (--allow-undefined). Use options without leading hyphens, for example `stanc_options = list('allow-undefined')`",
+    "No leading hyphens allowed in stanc options (--allow-undefined). Use options without leading hyphens, for example `stanc_options = list('warn-uninitialized')`",
     fixed = TRUE
   )
   expect_error(
     cmdstan_model(stan_file, stanc_options = hyphens3, compile = FALSE),
-    "No leading hyphens allowed in stanc options (--o). Use options without leading hyphens, for example `stanc_options = list('allow-undefined')`",
+    "No leading hyphens allowed in stanc options (--o). Use options without leading hyphens, for example `stanc_options = list('warn-uninitialized')`",
     fixed = TRUE
   )
   mod <- cmdstan_model(stan_file, compile = FALSE)
   expect_error(
     mod$compile(stanc_options = hyphens),
-    "No leading hyphens allowed in stanc options (--allow-undefined). Use options without leading hyphens, for example `stanc_options = list('allow-undefined')`",
+    "No leading hyphens allowed in stanc options (--allow-undefined). Use options without leading hyphens, for example `stanc_options = list('warn-uninitialized')`",
     fixed = TRUE
   )
   expect_error(
     mod$compile(stanc_options = hyphens2),
-    "No leading hyphens allowed in stanc options (--allow-undefined). Use options without leading hyphens, for example `stanc_options = list('allow-undefined')`",
+    "No leading hyphens allowed in stanc options (--allow-undefined). Use options without leading hyphens, for example `stanc_options = list('warn-uninitialized')`",
     fixed = TRUE
   )
   expect_error(
     mod$compile(stanc_options = hyphens3),
-    "No leading hyphens allowed in stanc options (--o). Use options without leading hyphens, for example `stanc_options = list('allow-undefined')`",
+    "No leading hyphens allowed in stanc options (--o). Use options without leading hyphens, for example `stanc_options = list('warn-uninitialized')`",
     fixed = TRUE
+  )
+})
+
+test_that("compiling stops on stanc options cmdstanr sets itself", {
+  stan_file <- testing_stan_file("bernoulli")
+  mod <- cmdstan_model(stan_file, compile = FALSE)
+  fragments <- list(
+    "include-paths" = "Pass the directories with the `include_paths` argument.",
+    "warn-pedantic" = "Use `pedantic = TRUE`.",
+    "allow-undefined" = "Builds turn it on when a `user_header` is supplied",
+    "use-opencl" = "Use `cpp_options = list(stan_opencl = TRUE)`, which turns it on.",
+    "name" = "The model name comes from the name of the Stan file."
+  )
+  for (flag in names(fragments)) {
+    fragment <- fragments[[flag]]
+    spellings <- list(
+      list(flag),
+      list(paste0(flag, "=yes")),
+      setNames(list(TRUE), flag),
+      setNames(list(FALSE), flag),
+      setNames(list(NA), flag),
+      setNames(list(NULL), flag),
+      setNames(list("yes"), flag)
+    )
+    for (spelling in spellings) {
+      expect_error(
+        cmdstan_model(stan_file, stanc_options = spelling, compile = FALSE),
+        fragment,
+        fixed = TRUE
+      )
+      expect_error(
+        mod$compile(stanc_options = spelling),
+        fragment,
+        fixed = TRUE
+      )
+    }
+  }
+
+  # A named entry carrying its own value still matches on the flag name.
+  expect_error(
+    cmdstan_model(stan_file, stanc_options = list("include-paths=/b" = TRUE), compile = FALSE),
+    "Pass the directories with the `include_paths` argument.",
+    fixed = TRUE
+  )
+})
+
+test_that("stanc_options names cannot carry their own value", {
+  expect_error(
+    cmdstan_model(
+      testing_stan_file("bernoulli"),
+      stanc_options = list("max-line-length=78" = TRUE),
+      compile = FALSE
+    ),
+    "`list(\"max-line-length\" = \"78\")`",
+    fixed = TRUE
+  )
+})
+
+test_that("stanc options without a dedicated argument are left alone", {
+  options <- list("filename-in-msg" = "x.stan")
+  expect_equal(assert_valid_stanc_options(options), options)
+  expect_equal(assert_valid_stanc_options(list("O1")), list("O1"))
+  expect_equal(
+    assert_valid_stanc_options(list("warn-uninitialized" = TRUE)),
+    list("warn-uninitialized" = TRUE)
   )
 })
 
 test_that("compiling works with only names in list", {
   stan_file <- testing_stan_file("bernoulli")
-  expect_call_compilation(mod <- cmdstan_model(stan_file, stanc_options = list("warn-pedantic"), force_recompile = TRUE))
+  expect_call_compilation(mod <- cmdstan_model(stan_file, stanc_options = list("warn-uninitialized"), force_recompile = TRUE))
   checkmate::expect_r6(
     mod,
     "CmdStanModel"
@@ -732,13 +792,23 @@ test_that("check_syntax() works", {
     regexp = NA
   )
   expect_message(
-    mod_ok$check_syntax(stanc_options = list("allow-undefined", "warn-pedantic")),
+    mod_ok$check_syntax(stanc_options = list("warn-uninitialized")),
     "Stan program is syntactically correct",
     fixed = TRUE
   )
   expect_message(
-    mod_ok$check_syntax(stanc_options = list("allow-undefined", "warn-pedantic"), quiet = TRUE),
+    mod_ok$check_syntax(stanc_options = list("warn-uninitialized"), quiet = TRUE),
     regexp = NA
+  )
+  expect_error(
+    mod_ok$check_syntax(stanc_options = list("warn-pedantic")),
+    "Use `pedantic = TRUE`.",
+    fixed = TRUE
+  )
+  expect_error(
+    mod_ok$check_syntax(stanc_options = list("allow-undefined")),
+    "Builds turn it on when a `user_header` is supplied",
+    fixed = TRUE
   )
 
   code <- "
@@ -789,10 +859,10 @@ test_that("check_syntax() works with pedantic=TRUE", {
     fixed = TRUE
   )
 
-  # should also still work if specified via stanc_options
-  expect_message(
+  # pedantic mode has one channel here as well
+  expect_error(
     mod_pedantic_warn$check_syntax(stanc_options = list("warn-pedantic" = TRUE)),
-    "The parameter x was declared but was not used",
+    "Use `pedantic = TRUE`.",
     fixed = TRUE
   )
 
@@ -1210,16 +1280,11 @@ test_that("format() works", {
   )
 
   stan_file <- testing_stan_file("bernoulli_external")
-  mod_2 <- cmdstan_model(stan_file, compile = FALSE, stanc_options = list("allow-undefined"))
+  mod_2 <- cmdstan_model(stan_file, compile = FALSE)
   expect_output(
     mod_2$format(),
     "make_odds(theta);",
     fixed = TRUE
-  )
-  mod_3 <- cmdstan_model(
-    stan_file,
-    compile = FALSE,
-    stanc_options = list("allow-undefined", "warn-pedantic")
   )
   expect_output(
     expect_message(
@@ -1252,6 +1317,20 @@ test_that("format() works", {
     "'$format()' cannot be used because the 'CmdStanModel' was not created with a Stan file.",
     fixed = TRUE
   )
+})
+
+test_that("source-only operations do not need a user header to allow undefined functions", {
+  mod <- cmdstan_model(testing_stan_file("bernoulli_external"), compile = FALSE)
+  expect_message(
+    expect_true(mod$check_syntax()),
+    "Stan program is syntactically correct"
+  )
+  expect_output(
+    mod$format(),
+    "make_odds(theta);",
+    fixed = TRUE
+  )
+  expect_equal(names(mod$variables()$parameters), "theta")
 })
 
 test_that("format() works with include_paths", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -1473,6 +1473,21 @@ test_that("STANCFLAGS from get_cmdstan_flags() are included in compile output", 
     out_w_flags <- "bin/stanc --name=bernoulli_model[[:space:]]+--O1[[:space:]]+--warn-pedantic[[:space:]]+--o"
   }
   expect_output(print(out), out_w_flags)
+
+  # The call emits --warn-pedantic, so make/local's copy is dropped and the
+  # stanc command line make prints holds the flag once.
+  out <- utils::capture.output(
+    mod$compile(pedantic = TRUE, quiet = FALSE, force_recompile = TRUE)
+  )
+  stanc_lines <- out[grepl("bin/stanc", out)]
+  expect_gt(length(stanc_lines), 0)
+  expect_equal(
+    lengths(regmatches(
+      stanc_lines,
+      gregexpr("--warn-pedantic", stanc_lines, fixed = TRUE)
+    )),
+    rep(1L, length(stanc_lines))
+  )
 })
 
 test_that("quoted make/local STANCFLAGS values reach stanc as one argument (#1232)", {
@@ -1495,6 +1510,105 @@ test_that("quoted make/local STANCFLAGS values reach stanc as one argument (#123
     "'--filename-in-msg=/my dir/model.stan'",
     fixed = TRUE
   )
+})
+
+test_that("include paths in make/local STANCFLAGS stop the build", {
+  # Use a temporary copy because mocked compiles install executables.
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(testing_stan_file("bernoulli"), stan_file)
+  local_flags <- NULL
+  received_stancflags <- list()
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) {
+      if (identical(flag_name, "STANCFLAGS")) local_flags else character()
+    },
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
+  )
+
+  for (flags in list("--include-paths=/b", c("-I", "/b"), "-I/b")) {
+    local_flags <- flags
+    received_stancflags <- list()
+    model <- cmdstan_model(stan_file, compile = FALSE)
+    with_mocked_cli(
+      compile_ret = list(status = 0),
+      info_ret = list(status = 1),
+      code = expect_error(
+        model$compile(force_recompile = TRUE),
+        "pass the directories with the `include_paths` argument",
+        fixed = TRUE
+      )
+    )
+    # The build stops before stanc is called at all.
+    expect_length(received_stancflags, 0)
+  }
+})
+
+test_that("a flag the call emits reaches stanc once when make/local sets it too", {
+  model_dir <- withr::local_tempdir()
+  stan_file <- file.path(model_dir, "bernoulli.stan")
+  file.copy(testing_stan_file("bernoulli"), stan_file)
+  model <- cmdstan_model(stan_file, compile = FALSE)
+  local_flags <- NULL
+  received_stancflags <- list()
+  local_mocked_bindings(
+    get_cmdstan_flags = function(flag_name) {
+      if (identical(flag_name, "STANCFLAGS")) local_flags else character()
+    },
+    get_standalone_hpp = function(stan_file, stancflags) {
+      received_stancflags <<- append(received_stancflags, list(stancflags))
+      ""
+    }
+  )
+
+  # The next word is another flag, so it survives the drop.
+  local_flags <- c("--warn-pedantic", "-fno-soa")
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(pedantic = TRUE, force_recompile = TRUE)
+  )
+  expect_equal(
+    vapply(received_stancflags, function(x) sum(x == "--warn-pedantic"), integer(1)),
+    rep(1L, 2)
+  )
+  expect_true(all(vapply(
+    received_stancflags,
+    function(x) "-fno-soa" %in% x,
+    logical(1)
+  )))
+
+  local_flags <- "--O1"
+  received_stancflags <- list()
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(stanc_options = list("O1"), force_recompile = TRUE)
+  )
+  expect_equal(
+    vapply(received_stancflags, function(x) sum(x == "--O1"), integer(1)),
+    rep(1L, 2)
+  )
+
+  # The value given as a separate word goes with the flag it belongs to.
+  local_flags <- c("--filename-in-msg", "published.stan")
+  received_stancflags <- list()
+  with_mocked_cli(
+    compile_ret = list(status = 0),
+    info_ret = list(status = 1),
+    code = model$compile(
+      stanc_options = list("filename-in-msg" = "x.stan"),
+      force_recompile = TRUE
+    )
+  )
+  expect_true(all(vapply(
+    received_stancflags,
+    function(x) "--filename-in-msg=x.stan" %in% x && !("published.stan" %in% x),
+    logical(1)
+  )))
 })
 
 test_that("stanc_options_to_args() builds direct and Make-quoted arguments", {
@@ -1533,6 +1647,45 @@ test_that("stanc_options_to_args() builds direct and Make-quoted arguments", {
 
   expect_equal(stanc_options_to_args(list()), NULL)
   expect_equal(stanc_options_to_args(NULL), NULL)
+})
+
+test_that("a flag the call emits drops the make/local copy", {
+  expect_equal(
+    drop_overridden_stancflags(c("--warn-pedantic"), c("--warn-pedantic")),
+    character(0)
+  )
+  expect_equal(drop_overridden_stancflags(c("--O1"), c("--O1")), character(0))
+
+  # One hyphen, not two: the next word is a flag of its own
+  expect_equal(
+    drop_overridden_stancflags(c("--warn-pedantic", "-fno-soa"), c("--warn-pedantic")),
+    "-fno-soa"
+  )
+
+  # A value given as a separate word goes with the flag
+  expect_equal(
+    drop_overridden_stancflags(
+      c("--filename-in-msg", "published.stan"),
+      c("--filename-in-msg=x.stan")
+    ),
+    character(0)
+  )
+  expect_equal(
+    drop_overridden_stancflags(
+      c("--filename-in-msg=published.stan"),
+      c("--filename-in-msg=x.stan")
+    ),
+    character(0)
+  )
+
+  expect_equal(
+    drop_overridden_stancflags(c("--O1", "--warn-pedantic"), c("--name=bernoulli_model")),
+    c("--O1", "--warn-pedantic")
+  )
+  expect_equal(
+    drop_overridden_stancflags(character(0), c("--name=bernoulli_model")),
+    character(0)
+  )
 })
 
 test_that("compile() passes unquoted named stanc options to direct calls", {

--- a/tests/testthat/test-model-compile.R
+++ b/tests/testthat/test-model-compile.R
@@ -290,7 +290,7 @@ test_that("$compile() doesn't reuse cpp and stanc options from the previous comp
       force_recompile = TRUE
     )
   )
-  expect_true(model$cpp_options()[["stan_threads"]])
+  expect_true(model$cpp_options()[["STAN_THREADS"]])
   expect_equal(
     vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
     rep(TRUE, 2)
@@ -303,7 +303,7 @@ test_that("$compile() doesn't reuse cpp and stanc options from the previous comp
     code = model$compile(force_recompile = TRUE)
   )
 
-  expect_null(model$cpp_options()[["stan_threads"]])
+  expect_null(model$cpp_options()[["STAN_THREADS"]])
   expect_equal(
     vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
     rep(FALSE, 2)
@@ -336,7 +336,7 @@ test_that("$compile() doesn't reuse cpp and stanc options supplied to cmdstan_mo
     info_ret = list(status = 1),
     code = model$compile(force_recompile = TRUE)
   )
-  expect_true(model$cpp_options()[["stan_threads"]])
+  expect_true(model$cpp_options()[["STAN_THREADS"]])
   expect_equal(
     vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
     rep(TRUE, 2)
@@ -349,7 +349,7 @@ test_that("$compile() doesn't reuse cpp and stanc options supplied to cmdstan_mo
     code = model$compile(force_recompile = TRUE)
   )
 
-  expect_null(model$cpp_options()[["stan_threads"]])
+  expect_null(model$cpp_options()[["STAN_THREADS"]])
   expect_equal(
     vapply(received_stancflags, function(x) "--warn-pedantic" %in% x, logical(1)),
     rep(FALSE, 2)
@@ -565,7 +565,7 @@ expect_describes_new_program <- function(model) {
   expect_equal(model$variables()$parameters$beta$dimensions, 0)
   expect_match(paste(private$model_methods_env_$hpp_code_, collapse = "\n"), "beta")
   expect_match(paste(readLines(model$hpp_file()), collapse = "\n"), "beta")
-  expect_true(model$cpp_options()$stan_threads)
+  expect_true(model$cpp_options()$STAN_THREADS)
   expect_match(readLines(model$exe_file()), "^mock executable ")
 }
 
@@ -890,16 +890,35 @@ test_that("compilation errors if folder with the model name exists", {
 
 test_that("cpp_options_to_compile_flags() works", {
   options = list(
-    stan_threads = TRUE
+    STAN_THREADS = TRUE
   )
   expect_equal(cpp_options_to_compile_flags(options), "STAN_THREADS=TRUE")
   options = list(
-    stan_threads = TRUE,
-    stanc2 = TRUE
+    STAN_THREADS = TRUE,
+    STANC2 = TRUE
   )
   expect_equal(cpp_options_to_compile_flags(options), c("STAN_THREADS=TRUE", "STANC2=TRUE"))
   options = list()
   expect_equal(cpp_options_to_compile_flags(options), NULL)
+
+  # FALSE and NULL both ask for the option off, which make spells as an empty
+  # assignment. The string "FALSE" is a value like any other.
+  expect_equal(
+    cpp_options_to_compile_flags(list(STAN_THREADS = FALSE)),
+    "STAN_THREADS="
+  )
+  expect_equal(
+    cpp_options_to_compile_flags(list(STAN_THREADS = NULL)),
+    "STAN_THREADS="
+  )
+  expect_equal(
+    cpp_options_to_compile_flags(list(STAN_THREADS = "FALSE")),
+    "STAN_THREADS=FALSE"
+  )
+  expect_equal(
+    cpp_options_to_compile_flags(list(STAN_THREADS = c(TRUE, FALSE))),
+    c("STAN_THREADS=TRUE", "STAN_THREADS=")
+  )
 })
 
 test_that("include_paths_stanc3_args() works", {
@@ -1120,17 +1139,28 @@ test_that("cmdstan_model works with user_header", {
   )
 })
 
-test_that("cmdstan_model cpp_options dont capitalize cxxflags ", {
+test_that("cpp_options names reach make uppercased and values verbatim", {
   file <- file.path(cmdstan_path(), "examples", "bernoulli", "bernoulli.stan")
-  cpp_options <- list(
-    "CXXFLAGS_OPTIM += -Dsomething_not_used"
+  expect_error(
+    cmdstan_model(
+      file,
+      cpp_options = list("CXXFLAGS_OPTIM += -Dsomething_not_used"),
+      force_recompile = TRUE
+    ),
+    "cmdstan_make_local(cpp_options = list(\"CXXFLAGS_OPTIM += -Dsomething_not_used\"))",
+    fixed = TRUE
   )
+
   withr::with_options(list("cmdstanr_verbose" = TRUE),
     out <- utils::capture.output(
-      mod <- cmdstan_model(file, cpp_options = cpp_options, force_recompile = TRUE)
+      mod <- cmdstan_model(
+        file,
+        cpp_options = list(CXXFLAGS_OPTIM = "-Dsomething_not_used"),
+        force_recompile = TRUE
+      )
     )
   )
-  expect_output(print(out), "-Dsomething_not_used")
+  expect_output(print(out), "CXXFLAGS_OPTIM=-Dsomething_not_used", fixed = TRUE)
 })
 
 test_that("format(overwrite_file = TRUE) refreshes cached variables", {

--- a/tests/testthat/test-model-recompile-logic.R
+++ b/tests/testthat/test-model-recompile-logic.R
@@ -50,7 +50,7 @@ test_that("a no-op compile preserves what the previous compilation recorded", {
       force_recompile = TRUE
     )
   )
-  expect_true(mod$cpp_options()$stan_threads)
+  expect_true(mod$cpp_options()$STAN_THREADS)
   expect_false(mod$functions$existing_exe)
 
   # A no-op must preserve build options and local-build provenance.
@@ -59,7 +59,7 @@ test_that("a no-op compile preserves what the previous compilation recorded", {
     info_ret = list(status = 1),
     code = expect_no_mock_compile(mod$compile())
   )
-  expect_true(mod$cpp_options()$stan_threads)
+  expect_true(mod$cpp_options()$STAN_THREADS)
   expect_false(mod$functions$existing_exe)
 })
 
@@ -76,7 +76,7 @@ test_that("a no-op compile does not record cpp_options the executable lacks", {
   )
 
   # The unapplied threading request must not affect ordinary sampling (#1019).
-  expect_false(isTRUE(mod$cpp_options()$stan_threads))
+  expect_false(isTRUE(mod$cpp_options()$STAN_THREADS))
   expect_no_error(
     mod$sample(
       data = testing_data("bernoulli"),
@@ -267,7 +267,7 @@ test_that("adopting an executable describes the binary, not the request", {
     )
   )
 
-  expect_null(mod$cpp_options()$stan_threads)
+  expect_null(mod$cpp_options()$STAN_THREADS)
   expect_true(mod$functions$existing_exe)
 })
 
@@ -280,7 +280,7 @@ test_that("a no-op compile does not adopt options the executable lacks", {
     info_ret = list(status = 1),
     code = cmdstan_model(stan_file)
   )
-  expect_null(mod$cpp_options()$stan_threads)
+  expect_null(mod$cpp_options()$STAN_THREADS)
 
   # A no-op warns without changing the options recorded for the executable.
   with_mocked_cli(
@@ -296,7 +296,7 @@ test_that("a no-op compile does not adopt options the executable lacks", {
       )
     )
   )
-  expect_null(mod$cpp_options()$stan_threads)
+  expect_null(mod$cpp_options()$STAN_THREADS)
 })
 
 test_that("a no-op compile warns about options the executable cannot report", {
@@ -443,9 +443,9 @@ test_that("option comparison follows what make is actually given", {
   }
   quietly <- function(requested) no_op(requested, expect_no_warning)
 
-  # FALSE is not omission. It reaches make as STAN_CPP_OPTIMS=FALSE, and CmdStan
-  # enables some options whenever their make variable is non-empty, so asking
-  # for it would build a different executable than the recorded TRUE did.
+  # FALSE is not omission. It reaches make as an empty STAN_CPP_OPTIMS=, which
+  # asks for the option off, so it still describes a different executable than
+  # the recorded TRUE built.
   warns(list(stan_cpp_optims = FALSE))
   warns(list(stan_cpp_optims = TRUE, stan_threads = FALSE))
 
@@ -453,51 +453,28 @@ test_that("option comparison follows what make is actually given", {
   quietly(list(stan_cpp_optims = FALSE, stan_cpp_optims = TRUE))
   warns(list(stan_cpp_optims = TRUE, stan_cpp_optims = FALSE))
 
-  # An unnamed entry is a raw make argument rather than something to skip.
-  warns(list("STAN_THREADS=TRUE"))
-
-  # Order survives normalization: these reach make as the same two assignments
-  # in opposite orders, so exactly one of them matches the recorded TRUE.
-  quietly(list("STAN_CPP_OPTIMS=FALSE", "STAN_CPP_OPTIMS=TRUE"))
-  warns(list("STAN_CPP_OPTIMS=TRUE", "STAN_CPP_OPTIMS=FALSE"))
-
-  # The same, across the boundary between a named entry and a raw one.
-  quietly(structure(
-    list(FALSE, "STAN_CPP_OPTIMS=TRUE"),
-    names = c("stan_cpp_optims", "")
-  ))
-  warns(structure(
-    list("STAN_CPP_OPTIMS=TRUE", FALSE),
-    names = c("", "stan_cpp_optims")
-  ))
-
   # A vector value expands into one assignment per element, so it is the last
   # element that decides, not the vector as a whole.
   quietly(list(stan_cpp_optims = c(FALSE, TRUE)))
   warns(list(stan_cpp_optims = c(TRUE, FALSE)))
 })
 
-test_that("a raw make argument round-trips through the option comparison", {
+test_that("stan_threads = FALSE asks for threading off without a warning", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
 
-  mod <- with_mocked_cli(
-    compile_ret = list(status = 0),
-    info_ret = list(status = 1),
-    code = cmdstan_model(
-      stan_file,
-      cpp_options = list("STAN_CPP_OPTIMS=TRUE"),
-      force_recompile = TRUE
-    )
-  )
-
+  mod <- cmdstan_model(stan_file, compile = FALSE)
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 1),
-    code = expect_no_mock_compile(
-      expect_no_warning(mod$compile(cpp_options = list("STAN_CPP_OPTIMS=TRUE")))
+    code = expect_no_warning(
+      mod$compile(
+        cpp_options = list(stan_threads = FALSE),
+        force_recompile = TRUE
+      )
     )
   )
+  expect_identical(mod$cpp_options()$STAN_THREADS, FALSE)
 })
 
 test_that("a successful compile records options only the executable reports", {
@@ -675,7 +652,7 @@ test_that("options inherited from make/local are learned, not warned about", {
   )
 })
 
-test_that("an explicitly passed raw assignment is not taken for make/local", {
+test_that("an explicitly passed option is not taken for make/local", {
   stan_file <- file.path(withr::local_tempdir(), "bernoulli.stan")
   file.copy(stan_program, stan_file)
   threaded <- paste0(
@@ -688,15 +665,12 @@ test_that("an explicitly passed raw assignment is not taken for make/local", {
     compile_ret = list(status = 0),
     info_ret = list(status = 0, stdout = threaded),
     code = mod$compile(
-      cpp_options = structure(
-        list("STAN_THREADS=TRUE", TRUE),
-        names = c("", "stan_cpp_optims")
-      ),
+      cpp_options = list(stan_threads = TRUE, stan_cpp_optims = TRUE),
       force_recompile = TRUE
     )
   )
 
-  # Raw STAN_THREADS=TRUE is explicit, not inherited from make/local.
+  # An explicit STAN_THREADS=TRUE is not inherited from make/local.
   with_mocked_cli(
     compile_ret = list(status = 0),
     info_ret = list(status = 0, stdout = threaded),
@@ -786,7 +760,7 @@ test_that("an adopted executable stays silent about options it cannot report", {
       )
     )
   )
-  expect_null(mod$cpp_options()$stan_cpp_optims)
+  expect_null(mod$cpp_options()$STAN_CPP_OPTIMS)
 })
 
 test_that("no mismatch warning when the executable already has the options", {

--- a/tests/testthat/test-threads.R
+++ b/tests/testthat/test-threads.R
@@ -197,24 +197,26 @@ test_that("threading works with generate_quantities()", {
   expect_equal(f_gq$metadata()$threads_per_chain, 4)
 })
 
-test_that("executable metadata takes precedence over compile options", {
+test_that("stan_threads = FALSE builds an executable without threading", {
   mod <- cmdstan_model(
     stan_program,
     cpp_options = list(stan_threads = FALSE),
     force_recompile = TRUE
   )
-  expect_snapshot(
-    error = TRUE,
-    mod$sample(data = data_file_json, chains = 1)
-  )
+  expect_false(mod$cpp_options()$STAN_THREADS)
   expect_output(
-    fit <- mod$sample(
-      data = data_file_json,
-      chains = 1,
-      threads_per_chain = 2
-    ),
-    "with 2 thread(s) per chain",
+    fit <- mod$sample(data = data_file_json, chains = 1),
+    "Running MCMC with 1 chain",
     fixed = TRUE
   )
-  expect_equal(fit$metadata()$threads_per_chain, 2)
+  expect_equal(fit$metadata()$threads_per_chain, 1)
+  expect_warning(
+    expect_output(
+      mod$sample(data = data_file_json, chains = 1, threads_per_chain = 2),
+      "Running MCMC with 1 chain",
+      fixed = TRUE
+    ),
+    "'threads_per_chain' will have no effect!",
+    fixed = TRUE
+  )
 })

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -693,7 +693,24 @@ test_that("get_cmdstan_flags() returns empty STANCFLAGS as character(0)", {
       expect_equal(get_cmdstan_flags("STANCFLAGS"), character(0))
     },
     wsl_compatible_run = function(...) {
-      list(stdout = "STANCFLAGS =\n")
+      list(stdout = "cmdstanr-stancflag=\n")
+    }
+  )
+})
+
+test_that("get_cmdstan_flags() ignores unrelated output around STANCFLAGS", {
+  with_mocked_bindings(
+    {
+      expect_equal(get_cmdstan_flags("STANCFLAGS"), c("--O1", "--warn-pedantic"))
+    },
+    wsl_compatible_run = function(...) {
+      list(stdout = paste(
+        "make[1]: Entering directory '/tmp/cmdstan'",
+        "cmdstanr-stancflag=--O1",
+        "cmdstanr-stancflag=--warn-pedantic",
+        "make[1]: Leaving directory '/tmp/cmdstan'",
+        sep = "\n"
+      ))
     }
   )
 })
@@ -709,27 +726,85 @@ test_that("get_cmdstan_flags() preserves empty non-STANCFLAGS values", {
   )
 })
 
-test_that("get_cmdstan_flags() handles line-continuation STANCFLAGS in make/local", {
-  tmpdir <- withr::local_tempdir()
-  # Build a minimal make setup so we can exercise real make line continuations.
-  writeLines(
-    c(
-      "print-%: ; @echo $* = $($*)",
-      "-include local"
-    ),
-    file.path(tmpdir, "Makefile")
+# Run get_cmdstan_flags()'s own make call against a directory holding a
+# minimal `makefile` that includes `local`, as CmdStan's does.
+local_mini_make_local <- function(local_lines, envir = parent.frame()) {
+  tmpdir <- withr::local_tempdir(.local_envir = envir)
+  writeLines("-include local", file.path(tmpdir, "makefile"))
+  writeLines(local_lines, file.path(tmpdir, "local"))
+  local_mocked_bindings(
+    wsl_compatible_run = function(command, args, ...) {
+      processx::run(command = command, args = args, wd = tmpdir)
+    },
+    .env = envir
   )
+  invisible(tmpdir)
+}
+
+test_that("get_cmdstan_flags() handles line-continuation STANCFLAGS in make/local", {
+  local_mini_make_local(c(
+    "STANCFLAGS += --O1 \\",
+    "  --warn-pedantic \\",
+    "  --allow-undefined"
+  ))
+  expect_equal(
+    get_cmdstan_flags("STANCFLAGS"),
+    c("--O1", "--warn-pedantic", "--allow-undefined")
+  )
+})
+
+test_that("get_cmdstan_flags() keeps quoted STANCFLAGS values whole (#1232)", {
+  local_mini_make_local("STANCFLAGS += --O1 --filename-in-msg='/my dir/model.stan'")
+  expect_equal(
+    get_cmdstan_flags("STANCFLAGS"),
+    c("--O1", "--filename-in-msg=/my dir/model.stan")
+  )
+})
+
+test_that("get_cmdstan_flags() splits STANCFLAGS the way the shell does", {
+  local_mini_make_local(c(
+    'STANCFLAGS += --filename-in-msg="/my dir/model.stan"',
+    "STANCFLAGS += 'a b'\"c d\"e",
+    "STANCFLAGS += x\\ y",
+    "STANCFLAGS +=   --O1  "
+  ))
+  expect_equal(
+    get_cmdstan_flags("STANCFLAGS"),
+    c("--filename-in-msg=/my dir/model.stan", "a bc de", "x y", "--O1")
+  )
+})
+
+test_that("get_cmdstan_flags() returns an unset STANCFLAGS as character(0)", {
+  local_mini_make_local("CXXFLAGS += -O3")
+  expect_equal(get_cmdstan_flags("STANCFLAGS"), character(0))
+})
+
+test_that("make_shell_quote() survives Make expansion and shell splitting (#1230)", {
+  words <- c(
+    "--O1",
+    "--filename-in-msg=/my dir/model.stan",
+    "/the model's includes",
+    "/costs $5",
+    "/the model's $5",
+    "C:/Users/me/inc",
+    "*"
+  )
+  quoted <- make_shell_quote(words)
+  # Words the shell and Make leave alone are not touched
+  expect_equal(quoted[c(1, 6)], words[c(1, 6)])
+  expect_equal(quoted[2], "'--filename-in-msg=/my dir/model.stan'")
+  expect_equal(quoted[4], "'/costs $$5'")
+
+  # Oracle: hand the quoted words to make the way $compile() does and read
+  # back what the shell delivers to the recipe, one argument per line.
+  tmpdir <- withr::local_tempdir()
   writeLines(
-    c(
-      "STANCFLAGS += --O1 \\",
-      "  --warn-pedantic \\",
-      "  --allow-undefined"
-    ),
-    file.path(tmpdir, "local")
+    "args: ; @printf '%s\\n' $(STANCFLAGS)",
+    file.path(tmpdir, "Makefile")
   )
   make_run <- processx::run(
     command = "make",
-    args = c("-s", "print-STANCFLAGS"),
+    args = c("-s", "args", paste0("STANCFLAGS += ", paste(quoted, collapse = " "))),
     wd = tmpdir,
     error_on_status = FALSE
   )
@@ -747,18 +822,7 @@ test_that("get_cmdstan_flags() handles line-continuation STANCFLAGS in make/loca
     )
     return(invisible())
   }
-
-  with_mocked_bindings(
-    {
-      expect_equal(
-        get_cmdstan_flags("STANCFLAGS"),
-        c("--O1", "--warn-pedantic", "--allow-undefined")
-      )
-    },
-    wsl_compatible_run = function(...) {
-      list(stdout = make_run$stdout)
-    }
-  )
+  expect_equal(strsplit(make_run$stdout, "\n")[[1]], words)
 })
 
 test_that("local_make_local_backup() heals residue and nests", {

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -789,6 +789,11 @@ test_that("get_cmdstan_flags() returns an unset STANCFLAGS as character(0)", {
   expect_equal(get_cmdstan_flags("STANCFLAGS"), character(0))
 })
 
+test_that("get_cmdstan_flags() keeps the rule file out of MAKEFILE_LIST", {
+  local_mini_make_local("STANCFLAGS = --filename-in-msg=$(lastword $(MAKEFILE_LIST))")
+  expect_equal(get_cmdstan_flags("STANCFLAGS"), "--filename-in-msg=local")
+})
+
 test_that("make_shell_quote() survives Make expansion and shell splitting (#1230)", {
   words <- c(
     "--O1",

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -730,11 +730,21 @@ test_that("get_cmdstan_flags() preserves empty non-STANCFLAGS values", {
 # minimal `makefile` that includes `local`, as CmdStan's does.
 local_mini_make_local <- function(local_lines, envir = parent.frame()) {
   tmpdir <- withr::local_tempdir(.local_envir = envir)
-  writeLines("-include local", file.path(tmpdir, "makefile"))
-  writeLines(local_lines, file.path(tmpdir, "local"))
+  # Binary mode keeps the line endings LF; under WSL a Linux make reads files
+  # written on Windows.
+  write_lf <- function(lines, path) {
+    con <- file(path, open = "wb")
+    on.exit(close(con))
+    writeLines(lines, con, sep = "\n")
+  }
+  write_lf("-include local", file.path(tmpdir, "makefile"))
+  write_lf(local_lines, file.path(tmpdir, "local"))
+  # Keep the real runner so the call still goes through wsl under WSL, where
+  # the rule file path is already converted to /mnt/.
+  run <- wsl_compatible_run
   local_mocked_bindings(
     wsl_compatible_run = function(command, args, ...) {
-      processx::run(command = command, args = args, wd = tmpdir)
+      run(command = command, args = args, wd = tmpdir)
     },
     .env = envir
   )

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -794,6 +794,28 @@ test_that("get_cmdstan_flags() keeps the rule file out of MAKEFILE_LIST", {
   expect_equal(get_cmdstan_flags("STANCFLAGS"), "--filename-in-msg=local")
 })
 
+test_that("get_cmdstan_flags() resolves STANCFLAGS with the call's cpp_options applied", {
+  local_mini_make_local(c(
+    "ifdef STAN_OPENCL",
+    "STANCFLAGS += --use-opencl",
+    "endif"
+  ))
+  expect_equal(get_cmdstan_flags("STANCFLAGS"), character(0))
+  expect_equal(get_cmdstan_flags("STANCFLAGS", "STAN_OPENCL=TRUE"), "--use-opencl")
+  expect_equal(get_cmdstan_flags("STANCFLAGS", "STAN_OPENCL="), character(0))
+})
+
+test_that("the call's cpp_options override make/local when STANCFLAGS are resolved", {
+  local_mini_make_local(c(
+    "STAN_OPENCL=true",
+    "ifdef STAN_OPENCL",
+    "STANCFLAGS += --use-opencl",
+    "endif"
+  ))
+  expect_equal(get_cmdstan_flags("STANCFLAGS"), "--use-opencl")
+  expect_equal(get_cmdstan_flags("STANCFLAGS", "STAN_OPENCL="), character(0))
+})
+
 test_that("make_shell_quote() survives Make expansion and shell splitting (#1230)", {
   words <- c(
     "--O1",


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

This PR and the summary below was written with the help of AI coding tools. I have reviewed the code myself. 

Stage 1 of the v1.0 compilation-state work (#1258): every option that reaches `make` or `stanc` now arrives through one channel, is spelled the way the tool reads it, and is checked before anything runs. Targets `v1.0`, not `master`.

What changes for users (NEWS has the full list):

- `cpp_options` entries must be named with a Make variable name. Names are uppercased on entry and `$cpp_options()` reports the Make spelling. `FALSE` or `NULL` passes an empty assignment, which turns the option off and overrides `make/local`. Previously `stan_threads = FALSE` enabled threading (#1251), and unnamed entries such as `"STAN_THREADS=TRUE"` reached `make` but were invisible to everything keyed on names (#1250).
- `user_header` is the only way to supply a user header; `cpp_options = list(USER_HEADER = ...)` is an error naming the argument. The new `$user_header()` method returns the path.
- `include_paths` is the only way to give `stanc` include paths. `include-paths` in `stanc_options`, `STANCFLAGS` in `cpp_options` and an include path in `make/local`'s `STANCFLAGS` are all errors.
- `stanc_options` rejects the flags cmdstanr sets from its own arguments (`warn-pedantic`, `allow-undefined`, `use-opencl`, `include-paths`, `name`) in every spelling. `$check_syntax()` checks its list the same way.
- `$check_syntax()`, `$format()` and `$variables()` always pass `--allow-undefined`; they read a program and link nothing.
- `make/local`'s `STANCFLAGS` are read the way the shell splits them (#1232), and are resolved with the call's `cpp_options` applied, so `stan_opencl = FALSE` also keeps the `--use-opencl` that CmdStan's makefiles add from reaching `stanc`. A flag the call sets wins over the same flag in `make/local`.
- Include paths handed to `make` are quoted for Make and the shell (#1230).
- `cmdstan_model(exe_file = )` with no `stan_file` rejects `cpp_options`, `stanc_options`, `include_paths`, `user_header`, `force_recompile` and `pedantic`. There is nothing to build, so the executable is used as it is.

Each rule has a sentence in `dev-notes/compilation-state-contract.md` (§3, §6, §7) and a test that fails if the rule is removed.

Closes #1230, #1232, #1250, #1251.

Reviewed externally before this was marked ready; the review found one real defect (the `STANCFLAGS` query ignored the call's `cpp_options`, fixed in the last commit) and a handful of message and doc corrections, all in the two final commits. One finding is deferred on purpose and recorded on #1258: the executable-only check reads the captured arguments by exact name, so an abbreviation such as `force = TRUE` passes it. Removing `$compile()` later in v1.0 makes those arguments the constructor's own formals and closes that without matching code.

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):
Jonah Gabry


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
