### PR TITLE
ask to copy make/local before build

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -78,7 +78,9 @@
 #'   installation currently in use be copied to the new installation? The copy
 #'   happens before CmdStan is built, so the flags are already in effect for
 #'   that build. The default is `NULL`, which shows the previous `make/local`
-#'   and asks in an interactive session, and copies nothing otherwise.
+#'   and asks in an interactive session, and copies nothing otherwise. The
+#'   question comes before the download, so that the rest of the installation
+#'   runs unattended.
 #'   Use `TRUE` or `FALSE` to decide without being asked. Flags given in
 #'   `cpp_options` are written after the copied ones and therefore take precedence.
 #'
@@ -214,6 +216,12 @@ install_cmdstan <- function(dir = NULL,
   if (!check_install_dir(dir_cmdstan, overwrite)) {
     return(invisible(NULL))
   }
+  # Ask before downloading
+  copy_make_local <- resolve_copy_make_local(
+    previous_make_local,
+    old_cmdstan_path,
+    copy_make_local
+  )
   if (is.null(release_file)) {
     tar_downloaded <- download_with_retries(download_url, dest_file, quiet = quiet)
     if (inherits(tar_downloaded, "try-error")) {
@@ -418,6 +426,31 @@ check_cmdstan_toolchain <- function(fix = FALSE, quiet = FALSE) {
 
 # internal ----------------------------------------------------------------
 
+#' Decide whether the previous installation's makefile flags should be reused
+#'
+#' Asked before the download starts. The flags themselves can
+#' only be written once the new installation has been unpacked.
+#'
+#' @noRd
+#' @param previous_contents (character vector) `make/local` of the installation
+#'   that was in use, as returned by `cmdstan_make_local()`.
+#' @param previous_path (string) Where those contents came from.
+#' @param copy_make_local (logical or `NULL`) `TRUE`/`FALSE` decide directly.
+#'   `NULL` asks in an interactive session and declines otherwise, so that
+#'   scripts, R CMD check and CI never block on a prompt.
+#' @return `TRUE` if the flags should be copied.
+resolve_copy_make_local <- function(previous_contents,
+                                    previous_path,
+                                    copy_make_local = NULL) {
+  if (length(previous_contents) == 0 || identical(previous_contents, "")) {
+    return(FALSE)
+  }
+  if (!is.null(copy_make_local)) {
+    return(isTRUE(copy_make_local))
+  }
+  rlang::is_interactive() && prompt_copy_make_local(previous_contents, previous_path)
+}
+
 #' Carry the makefile flags of the previous CmdStan installation over to a
 #' freshly unpacked one, before it is built.
 #'
@@ -426,22 +459,15 @@ check_cmdstan_toolchain <- function(fix = FALSE, quiet = FALSE) {
 #' @param previous_contents (character vector) `make/local` of the installation
 #'   that was in use, as returned by `cmdstan_make_local()`.
 #' @param previous_path (string) Where those contents came from.
-#' @param copy_make_local (logical or `NULL`) `TRUE`/`FALSE` decide directly.
-#'   `NULL` asks in an interactive session and declines otherwise, so that
-#'   scripts, R CMD check and CI never block on a prompt.
+#' @param copy_make_local (logical) The resolved answer.
 #' @return `TRUE` if the flags were written to the new installation.
 maybe_copy_make_local <- function(dir_cmdstan,
                                   previous_contents,
                                   previous_path,
-                                  copy_make_local = NULL) {
-  if (length(previous_contents) == 0 || identical(previous_contents, "")) {
-    return(FALSE)
-  }
-  if (is.null(copy_make_local)) {
-    copy_make_local <- rlang::is_interactive() &&
-      prompt_copy_make_local(previous_contents, previous_path)
-  }
-  if (!isTRUE(copy_make_local)) {
+                                  copy_make_local) {
+  if (!isTRUE(copy_make_local) ||
+      length(previous_contents) == 0 ||
+      identical(previous_contents, "")) {
     return(FALSE)
   }
   cmdstan_make_local(
@@ -454,7 +480,7 @@ maybe_copy_make_local <- function(dir_cmdstan,
 }
 
 # Show the previous make/local and ask whether to reuse it. Separate from
-# maybe_copy_make_local() so that tests can mock the answer.
+# resolve_copy_make_local() so that tests can mock the answer.
 prompt_copy_make_local <- function(previous_contents, previous_path) {
   message(
     "\nThe CmdStan installation in ", previous_path,

--- a/R/install.R
+++ b/R/install.R
@@ -149,11 +149,14 @@ install_cmdstan <- function(dir = NULL,
   previous_make_local <- NULL
   old_cmdstan_path <- NULL
   if (!is.null(cmdstan_version(error_on_NA = FALSE))) {
+    old_cmdstan_path <- cmdstan_path()
     current_make_local_contents <- cmdstan_make_local()
-    if (length(current_make_local_contents) > 0) {
-      old_cmdstan_path <- cmdstan_path()
+    # cmdstan_make_local() returns "" for a make/local that exists but is
+    # empty, which carries no flags and is not worth reporting either
+    if (length(current_make_local_contents) > 0 &&
+        !identical(current_make_local_contents, "")) {
       previous_make_local <- current_make_local_contents
-      make_local_msg <- paste0("cmdstan_make_local(cpp_options = cmdstan_make_local(dir = \"", cmdstan_path(), "\"))")
+      make_local_msg <- paste0("cmdstan_make_local(cpp_options = cmdstan_make_local(dir = \"", old_cmdstan_path, "\"))")
     }
   }
   if (is.null(dir)) {
@@ -216,7 +219,9 @@ install_cmdstan <- function(dir = NULL,
   if (!check_install_dir(dir_cmdstan, overwrite)) {
     return(invisible(NULL))
   }
-  # Ask before downloading
+  # Ask before downloading. Argument or answer decides whether the
+  # post-build message below is shown.
+  copy_make_local_decided <- !is.null(copy_make_local) || rlang::is_interactive()
   copy_make_local <- resolve_copy_make_local(
     previous_make_local,
     old_cmdstan_path,
@@ -272,10 +277,8 @@ install_cmdstan <- function(dir = NULL,
   # Carry the previous installation's makefile flags over before the build, so
   # that the build already uses them. Written first, so that cpp_options and
   # the platform flags below take precedence over an inherited assignment.
-  if (maybe_copy_make_local(dir_cmdstan, previous_make_local, old_cmdstan_path,
-                            copy_make_local)) {
-    make_local_msg <- NULL
-  }
+  maybe_copy_make_local(dir_cmdstan, previous_make_local, old_cmdstan_path,
+                        copy_make_local)
 
   cmdstan_make_local(dir = dir_cmdstan, cpp_options = cpp_options, append = TRUE)
   # Setting up native M1 compilation of CmdStan and its downstream libraries
@@ -322,15 +325,16 @@ install_cmdstan <- function(dir = NULL,
 
   message("* Finished installing CmdStan to ", dir_cmdstan, "\n")
   set_cmdstan_path(dir_cmdstan)
-  if (!is.null(make_local_msg) && !identical(old_cmdstan_path, cmdstan_path())) {
+  if (report_uncopied_make_local(make_local_msg, copy_make_local_decided,
+                                 old_cmdstan_path, cmdstan_path())) {
     message(
       "\nThe previous installation of CmdStan had a non-empty make/local file.\n",
       "If you wish to copy the file to the new installation, run the following commands:\n",
       "\n",
       make_local_msg,
       "\nrebuild_cmdstan(cores = ...)",
-      "\n\nTo copy the flags before the build instead, and avoid the rebuild, use\n",
-      "install_cmdstan(copy_make_local = TRUE)."
+      "\n\nNext time, install_cmdstan(copy_make_local = TRUE) copies the flags\n",
+      "before the build, so that no rebuild is needed."
     )
   }
   if (isTRUE(wsl)) {
@@ -426,6 +430,23 @@ check_cmdstan_toolchain <- function(fix = FALSE, quiet = FALSE) {
 
 # internal ----------------------------------------------------------------
 
+#' Should the finished installation point out the `make/local` left behind?
+#'
+#' An explicit `copy_make_local`, or a prompt they answered, has
+#' settled it already. Reinstalling over the same path is excluded
+#' too: the `make/local` the message tells them to read has been
+#' overwritten by then.
+#'
+#' @noRd
+#' @param make_local_msg (string or `NULL`) The suggested command, `NULL` when
+#'   the previous installation had no flags.
+#' @param decided (logical) Was the copy question settled during the install?
+#' @param old_path,new_path (string or `NULL`) Previous and new installation.
+#' @return `TRUE` if the message should be shown.
+report_uncopied_make_local <- function(make_local_msg, decided, old_path, new_path) {
+  !is.null(make_local_msg) && !isTRUE(decided) && !identical(old_path, new_path)
+}
+
 #' Decide whether the previous installation's makefile flags should be reused
 #'
 #' Asked before the download starts. The flags themselves can
@@ -438,11 +459,22 @@ check_cmdstan_toolchain <- function(fix = FALSE, quiet = FALSE) {
 #' @param copy_make_local (logical or `NULL`) `TRUE`/`FALSE` decide directly.
 #'   `NULL` asks in an interactive session and declines otherwise, so that
 #'   scripts, R CMD check and CI never block on a prompt.
-#' @return `TRUE` if the flags should be copied.
+#' @return `TRUE` if the flags should be copied. An explicit `TRUE` with
+#'   nothing to copy returns `FALSE` and reports why.
 resolve_copy_make_local <- function(previous_contents,
                                     previous_path,
                                     copy_make_local = NULL) {
   if (length(previous_contents) == 0 || identical(previous_contents, "")) {
+    if (isTRUE(copy_make_local)) {
+      # An explicit request that cannot be honoured
+      if (is.null(previous_path)) {
+        message("* copy_make_local = TRUE, but no CmdStan installation is ",
+                "currently in use, so there are no makefile flags to copy.")
+      } else {
+        message("* copy_make_local = TRUE, but ", previous_path,
+                " has an empty or missing make/local, so there is nothing to copy.")
+      }
+    }
     return(FALSE)
   }
   if (!is.null(copy_make_local)) {

--- a/R/install.R
+++ b/R/install.R
@@ -7,6 +7,11 @@
 #'   See the first few sections of the CmdStan
 #'   [installation guide](https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html)
 #'   for details on the C++ toolchain required for installing CmdStan.
+#'   If the CmdStan installation currently in use has a non-empty `make/local`
+#'   file, the flags in it can be copied to the new installation before
+#'   it is built, so that no rebuild is needed afterwards. In an interactive
+#'   session `install_cmdstan()` shows the file and asks. See the
+#'   `copy_make_local` argument to decide without being asked.
 #'
 #'   The `rebuild_cmdstan()` function cleans and rebuilds the CmdStan
 #'   installation. Use this function in case of any issues when compiling models.
@@ -69,6 +74,13 @@
 #'   default is `TRUE`.
 #' @param wsl (logical) Should CmdStan be installed and run through the Windows
 #'  Subsystem for Linux (WSL). The default is `FALSE`.
+#' @param copy_make_local (logical) Should the `make/local` file of the CmdStan
+#'   installation currently in use be copied to the new installation? The copy
+#'   happens before CmdStan is built, so the flags are already in effect for
+#'   that build. The default is `NULL`, which shows the previous `make/local`
+#'   and asks in an interactive session, and copies nothing otherwise.
+#'   Use `TRUE` or `FALSE` to decide without being asked. Flags given in
+#'   `cpp_options` are written after the copied ones and therefore take precedence.
 #'
 #' @return
 #' If a build fails or times out, `install_cmdstan()` issues a warning and
@@ -106,7 +118,9 @@ install_cmdstan <- function(dir = NULL,
                             release_file = NULL,
                             cpp_options = list(),
                             check_toolchain = TRUE,
-                            wsl = FALSE) {
+                            wsl = FALSE,
+                            copy_make_local = NULL) {
+  checkmate::assert_flag(copy_make_local, null.ok = TRUE)
   warn_if_ignored_msys_toolchain_env()
   # Use environment variable to record WSL usage throughout install,
   # post-installation will simply check for 'wsl-' prefix in cmdstan path
@@ -124,11 +138,19 @@ install_cmdstan <- function(dir = NULL,
   if (check_toolchain) {
     check_cmdstan_toolchain(quiet = quiet)
   }
+  # Read the make/local of the installation in use before anything is
+  # downloaded, so that its flags can be offered to the new installation
+  # *before* it is built (see maybe_copy_make_local() below). With
+  # overwrite=TRUE the directory is deleted further down, so this is the last
+  # chance to see the file at all.
   make_local_msg <- NULL
+  previous_make_local <- NULL
+  old_cmdstan_path <- NULL
   if (!is.null(cmdstan_version(error_on_NA = FALSE))) {
     current_make_local_contents <- cmdstan_make_local()
     if (length(current_make_local_contents) > 0) {
       old_cmdstan_path <- cmdstan_path()
+      previous_make_local <- current_make_local_contents
       make_local_msg <- paste0("cmdstan_make_local(cpp_options = cmdstan_make_local(dir = \"", cmdstan_path(), "\"))")
     }
   }
@@ -239,6 +261,14 @@ install_cmdstan <- function(dir = NULL,
     assert_supported_requested_cmdstan_version(extracted_version, source = "archive")
   }
 
+  # Carry the previous installation's makefile flags over before the build, so
+  # that the build already uses them. Written first, so that cpp_options and
+  # the platform flags below take precedence over an inherited assignment.
+  if (maybe_copy_make_local(dir_cmdstan, previous_make_local, old_cmdstan_path,
+                            copy_make_local)) {
+    make_local_msg <- NULL
+  }
+
   cmdstan_make_local(dir = dir_cmdstan, cpp_options = cpp_options, append = TRUE)
   # Setting up native M1 compilation of CmdStan and its downstream libraries
   if (is_rosetta2()) {
@@ -284,13 +314,15 @@ install_cmdstan <- function(dir = NULL,
 
   message("* Finished installing CmdStan to ", dir_cmdstan, "\n")
   set_cmdstan_path(dir_cmdstan)
-  if (!is.null(make_local_msg) && old_cmdstan_path != cmdstan_path()) {
+  if (!is.null(make_local_msg) && !identical(old_cmdstan_path, cmdstan_path())) {
     message(
       "\nThe previous installation of CmdStan had a non-empty make/local file.\n",
       "If you wish to copy the file to the new installation, run the following commands:\n",
       "\n",
       make_local_msg,
-      "\nrebuild_cmdstan(cores = ...)"
+      "\nrebuild_cmdstan(cores = ...)",
+      "\n\nTo copy the flags before the build instead, and avoid the rebuild, use\n",
+      "install_cmdstan(copy_make_local = TRUE)."
     )
   }
   if (isTRUE(wsl)) {
@@ -385,6 +417,58 @@ check_cmdstan_toolchain <- function(fix = FALSE, quiet = FALSE) {
 
 
 # internal ----------------------------------------------------------------
+
+#' Carry the makefile flags of the previous CmdStan installation over to a
+#' freshly unpacked one, before it is built.
+#'
+#' @noRd
+#' @param dir_cmdstan (string) The new installation.
+#' @param previous_contents (character vector) `make/local` of the installation
+#'   that was in use, as returned by `cmdstan_make_local()`.
+#' @param previous_path (string) Where those contents came from.
+#' @param copy_make_local (logical or `NULL`) `TRUE`/`FALSE` decide directly.
+#'   `NULL` asks in an interactive session and declines otherwise, so that
+#'   scripts, R CMD check and CI never block on a prompt.
+#' @return `TRUE` if the flags were written to the new installation.
+maybe_copy_make_local <- function(dir_cmdstan,
+                                  previous_contents,
+                                  previous_path,
+                                  copy_make_local = NULL) {
+  if (length(previous_contents) == 0 || identical(previous_contents, "")) {
+    return(FALSE)
+  }
+  if (is.null(copy_make_local)) {
+    copy_make_local <- rlang::is_interactive() &&
+      prompt_copy_make_local(previous_contents, previous_path)
+  }
+  if (!isTRUE(copy_make_local)) {
+    return(FALSE)
+  }
+  cmdstan_make_local(
+    dir = dir_cmdstan,
+    cpp_options = as.list(previous_contents),
+    append = TRUE
+  )
+  message("* Copied make/local from ", previous_path)
+  TRUE
+}
+
+# Show the previous make/local and ask whether to reuse it. Separate from
+# maybe_copy_make_local() so that tests can mock the answer.
+prompt_copy_make_local <- function(previous_contents, previous_path) {
+  message(
+    "\nThe CmdStan installation in ", previous_path,
+    " has a non-empty make/local:\n",
+    paste0("  ", previous_contents, collapse = "\n")
+  )
+  answer <- read_line("Copy these makefile flags to the new installation? [y/N] ")
+  tolower(trimws(answer)) %in% c("y", "yes")
+}
+
+# Thin wrapper around readline() so that tests can answer the prompt.
+read_line <- function(prompt) {
+  readline(prompt)
+}
 
 check_install_dir <- function(dir_cmdstan, overwrite = FALSE) {
   if (dir.exists(dir_cmdstan)) {

--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -18,7 +18,8 @@ install_cmdstan(
   release_file = NULL,
   cpp_options = list(),
   check_toolchain = TRUE,
-  wsl = FALSE
+  wsl = FALSE,
+  copy_make_local = NULL
 )
 
 rebuild_cmdstan(
@@ -86,6 +87,14 @@ default is \code{TRUE}.}
 \item{wsl}{(logical) Should CmdStan be installed and run through the Windows
 Subsystem for Linux (WSL). The default is \code{FALSE}.}
 
+\item{copy_make_local}{(logical) Should the \code{make/local} file of the CmdStan
+installation currently in use be copied to the new installation? The copy
+happens before CmdStan is built, so the flags are already in effect for
+that build. The default is \code{NULL}, which shows the previous \code{make/local}
+and asks in an interactive session, and copies nothing otherwise.
+Use \code{TRUE} or \code{FALSE} to decide without being asked. Flags given in
+\code{cpp_options} are written after the copied ones and therefore take precedence.}
+
 \item{append}{(logical) For \code{cmdstan_make_local()}, should the listed
 makefile flags be appended to the end of the existing \code{make/local} file?
 The default is \code{TRUE}. If \code{FALSE} the file is overwritten.}
@@ -109,6 +118,11 @@ by specifying the \code{version} or \code{release_url} argument.
 See the first few sections of the CmdStan
 \href{https://mc-stan.org/docs/cmdstan-guide/cmdstan-installation.html}{installation guide}
 for details on the C++ toolchain required for installing CmdStan.
+If the CmdStan installation currently in use has a non-empty \code{make/local}
+file, the flags in it can be copied to the new installation before
+it is built, so that no rebuild is needed afterwards. In an interactive
+session \code{install_cmdstan()} shows the file and asks. See the
+\code{copy_make_local} argument to decide without being asked.
 
 The \code{rebuild_cmdstan()} function cleans and rebuilds the CmdStan
 installation. Use this function in case of any issues when compiling models.

--- a/man/install_cmdstan.Rd
+++ b/man/install_cmdstan.Rd
@@ -91,7 +91,9 @@ Subsystem for Linux (WSL). The default is \code{FALSE}.}
 installation currently in use be copied to the new installation? The copy
 happens before CmdStan is built, so the flags are already in effect for
 that build. The default is \code{NULL}, which shows the previous \code{make/local}
-and asks in an interactive session, and copies nothing otherwise.
+and asks in an interactive session, and copies nothing otherwise. The
+question comes before the download, so that the rest of the installation
+runs unattended.
 Use \code{TRUE} or \code{FALSE} to decide without being asked. Flags given in
 \code{cpp_options} are written after the copied ones and therefore take precedence.}
 

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -310,6 +310,141 @@ test_that("check_cmdstan_toolchain(fix = TRUE) is deprecated", {
   )
 })
 
+# Reusing the previous installation's make/local -----------------------------
+
+# A directory that looks enough like a CmdStan installation for
+# cmdstan_make_local() to write into it.
+fake_cmdstan_dir <- function(contents = NULL, envir = parent.frame()) {
+  dir <- withr::local_tempdir(.local_envir = envir)
+  dir.create(file.path(dir, "make"), recursive = TRUE, showWarnings = FALSE)
+  if (!is.null(contents)) {
+    writeLines(contents, file.path(dir, "make", "local"))
+  }
+  dir
+}
+
+test_that("maybe_copy_make_local() copies the previous flags when asked to", {
+  new_dir <- fake_cmdstan_dir()
+  previous <- c("CXXFLAGS += -march=native", "STAN_THREADS=true")
+
+  expect_message(
+    expect_true(
+      maybe_copy_make_local(new_dir, previous, "/old/cmdstan", copy_make_local = TRUE)
+    ),
+    "Copied make/local from /old/cmdstan",
+    fixed = TRUE
+  )
+  expect_equal(cmdstan_make_local(dir = new_dir), previous)
+})
+
+test_that("maybe_copy_make_local() does nothing when told not to copy", {
+  new_dir <- fake_cmdstan_dir()
+
+  expect_false(
+    maybe_copy_make_local(new_dir, "STAN_THREADS=true", "/old/cmdstan",
+                          copy_make_local = FALSE)
+  )
+  expect_false(file.exists(file.path(new_dir, "make", "local")))
+})
+
+test_that("maybe_copy_make_local() does not prompt in a non-interactive session", {
+  new_dir <- fake_cmdstan_dir()
+  rlang::local_interactive(FALSE)
+  local_mocked_bindings(
+    prompt_copy_make_local = function(...) stop("must not prompt when not interactive")
+  )
+
+  expect_false(
+    maybe_copy_make_local(new_dir, "STAN_THREADS=true", "/old/cmdstan",
+                          copy_make_local = NULL)
+  )
+  expect_false(file.exists(file.path(new_dir, "make", "local")))
+})
+
+test_that("maybe_copy_make_local() follows the answer to the prompt", {
+  rlang::local_interactive(TRUE)
+
+  yes_dir <- fake_cmdstan_dir()
+  local({
+    local_mocked_bindings(prompt_copy_make_local = function(...) TRUE)
+    expect_message(
+      expect_true(
+        maybe_copy_make_local(yes_dir, "STAN_THREADS=true", "/old/cmdstan",
+                              copy_make_local = NULL)
+      ),
+      "Copied make/local",
+      fixed = TRUE
+    )
+  })
+  expect_equal(cmdstan_make_local(dir = yes_dir), "STAN_THREADS=true")
+
+  no_dir <- fake_cmdstan_dir()
+  local({
+    local_mocked_bindings(prompt_copy_make_local = function(...) FALSE)
+    expect_false(
+      maybe_copy_make_local(no_dir, "STAN_THREADS=true", "/old/cmdstan",
+                            copy_make_local = NULL)
+    )
+  })
+  expect_false(file.exists(file.path(no_dir, "make", "local")))
+})
+
+test_that("maybe_copy_make_local() ignores a missing or empty make/local", {
+  rlang::local_interactive(TRUE)
+  local_mocked_bindings(
+    prompt_copy_make_local = function(...) stop("must not prompt without flags to copy")
+  )
+
+  # cmdstan_make_local() returns NULL when there is no file and "" when the
+  # file is empty.
+  expect_false(maybe_copy_make_local(fake_cmdstan_dir(), NULL, "/old/cmdstan"))
+  expect_false(maybe_copy_make_local(fake_cmdstan_dir(), "", "/old/cmdstan"))
+  expect_false(maybe_copy_make_local(fake_cmdstan_dir(), character(0), "/old/cmdstan"))
+})
+
+test_that("copied flags are written before cpp_options, which win", {
+  # Order matters: an inherited assignment must not override what the user
+  # asked install_cmdstan() for, and make takes the last assignment.
+  new_dir <- fake_cmdstan_dir()
+  suppressMessages(
+    maybe_copy_make_local(new_dir, "STANCFLAGS=--O1", "/old/cmdstan",
+                          copy_make_local = TRUE)
+  )
+  cmdstan_make_local(
+    dir = new_dir,
+    cpp_options = list(STANCFLAGS = "--Oexperimental"),
+    append = TRUE
+  )
+
+  expect_equal(
+    cmdstan_make_local(dir = new_dir),
+    c("STANCFLAGS=--O1", "STANCFLAGS=--Oexperimental")
+  )
+})
+
+test_that("prompt_copy_make_local() shows the flags and reads the answer", {
+  local_mocked_bindings(read_line = function(...) "y")
+  expect_message(
+    expect_true(prompt_copy_make_local("STAN_THREADS=true", "/old/cmdstan")),
+    "STAN_THREADS=true",
+    fixed = TRUE
+  )
+
+  local_mocked_bindings(read_line = function(...) "")
+  expect_message(
+    expect_false(prompt_copy_make_local("STAN_THREADS=true", "/old/cmdstan")),
+    "/old/cmdstan",
+    fixed = TRUE
+  )
+})
+
+test_that("install_cmdstan() rejects a non-logical copy_make_local", {
+  expect_error(
+    install_cmdstan(copy_make_local = "yes", check_toolchain = FALSE),
+    "copy_make_local"
+  )
+})
+
 # Windows toolchain discovery tests ----------------------------------------
 
 test_that("toolchain_PATH_env_var() returns NULL on non-Windows", {

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -409,9 +409,55 @@ test_that("resolve_copy_make_local() does not ask when there is nothing to copy"
     prompt_copy_make_local = function(...) stop("must not prompt without flags to copy")
   )
 
-  expect_false(resolve_copy_make_local(NULL, "/old/cmdstan", NULL))
-  expect_false(resolve_copy_make_local("", "/old/cmdstan", NULL))
-  expect_false(resolve_copy_make_local(character(0), "/old/cmdstan", NULL))
+  # Nothing was requested, so a make/local with no flags is a non-event
+  expect_no_message(expect_false(resolve_copy_make_local(NULL, "/old/cmdstan", NULL)))
+  expect_no_message(expect_false(resolve_copy_make_local("", "/old/cmdstan", NULL)))
+  expect_no_message(
+    expect_false(resolve_copy_make_local(character(0), "/old/cmdstan", NULL))
+  )
+  expect_no_message(expect_false(resolve_copy_make_local("", "/old/cmdstan", FALSE)))
+})
+
+test_that("resolve_copy_make_local() reports an explicit TRUE it cannot honour", {
+  # Otherwise the flags silently fail to arrive and the user finds out weeks
+  # later, from a model that compiles differently.
+
+  # An installation is in use, but it has no flags to copy: name it, because
+  # that is what reveals a cmdstan_path() pointing somewhere unexpected.
+  expect_message(
+    expect_false(resolve_copy_make_local("", "/old/cmdstan", TRUE)),
+    "/old/cmdstan has an empty or missing make/local",
+    fixed = TRUE
+  )
+  expect_message(
+    expect_false(resolve_copy_make_local(NULL, "/old/cmdstan", TRUE)),
+    "nothing to copy",
+    fixed = TRUE
+  )
+
+  # No installation in use at all: there is no path to name
+  expect_message(
+    expect_false(resolve_copy_make_local(NULL, NULL, TRUE)),
+    "no CmdStan installation is currently in use",
+    fixed = TRUE
+  )
+})
+
+test_that("report_uncopied_make_local() only reports an unanswered question", {
+  msg <- "cmdstan_make_local(cpp_options = cmdstan_make_local(dir = \"/old\"))"
+
+  # Non-interactive with copy_make_local = NULL: nobody was ever asked
+  expect_true(report_uncopied_make_local(msg, FALSE, "/old", "/new"))
+
+  # Answered, by argument or by prompt: saying it again would suggest a
+  # rebuild the user has already declined
+  expect_false(report_uncopied_make_local(msg, TRUE, "/old", "/new"))
+
+  # Previous installation had no flags
+  expect_false(report_uncopied_make_local(NULL, FALSE, "/old", "/new"))
+
+  # Reinstall over the same path: the file the message points at is gone
+  expect_false(report_uncopied_make_local(msg, FALSE, "/old", "/old"))
 })
 
 test_that("copied flags are written before cpp_options, which win", {

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -347,59 +347,71 @@ test_that("maybe_copy_make_local() does nothing when told not to copy", {
   expect_false(file.exists(file.path(new_dir, "make", "local")))
 })
 
-test_that("maybe_copy_make_local() does not prompt in a non-interactive session", {
+test_that("maybe_copy_make_local() never asks anything", {
+  # The question is asked by resolve_copy_make_local() before the download.
+  rlang::local_interactive(TRUE)
+  local_mocked_bindings(
+    prompt_copy_make_local = function(...) stop("must not prompt after the download")
+  )
+
   new_dir <- fake_cmdstan_dir()
+  expect_false(
+    maybe_copy_make_local(new_dir, "STAN_THREADS=true", "/old/cmdstan", NULL)
+  )
+  expect_false(file.exists(file.path(new_dir, "make", "local")))
+})
+
+test_that("maybe_copy_make_local() ignores a missing or empty make/local", {
+  # cmdstan_make_local() returns NULL when there is no file and "" when the
+  # file is empty.
+  expect_false(maybe_copy_make_local(fake_cmdstan_dir(), NULL, "/old/cmdstan", TRUE))
+  expect_false(maybe_copy_make_local(fake_cmdstan_dir(), "", "/old/cmdstan", TRUE))
+  expect_false(
+    maybe_copy_make_local(fake_cmdstan_dir(), character(0), "/old/cmdstan", TRUE)
+  )
+})
+
+test_that("resolve_copy_make_local() takes an explicit answer without asking", {
+  rlang::local_interactive(TRUE)
+  local_mocked_bindings(
+    prompt_copy_make_local = function(...) stop("must not prompt when told what to do")
+  )
+
+  expect_true(resolve_copy_make_local("STAN_THREADS=true", "/old/cmdstan", TRUE))
+  expect_false(resolve_copy_make_local("STAN_THREADS=true", "/old/cmdstan", FALSE))
+})
+
+test_that("resolve_copy_make_local() does not prompt in a non-interactive session", {
   rlang::local_interactive(FALSE)
   local_mocked_bindings(
     prompt_copy_make_local = function(...) stop("must not prompt when not interactive")
   )
 
-  expect_false(
-    maybe_copy_make_local(new_dir, "STAN_THREADS=true", "/old/cmdstan",
-                          copy_make_local = NULL)
-  )
-  expect_false(file.exists(file.path(new_dir, "make", "local")))
+  expect_false(resolve_copy_make_local("STAN_THREADS=true", "/old/cmdstan", NULL))
 })
 
-test_that("maybe_copy_make_local() follows the answer to the prompt", {
+test_that("resolve_copy_make_local() follows the answer to the prompt", {
   rlang::local_interactive(TRUE)
 
-  yes_dir <- fake_cmdstan_dir()
   local({
     local_mocked_bindings(prompt_copy_make_local = function(...) TRUE)
-    expect_message(
-      expect_true(
-        maybe_copy_make_local(yes_dir, "STAN_THREADS=true", "/old/cmdstan",
-                              copy_make_local = NULL)
-      ),
-      "Copied make/local",
-      fixed = TRUE
-    )
+    expect_true(resolve_copy_make_local("STAN_THREADS=true", "/old/cmdstan", NULL))
   })
-  expect_equal(cmdstan_make_local(dir = yes_dir), "STAN_THREADS=true")
-
-  no_dir <- fake_cmdstan_dir()
   local({
     local_mocked_bindings(prompt_copy_make_local = function(...) FALSE)
-    expect_false(
-      maybe_copy_make_local(no_dir, "STAN_THREADS=true", "/old/cmdstan",
-                            copy_make_local = NULL)
-    )
+    expect_false(resolve_copy_make_local("STAN_THREADS=true", "/old/cmdstan", NULL))
   })
-  expect_false(file.exists(file.path(no_dir, "make", "local")))
 })
 
-test_that("maybe_copy_make_local() ignores a missing or empty make/local", {
+test_that("resolve_copy_make_local() does not ask when there is nothing to copy", {
   rlang::local_interactive(TRUE)
   local_mocked_bindings(
     prompt_copy_make_local = function(...) stop("must not prompt without flags to copy")
   )
 
-  # cmdstan_make_local() returns NULL when there is no file and "" when the
-  # file is empty.
-  expect_false(maybe_copy_make_local(fake_cmdstan_dir(), NULL, "/old/cmdstan"))
-  expect_false(maybe_copy_make_local(fake_cmdstan_dir(), "", "/old/cmdstan"))
-  expect_false(maybe_copy_make_local(fake_cmdstan_dir(), character(0), "/old/cmdstan"))
+  expect_false(resolve_copy_make_local(NULL, "/old/cmdstan", NULL))
+  expect_false(resolve_copy_make_local("", "/old/cmdstan", NULL))
+  expect_false(resolve_copy_make_local(character(0), "/old/cmdstan", NULL))
 })
 
 test_that("copied flags are written before cpp_options, which win", {
@@ -436,6 +448,33 @@ test_that("prompt_copy_make_local() shows the flags and reads the answer", {
     "/old/cmdstan",
     fixed = TRUE
   )
+})
+
+test_that("install_cmdstan() asks about make/local before downloading", {
+  rlang::local_interactive(TRUE)
+  events <- character()
+  local_mocked_bindings(
+    cmdstan_version = function(...) "2.36.0",
+    cmdstan_make_local = function(...) "STAN_THREADS=true",
+    cmdstan_path = function(...) "/old/cmdstan",
+    prompt_copy_make_local = function(...) {
+      events <<- c(events, "prompt")
+      FALSE
+    },
+    download_with_retries = function(...) {
+      events <<- c(events, "download")
+      try(stop("no downloads in tests"), silent = TRUE)
+    }
+  )
+
+  expect_error(
+    suppressMessages(
+      install_cmdstan(dir = withr::local_tempdir(), version = "2.36.0",
+                      check_toolchain = FALSE)
+    ),
+    "Download of CmdStan failed"
+  )
+  expect_equal(events, c("prompt", "download"))
 })
 
 test_that("install_cmdstan() rejects a non-logical copy_make_local", {


### PR DESCRIPTION
#### Submission Checklist

- [x] Run unit tests
- [x] Declare copyright holder and agree to license (see below)

#### Summary

Current `install_cmdstan()` downloads CmdStan, builds, and then asks whether to copy `make/local` from an older existing version, and then CmdStan need be rebuild. This PR asks in an interactive session whether to copy `make/local` flags before building, and thus the second build is not needed. In case of reinstalling a new version, this will also allow copying current version `make/local` flags, which would be otherwise deleted.

This PR was made with Claude assistance

#### Copyright and Licensing

Please list the copyright holder for the work you are submitting
(this will be you or your assignee, such as a university or company):

Aki Vehtari


By submitting this pull request, the copyright holder is agreeing to
license the submitted work under the following licenses:

- Code: BSD 3-clause (https://opensource.org/licenses/BSD-3-Clause)
- Documentation: CC-BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
