### PR TITLE
no duplicate make/local flags

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -314,9 +314,8 @@ rebuild_cmdstan <- function(dir = cmdstan_path(),
 #' @export
 #' @param append (logical) For `cmdstan_make_local()`, should the listed
 #'   makefile flags be appended to the end of the existing `make/local` file?
-#'   The default is `TRUE`. If `FALSE` the file is overwritten. Appending is
-#'   idempotent: a flag that is already present in `make/local` is not written
-#'   a second time, and repeated flags in `cpp_options` are written once.
+#'   The default is `TRUE`. If `FALSE` the file is overwritten. A flag that is
+#'   already present in `make/local` is not written a second time.
 #'
 cmdstan_make_local <- function(dir = cmdstan_path(),
                                cpp_options = NULL,
@@ -338,18 +337,13 @@ cmdstan_make_local <- function(dir = cmdstan_path(),
         }
       }
     }
-    if (append) {
-      # Don't write a flag that is already in the file.
-      existing <- tryCatch(
-        suppressWarnings(readLines(make_local_path, warn = FALSE)),
-        error = function(e) character(0)
-      )
-      built_flags <- built_flags[!trimws(built_flags) %in% trimws(existing)]
+    if (append && file.exists(make_local_path)) {
+      # Don't write a flag that make would already apply anyway.
+      existing <- suppressWarnings(readLines(make_local_path, warn = FALSE))
+      built_flags <- built_flags[!make_flag_already_applies(built_flags, existing)]
     }
-    built_flags <- unique(built_flags)
-    # Skip the write if there is nothing left to add and the file is
-    # already there.
-    if (length(built_flags) > 0 || !append || !file.exists(make_local_path)) {
+    # Skip the write if there is nothing left to add.
+    if (length(built_flags) > 0 || !append) {
       write(built_flags, file = make_local_path, append = append)
     }
   }
@@ -400,6 +394,43 @@ check_cmdstan_toolchain <- function(fix = FALSE, quiet = FALSE) {
 
 
 # internal ----------------------------------------------------------------
+
+#' Would make already apply these flags, given the current `make/local`?
+#'
+#' Follows what make does with the file rather than just looking for the same
+#' text: `+=` accumulates, so a second identical line adds nothing wherever it
+#' sits, but a plain assignment is only in force while it is the last one for
+#' that variable. Writing `STAN_THREADS=true` again after a `STAN_THREADS=false`
+#' further down is therefore a real change, not a duplicate.
+#'
+#' @noRd
+#' @param flags (character vector) Flags about to be appended.
+#' @param existing (character vector) Current contents of `make/local`.
+#' @return A logical vector of the same length as `flags`.
+make_flag_already_applies <- function(flags, existing) {
+  flags <- trimws(flags)
+  existing <- trimws(existing)
+  existing_variable <- make_assignment_part(existing, "\\1")
+  flag_variable <- make_assignment_part(flags, "\\1")
+  flag_operator <- make_assignment_part(flags, "\\2")
+
+  vapply(seq_along(flags), function(i) {
+    if (is.na(flag_variable[i]) || flag_operator[i] == "+=") {
+      return(flags[i] %in% existing)
+    }
+    assignments <- which(!is.na(existing_variable) &
+                           existing_variable == flag_variable[i])
+    length(assignments) > 0 &&
+      identical(existing[max(assignments)], flags[i])
+  }, logical(1))
+}
+
+# Variable name ("\\1") or operator ("\\2") of a makefile assignment, NA for
+# lines that do not assign anything, such as comments and blanks.
+make_assignment_part <- function(lines, part) {
+  pattern <- "^([A-Za-z_][A-Za-z0-9_]*)[[:space:]]*(\\+=|:=|\\?=|=).*$"
+  ifelse(grepl(pattern, lines), sub(pattern, part, lines), NA_character_)
+}
 
 check_install_dir <- function(dir_cmdstan, overwrite = FALSE) {
   if (dir.exists(dir_cmdstan)) {

--- a/R/install.R
+++ b/R/install.R
@@ -314,7 +314,9 @@ rebuild_cmdstan <- function(dir = cmdstan_path(),
 #' @export
 #' @param append (logical) For `cmdstan_make_local()`, should the listed
 #'   makefile flags be appended to the end of the existing `make/local` file?
-#'   The default is `TRUE`. If `FALSE` the file is overwritten.
+#'   The default is `TRUE`. If `FALSE` the file is overwritten. Appending is
+#'   idempotent: a flag that is already present in `make/local` is not written
+#'   a second time, and repeated flags in `cpp_options` are written once.
 #'
 cmdstan_make_local <- function(dir = cmdstan_path(),
                                cpp_options = NULL,
@@ -336,7 +338,20 @@ cmdstan_make_local <- function(dir = cmdstan_path(),
         }
       }
     }
-    write(built_flags, file = make_local_path, append = append)
+    if (append) {
+      # Don't write a flag that is already in the file.
+      existing <- tryCatch(
+        suppressWarnings(readLines(make_local_path, warn = FALSE)),
+        error = function(e) character(0)
+      )
+      built_flags <- built_flags[!trimws(built_flags) %in% trimws(existing)]
+    }
+    built_flags <- unique(built_flags)
+    # Skip the write if there is nothing left to add and the file is
+    # already there.
+    if (length(built_flags) > 0 || !append || !file.exists(make_local_path)) {
+      write(built_flags, file = make_local_path, append = append)
+    }
   }
   make_local_contents <- tryCatch(
     suppressWarnings(readLines(make_local_path, warn = FALSE)),

--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -88,7 +88,9 @@ Subsystem for Linux (WSL). The default is \code{FALSE}.}
 
 \item{append}{(logical) For \code{cmdstan_make_local()}, should the listed
 makefile flags be appended to the end of the existing \code{make/local} file?
-The default is \code{TRUE}. If \code{FALSE} the file is overwritten.}
+The default is \code{TRUE}. If \code{FALSE} the file is overwritten. Appending is
+idempotent: a flag that is already present in \code{make/local} is not written
+a second time, and repeated flags in \code{cpp_options} are written once.}
 
 \item{fix}{Deprecated and will be removed in a future release. This argument
 is ignored and retained only for compatibility.}

--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -88,9 +88,8 @@ Subsystem for Linux (WSL). The default is \code{FALSE}.}
 
 \item{append}{(logical) For \code{cmdstan_make_local()}, should the listed
 makefile flags be appended to the end of the existing \code{make/local} file?
-The default is \code{TRUE}. If \code{FALSE} the file is overwritten. Appending is
-idempotent: a flag that is already present in \code{make/local} is not written
-a second time, and repeated flags in \code{cpp_options} are written once.}
+The default is \code{TRUE}. If \code{FALSE} the file is overwritten. A flag that is
+already present in \code{make/local} is not written a second time.}
 
 \item{fix}{Deprecated and will be removed in a future release. This argument
 is ignored and retained only for compatibility.}

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -545,6 +545,77 @@ test_that("cmdstan_make_local() reads back written make flags", {
   )
 })
 
+test_that("cmdstan_make_local() does not append flags that are already present", {
+  dir <- withr::local_tempdir()
+  dir.create(file.path(dir, "make"), recursive = TRUE, showWarnings = FALSE)
+  make_local_path <- file.path(dir, "make", "local")
+  writeLines(
+    c("CXXFLAGS += -Wno-deprecated-declarations", "PRECOMPILED_HEADERS=false"),
+    make_local_path
+  )
+
+  # A flag already in the file is not written again.
+  expect_equal(
+    cmdstan_make_local(
+      dir = dir,
+      cpp_options = list("CXXFLAGS += -Wno-deprecated-declarations")
+    ),
+    c("CXXFLAGS += -Wno-deprecated-declarations", "PRECOMPILED_HEADERS=false")
+  )
+
+  # Copying the make/local of a previous installation, as suggested by
+  # install_cmdstan(), adds only the flags that are new.
+  previous_install <- c(
+    "CXXFLAGS += -Wno-deprecated-declarations",
+    "PRECOMPILED_HEADERS=false",
+    "O = 3"
+  )
+  expect_equal(
+    cmdstan_make_local(dir = dir, cpp_options = as.list(previous_install)),
+    c(previous_install[1:2], "O = 3")
+  )
+
+  # Leading/trailing whitespace does not defeat the check.
+  expect_equal(
+    cmdstan_make_local(dir = dir, cpp_options = list("  O = 3  ")),
+    c(previous_install[1:2], "O = 3")
+  )
+})
+
+test_that("cmdstan_make_local() writes repeated flags in cpp_options once", {
+  dir <- withr::local_tempdir()
+  dir.create(file.path(dir, "make"), recursive = TRUE, showWarnings = FALSE)
+
+  expect_equal(
+    cmdstan_make_local(
+      dir = dir,
+      cpp_options = list(STAN_THREADS = TRUE, "STAN_THREADS" = TRUE)
+    ),
+    "STAN_THREADS=true"
+  )
+  expect_equal(
+    cmdstan_make_local(
+      dir = dir,
+      cpp_options = list("CXXFLAGS += -O1", "CXXFLAGS += -O1"),
+      append = FALSE
+    ),
+    "CXXFLAGS += -O1"
+  )
+})
+
+test_that("cmdstan_make_local() still appends a new value for a known variable", {
+  dir <- withr::local_tempdir()
+  dir.create(file.path(dir, "make"), recursive = TRUE, showWarnings = FALSE)
+  writeLines("STANCFLAGS=--O1", file.path(dir, "make", "local"))
+
+  # Same variable, different value: make lets the last assignment win, so this
+  # must not be treated as a duplicate.
+  expect_equal(
+    cmdstan_make_local(dir = dir, cpp_options = list(STANCFLAGS = "--Oexperimental")),
+    c("STANCFLAGS=--O1", "STANCFLAGS=--Oexperimental")
+  )
+})
+
 test_that("matching_variables() works", {
   ret <- matching_variables(c("beta"),  c("alpha", "beta[1]", "beta[2]", "beta[3]"))
   expect_equal(

--- a/tests/testthat/test-utils.R
+++ b/tests/testthat/test-utils.R
@@ -582,24 +582,28 @@ test_that("cmdstan_make_local() does not append flags that are already present",
   )
 })
 
-test_that("cmdstan_make_local() writes repeated flags in cpp_options once", {
+test_that("cmdstan_make_local() appends a flag that a later line has overridden", {
   dir <- withr::local_tempdir()
   dir.create(file.path(dir, "make"), recursive = TRUE, showWarnings = FALSE)
 
   expect_equal(
-    cmdstan_make_local(
-      dir = dir,
-      cpp_options = list(STAN_THREADS = TRUE, "STAN_THREADS" = TRUE)
-    ),
+    cmdstan_make_local(dir = dir, cpp_options = list(STAN_THREADS = TRUE)),
     "STAN_THREADS=true"
   )
   expect_equal(
-    cmdstan_make_local(
-      dir = dir,
-      cpp_options = list("CXXFLAGS += -O1", "CXXFLAGS += -O1"),
-      append = FALSE
-    ),
-    "CXXFLAGS += -O1"
+    cmdstan_make_local(dir = dir, cpp_options = list(STAN_THREADS = FALSE)),
+    c("STAN_THREADS=true", "STAN_THREADS=false")
+  )
+  # make applies the last assignment, so threading is off at this point and
+  # turning it back on is a real change rather than a duplicate
+  expect_equal(
+    cmdstan_make_local(dir = dir, cpp_options = list(STAN_THREADS = TRUE)),
+    c("STAN_THREADS=true", "STAN_THREADS=false", "STAN_THREADS=true")
+  )
+  # ... and now it is the last assignment again
+  expect_equal(
+    cmdstan_make_local(dir = dir, cpp_options = list(STAN_THREADS = TRUE)),
+    c("STAN_THREADS=true", "STAN_THREADS=false", "STAN_THREADS=true")
   )
 })
 


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Current `cmdstan_make_local()` copies `make/local` flags, but doesn't handle duplicates and using `cmdstan_make_local()` after every new release (and new release candidate) adds, for example, line `CXXFLAGS += -Wno-deprecated-declarations`. This PR copies the flags without creating duplicate lines.

This PR was made with Claude assistance

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):

Aki Vehtari


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
